### PR TITLE
Fix CodeQL incomplete URL substring sanitization alert

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -209,12 +209,18 @@ jobs:
             version: '11'
             name: Debian 11
           - distro: debian
+            version: '12'
+            name: Debian 12
+          - distro: debian
             version: '13'
             name: Debian 13
           # Ubuntu 22.04 skipped: system pip 22.0.2 has a regression with
           # pyproject.toml dynamic version metadata, building UNKNOWN-0.0.0.
           # Upgrading pip fixes it, but that no longer tests the real system.
           # Ubuntu 22.04 is covered by the test-deb job instead.
+          - distro: ubuntu
+            version: '24.04'
+            name: Ubuntu 24.04
           - distro: ubuntu
             version: '26.04'
             name: Ubuntu 26.04

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "4.3.0" for tagged releases, "4.3.0-5-gabcdef1" for dev builds
-__version__ = "5.0.0-rc4"
+__version__ = "5.1.0-rc0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,8 +227,7 @@ class TestAvatarUrlAppending:
         avatar = "https://example.com/avatar.png"
         result = ConfigLoader._append_avatar_to_url(TEST_DISCORD_APPRISE_URL, avatar)
 
-        assert "avatar_url=" in result
-        assert "example.com" in result
+        assert "avatar_url=https%3A%2F%2Fexample.com%2Favatar.png" in result
 
     @pytest.mark.unit
     def test_append_avatar_to_slack(self):


### PR DESCRIPTION
## Summary

- Resolves [code scanning alert #1](https://github.com/m4r1k/Eneru/security/code-scanning/1) — `py/incomplete-url-substring-sanitization`
- The assertion `"example.com" in result` in `test_config.py` was flagged because substring checks on URLs are unreliable for sanitization. This is a false positive (it's a test, not a security check), but the fix is better anyway: assert the exact URL-encoded avatar parameter instead of a vague domain substring.

## Test plan

- [x] `TestAvatarUrlAppending` tests pass locally (5/5)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test accuracy for URL parameter encoding validation.

* **Chores**
  * Version bumped to 5.1.0-rc0.
  * Expanded continuous integration testing to include Debian 12 and Ubuntu 24.04 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->