### PR TITLE
fix: add eneru symlink to PATH in deb/rpm packages

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -58,6 +58,11 @@ contents:
       owner: root
       group: root
 
+  # Symlink for PATH access
+  - dst: /usr/local/bin/eneru
+    type: symlink
+    src: /opt/ups-monitor/eneru.py
+
   # Eneru package modules
   - src: src/eneru/__init__.py
     dst: /opt/ups-monitor/eneru/__init__.py


### PR DESCRIPTION
The deb/rpm packages installed eneru.py to /opt/ups-monitor/ but did not create a PATH-accessible command. Adds a symlink from /usr/local/bin/eneru to /opt/ups-monitor/eneru.py.

## Description
Brief description of changes.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Configuration change

## Testing
Describe how you tested your changes:
- [ ] Tested with `--validate-config`
- [ ] Tested with `--dry-run` mode
- [ ] Tested actual shutdown sequence (if applicable)
- [ ] Tested on: [OS/Python version]

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated configuration examples if needed
- [ ] My changes generate no new warnings
- [ ] I have tested my changes thoroughly

## Related issues
Fixes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.
