### PR TITLE
Fix release channel detection misrouting RC packages to stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         id: channel
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          if echo "$VERSION" | grep -qE '-(rc|beta|alpha)'; then
+          if [[ "$VERSION" =~ -(rc|beta|alpha) ]]; then
             CHANNEL="testing"
           else
             CHANNEL="stable"


### PR DESCRIPTION
## Summary

- Fixes a bug where **all pre-release packages were deployed to the stable channel** instead of testing
- Root cause: `grep -qE '-(rc|beta|alpha)'` fails with `grep: invalid option -- '('` because the pattern starts with `-`, which grep interprets as an option flag
- Fix: replace `echo | grep -qE` with bash's built-in `[[ =~ ]]` regex matching
- The migration step greps (using `~` prefix) are unaffected

## Impact

The v5.1.0-rc0 package that was just deployed landed in the stable channel. After merging this fix, the next release workflow run will trigger the migration step which will automatically move it to testing.

## Test plan

- [x] Verified locally: `[[ "5.1.0-rc0" =~ -(rc|beta|alpha) ]]` correctly matches
- [x] Verified locally: `[[ "5.0.0" =~ -(rc|beta|alpha) ]]` correctly does not match
- [ ] CI passes
- [ ] After merge: re-run release workflow to trigger migration of misrouted RC package

🤖 Generated with [Claude Code](https://claude.com/claude-code)