### PR TITLE
feat: multi-phase shutdown ordering for remote servers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,14 +58,16 @@ jobs:
           done
 
           echo ""
-          echo "Waiting for SSH server..."
-          for i in {1..30}; do
-            if nc -z localhost 2222 2>/dev/null; then
-              echo "SSH server ready!"
-              break
-            fi
-            echo "  Attempt $i/30..."
-            sleep 2
+          echo "Waiting for SSH servers (ports 2222, 2223, 2224)..."
+          for port in 2222 2223 2224; do
+            for i in {1..30}; do
+              if nc -z localhost "$port" 2>/dev/null; then
+                echo "  SSH server on $port ready!"
+                break
+              fi
+              echo "  Attempt $i/30 for $port..."
+              sleep 2
+            done
           done
 
           echo ""
@@ -626,6 +628,94 @@ jobs:
           fi
 
           echo "PASS: Recovery correctly handled - no shutdown, power restored logged"
+
+      # ========================================
+      # TEST 19: Multi-phase shutdown ordering
+      # ========================================
+      - name: "Test 19: Multi-phase shutdown ordering (shutdown_order)"
+        run: |
+          echo "=== Test 19: Multi-Phase Shutdown Ordering ==="
+
+          cd ${{ env.E2E_DIR }}
+
+          # Reset shutdown state on all three SSH targets so we get fresh
+          # timestamps from this run only.
+          for svc in ssh-target ssh-target-2 ssh-target-3; do
+            docker compose exec -T "$svc" sh -c \
+              ": > /var/log/shutdown.log && rm -f /var/run/shutdown-triggered && touch /var/run/server-alive"
+          done
+
+          rm -f /tmp/eneru-e2e-shutdown-order-flag
+
+          # Trigger shutdown via low battery
+          cp scenarios/low-battery.dev scenarios/apply.dev
+          sleep 3
+
+          eneru run --config config-e2e-shutdown-order.yaml --exit-after-shutdown 2>&1 \
+            | tee /tmp/test19.log || true
+
+          echo ""
+          echo "=== Verifying all three targets received shutdown ==="
+          for svc in ssh-target ssh-target-2 ssh-target-3; do
+            if docker compose exec -T "$svc" test -f /var/run/shutdown-triggered; then
+              echo "  PASS: $svc received shutdown"
+            else
+              echo "  FAIL: $svc did NOT receive shutdown"
+              docker compose logs "$svc"
+              exit 1
+            fi
+          done
+
+          echo ""
+          echo "=== Verifying phase log lines in Eneru output ==="
+          if grep -q "Phase 1/2 (order=1)" /tmp/test19.log; then
+            echo "PASS: Phase 1/2 (order=1) logged"
+          else
+            echo "FAIL: Phase 1/2 (order=1) not found in Eneru output"
+            cat /tmp/test19.log
+            exit 1
+          fi
+
+          if grep -q "Phase 2/2 (order=2)" /tmp/test19.log; then
+            echo "PASS: Phase 2/2 (order=2) logged"
+          else
+            echo "FAIL: Phase 2/2 (order=2) not found in Eneru output"
+            cat /tmp/test19.log
+            exit 1
+          fi
+
+          echo ""
+          echo "=== Verifying timestamp ordering across phases ==="
+          # Each /var/log/shutdown.log has a single line:
+          #   Tue Apr 17 19:43:00 UTC 2026: Shutdown command received: -h now
+          # We extract the date prefix, parse to epoch, and assert
+          # phase-2 timestamp >= max(phase-1 timestamps).
+          parse_epoch() {
+            local svc="$1"
+            local line
+            line=$(docker compose exec -T "$svc" cat /var/log/shutdown.log)
+            local ts="${line%%: Shutdown*}"
+            date -d "$ts" +%s
+          }
+
+          T1=$(parse_epoch ssh-target)
+          T2=$(parse_epoch ssh-target-2)
+          T3=$(parse_epoch ssh-target-3)
+          PHASE1_MAX=$T1
+          [ "$T2" -gt "$PHASE1_MAX" ] && PHASE1_MAX=$T2
+
+          echo "  Phase 1 timestamps: ssh-target=$T1, ssh-target-2=$T2 (max=$PHASE1_MAX)"
+          echo "  Phase 2 timestamp:  ssh-target-3=$T3"
+
+          if [ "$T3" -ge "$PHASE1_MAX" ]; then
+            echo "PASS: phase-2 (T=$T3) ran at or after phase-1 max (T=$PHASE1_MAX)"
+          else
+            echo "FAIL: phase-2 (T=$T3) ran BEFORE phase-1 max (T=$PHASE1_MAX) — ordering broken"
+            exit 1
+          fi
+
+          echo ""
+          echo "=== Test 19 PASSED: multi-phase shutdown ordering verified ==="
 
       - name: Collect logs on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ README.md                       # Project overview
 - Always test with `--dry-run` before real shutdown logic changes
 - When adding new config feature flags, add them to `examples/config-reference.yaml`
 - When adding or removing tests, update `docs/testing.md` (test counts in pyramid/table, per-file breakdown, E2E test case table)
+- **New features require both synthetic AND end-to-end tests.** Any new feature must ship with (a) unit/integration tests in `tests/` covering the logic with maximum reasonable coverage, **and** (b) a corresponding step in `.github/workflows/e2e.yml` that exercises the feature end-to-end against the Docker Compose environment in `tests/e2e/`. Synthetic tests catch logic bugs; the E2E step proves the feature actually works against real NUT/SSH/Docker. PRs that add a feature without matching E2E coverage should be sent back for it.
 
 ## Git Workflow
 
@@ -174,12 +175,15 @@ README.md                       # Project overview
 
 **Workflow:**
 ```
-1. Create feature branch from main
-2. Develop, commit, push
-3. Open PR against main
-4. CI checks must pass (all 7)
-5. Merge via GitHub (branch auto-deletes)
+1. Pull latest main:   git checkout main && git pull --ff-only origin main
+2. Create feature branch from the up-to-date main
+3. Develop, commit, push
+4. Open PR against main
+5. CI checks must pass (all 7)
+6. Merge via GitHub (branch auto-deletes)
 ```
+
+**Always pull `main` before creating a feature branch.** Branching from a stale local `main` forces a rebase later and risks landing PRs against an obsolete base.
 
 **Releasing a new version:**
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Multi-phase shutdown ordering (`shutdown_order`):** Define shutdown phases for remote servers (#4)
+    - Servers with the same `shutdown_order` run in parallel; different orders run sequentially (ascending)
+    - Enables complex dependency chains: e.g., compute (phase 1) → storage (phase 2) → network (phase 3)
+    - Full backward compatibility: existing configs with `parallel: false` produce identical behavior
+    - `eneru validate` now shows a shutdown sequence tree with phase grouping
+    - Validation rejects invalid values (must be positive integer >= 1)
+- **Per-server `shutdown_safety_margin` (seconds, default `60`):** Tunable safety buffer added on top of (`pre_shutdown_commands` + `command_timeout` + `connect_timeout`) when waiting for a parallel-shutdown thread to finish. Replaces a previously hard-coded `60` constant. Raise for slow-flushing storage, lower for fast VMs, set `0` to opt out.
+
+### Changed
+- **`shutdown_order` and `parallel` are now mutually exclusive** — setting both on the same server is a hard validation error (previously a warning). Pick one model: `shutdown_order` for multi-phase ordering, or `parallel` for the legacy two-group behaviour.
+- **Parallel-phase join is now deadline-based.** Previously each thread was joined with the full per-phase timeout, so a phase with N stuck servers could wait up to `N × max_timeout` before continuing. The total wait is now bounded by a single deadline, restoring the "dead hosts don't block" guarantee from v4.6.
+
+---
+
 ## [5.0.0] - 2026-04-11
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,9 +125,8 @@ filesystems:
       - "/mnt/backup"
 
 # Remote Server Shutdown
-# Servers are shutdown in two phases:
-#   1. Sequential: Servers with parallel: false (in config order)
-#   2. Parallel: Remaining servers (parallel: true, the default)
+# Use shutdown_order to define phases. Same order = parallel, ascending = sequential.
+# Legacy parallel: false still works for simple two-group setups.
 remote_servers:
   # Proxmox host with pre-shutdown commands
   - name: "Proxmox Host"
@@ -290,7 +289,9 @@ mounts:
 | `shutdown_command` | `sudo shutdown -h now` | Final shutdown command |
 | `ssh_options` | `[]` | Additional SSH options |
 | `pre_shutdown_commands` | `[]` | Commands to run before shutdown (see below) |
-| `parallel` | `true` | Shutdown concurrently with other parallel servers |
+| `parallel` | (unset) | Legacy two-group flag; `true` = parallel batch, `false` = sequential before parallel batch. Mutually exclusive with `shutdown_order` |
+| `shutdown_order` | (none) | Phase number (>= 1). Same order = parallel, ascending = sequential. Mutually exclusive with `parallel` |
+| `shutdown_safety_margin` | `60` | Seconds added to the per-server timeout budget when waiting for the parallel-shutdown thread. Set `0` to opt out |
 
 #### Pre-shutdown commands
 
@@ -321,16 +322,11 @@ pre_shutdown_commands:
 | `stop_compose` | Stop a compose stack (requires `path` parameter) |
 | `sync` | Sync filesystems |
 
-#### Parallel vs sequential shutdown
+#### Shutdown ordering
 
-Servers are shutdown in two phases:
+Use `shutdown_order` to define multi-phase shutdown. Servers with the same order run in parallel; different orders run sequentially (ascending). For simple setups, `parallel: false` still works. The two flags are **mutually exclusive** — setting both on the same server is rejected at config load time.
 
-1. **Sequential**: Servers with `parallel: false` shutdown one-by-one in config order
-2. **Parallel**: Remaining servers (default `parallel: true`) shutdown concurrently
-
-Use `parallel: false` for servers with dependencies (e.g., NAS that other servers mount).
-
-See [Remote Servers](remote-servers.md) for SSH setup instructions.
+See [Remote Servers](remote-servers.md) for detailed examples, SSH setup instructions, and `shutdown_safety_margin` tuning guidance.
 
 ### Local shutdown section
 

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -113,47 +113,105 @@ Pre-shutdown commands are **best-effort**:
 
 ---
 
-## Parallel vs sequential shutdown
+## Shutdown ordering
 
 By default, all enabled remote servers shut down concurrently using threads, so one slow or unreachable server does not block others.
 
-### Dependency ordering
+### Multi-phase shutdown with `shutdown_order`
 
-If multiple servers mount NFS shares from a NAS, the NAS must shut down **last**.
-
-Use `parallel: false` to mark servers that should shutdown sequentially:
+Use `shutdown_order` to define phases when servers have dependencies. Servers with the same `shutdown_order` run in parallel; different orders run sequentially (ascending). A server alone in its order effectively runs sequentially.
 
 ```yaml
 remote_servers:
-  # These shutdown in parallel (default)
+  # Phase 1: Compute servers shutdown in parallel
   - name: "App Server 1"
     enabled: true
     host: "192.168.1.10"
     user: "root"
+    shutdown_order: 1
     shutdown_command: "shutdown -h now"
 
   - name: "App Server 2"
     enabled: true
     host: "192.168.1.11"
     user: "root"
+    shutdown_order: 1
     shutdown_command: "shutdown -h now"
 
-  # This shuts down AFTER all parallel servers complete
+  # Phase 2: Storage shuts down alone (after compute releases NFS mounts)
   - name: "NAS"
     enabled: true
     host: "192.168.1.50"
     user: "admin"
-    parallel: false  # Sequential - waits for parallel batch
+    shutdown_order: 2
+    shutdown_command: "sudo -i synoshutdown -s"
+
+  # Phase 3: Network infrastructure shuts down last
+  - name: "Router"
+    enabled: true
+    host: "192.168.1.254"
+    user: "admin"
+    shutdown_order: 3
+    shutdown_command: "shutdown -h now"
+
+  - name: "Switch"
+    enabled: true
+    host: "192.168.1.253"
+    user: "admin"
+    shutdown_order: 3
+    shutdown_command: "shutdown -h now"
+```
+
+`shutdown_order` must be a positive integer (>= 1). Gaps are allowed (e.g., 1, 5, 10) — only relative order matters.
+
+### Legacy `parallel` flag
+
+For simple two-group setups, the `parallel` flag still works:
+
+```yaml
+remote_servers:
+  - name: "App Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_command: "shutdown -h now"
+    # parallel: true is the default
+
+  - name: "NAS"
+    enabled: true
+    host: "192.168.1.50"
+    user: "admin"
+    parallel: false  # Shuts down before the parallel batch
     shutdown_command: "sudo -i synoshutdown -s"
 ```
 
-### Execution order
+### Behavior summary
 
-1. Servers with `parallel: false` shut down one-by-one in config order
-2. Remaining servers (default `parallel: true`) shut down concurrently
+| Config | Behavior |
+|--------|----------|
+| No `shutdown_order`, no `parallel` | Default: runs in the parallel batch |
+| No `shutdown_order`, `parallel: true` | Runs in the parallel batch |
+| No `shutdown_order`, `parallel: false` | Runs sequentially before the parallel batch |
+| `shutdown_order: N` (no `parallel`) | Grouped with other order-N servers, all in parallel |
+| `shutdown_order` + `parallel: true` or `false` | **Hard validation error** — pick one model |
 
-!!! tip "Dependency tip"
-    Put servers with dependencies (like NAS/storage) at the end of your config with `parallel: false`.
+!!! warning "shutdown_order and parallel are mutually exclusive"
+    Setting both `shutdown_order` and `parallel` on the same server is rejected at config load time. Use `shutdown_order` for multi-phase ordering, or `parallel` for the legacy two-group behavior — never both.
+
+!!! tip "Use `eneru validate` to preview"
+    Run `eneru validate --config your-config.yaml` to see the shutdown sequence tree, including remote server phases.
+
+### Tuning `shutdown_safety_margin`
+
+Each remote server has a `shutdown_safety_margin` (seconds, default `60`) added on top of `pre_shutdown_commands + command_timeout + connect_timeout` when waiting for its parallel-shutdown thread to finish. The margin covers SSH session setup, OS scheduling jitter, and the brief window between the remote shutdown command starting and SSH closing the channel.
+
+| When to tune | Suggested value |
+|--------------|-----------------|
+| Servers with battery-backed RAID, large write-back caches, or known slow shutdown paths | Raise (e.g. `120`–`300`) |
+| Fast VMs or stateless containers where shutdown completes immediately | Lower (e.g. `10`–`30`) |
+| Opt out of the buffer entirely (use only the explicit timeouts) | `0` |
+
+The phase-wide join window uses the **maximum** `shutdown_safety_margin` across the servers in that phase, so tuning one slow server up does not penalise the others' actual execution time — it only extends the worst-case wait before Eneru moves to the next phase.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -187,7 +187,7 @@ The E2E tests use scenario files to simulate different UPS states:
 
 ### E2E test cases
 
-The E2E workflow (`.github/workflows/e2e.yml`) runs 18 tests on every push and PR:
+The E2E workflow (`.github/workflows/e2e.yml`) runs 19 tests on every push and PR:
 
 | Test | Description |
 |------|-------------|
@@ -209,6 +209,7 @@ The E2E workflow (`.github/workflows/e2e.yml`) runs 18 tests on every push and P
 | **Test 16** | Local drain (`drain_on_local_shutdown=true`): all groups drain before local shutdown |
 | **Test 17** | Local no-drain (`drain_on_local_shutdown=false`): only local group shuts down |
 | **Test 18** | Power recovery: OB then power restored, no shutdown triggered |
+| **Test 19** | Multi-phase shutdown ordering: 3 SSH targets across 2 phases (`shutdown_order: 1, 1, 2`) — verifies all received shutdown, "Phase N/M (order=X)" log lines, and timestamp ordering across phases |
 
 ### Running E2E tests locally
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,7 +22,7 @@ Every commit runs unit tests, integration tests across 9 Linux distributions, en
               ╱    7 Linux Distros    ╲
              ╱─────────────────────────╲
             ╱         Unit Tests        ╲
-           ╱   pytest + Coverage (300)   ╲
+           ╱   pytest + Coverage (338)   ╲
           ╱      7 Python Versions        ╲
          ╱─────────────────────────────────╲
         ╱          Static Analysis          ╲
@@ -37,7 +37,7 @@ Every commit runs unit tests, integration tests across 9 Linux distributions, en
 |-------|-----------|---------------|
 | **AI-Assisted Dev** | Continuous | Code review, implementation guidance |
 | **Static Analysis** | Every commit | Python syntax, config validation |
-| **Unit Tests** | Every commit | Logic, state machine, edge cases (300 tests) |
+| **Unit Tests** | Every commit | Logic, state machine, edge cases (338 tests) |
 | **Integration** | Every commit | Package install on 7 Linux distros |
 | **E2E Tests** | Every commit | Full workflow with real NUT, SSH, Docker |
 | **Real UPS** | Pre-release | Actual hardware, power events |
@@ -109,12 +109,12 @@ Tests `pip install .` to ensure `pyproject.toml` is valid:
 
 ## Test coverage
 
-300 tests across 13 files:
+338 tests across 13 files:
 
-- Configuration parsing (64 tests) -- YAML options, defaults, multi-UPS detection, trigger inheritance, ownership validation, trigger_on enum validation
+- Configuration parsing (83 tests) -- YAML options, defaults, multi-UPS detection, trigger inheritance, ownership validation, trigger_on enum validation, shutdown_order parsing and validation (incl. YAML type coercion edge cases, mutual-exclusion error with `parallel`), shutdown_safety_margin parsing and validation
+- Core monitor logic (45 tests) -- OL/OB/FSD state machine, all four shutdown triggers, failsafe, shutdown sequence ordering, multi-phase shutdown (compute_effective_order, phased execution, thread verification, backward compat, deadline-based join, per-server safety margin)
 - Multi-UPS coordination (33 tests) -- coordinator routing, is_local/drain/trigger_on, defense-in-depth lock, battery anomaly with jitter filtering, notification prefixing, runtime is_local enforcement, exit_after_shutdown in coordinator, ownership rejection (VMs/containers/filesystems)
 - Remote commands (29 tests) -- SSH execution, pre-shutdown actions, parallel and sequential modes
-- Core monitor logic (26 tests) -- OL/OB/FSD state machine, all four shutdown triggers, failsafe, shutdown sequence ordering
 - Connection grace period (26 tests) -- OK/GRACE_PERIOD/FAILED transitions, flap detection, stale data
 - TUI dashboard (23 tests) -- state file parsing, log filtering, human-readable status, --once output
 - CLI (20 tests) -- subcommands, bare invocation, multi-UPS validate

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -189,10 +189,22 @@ filesystems:
 # Remote Server Shutdown
 # Define multiple remote servers to shutdown via SSH
 # Each server can have pre_shutdown_commands to gracefully stop services before shutdown
-# Servers are processed in two phases:
-#   1. Sequential: Servers with parallel: false are shutdown one by one (in config order)
-#   2. Parallel: Remaining servers (parallel: true, the default) are shutdown concurrently
-# Use parallel: false for servers with dependencies (e.g., NAS that other servers mount)
+#
+# Shutdown ordering:
+#   Use shutdown_order to define phases. Servers with the same shutdown_order
+#   run in parallel; different orders run sequentially (ascending).
+#   A server alone in its order effectively runs sequentially.
+#
+#   Example: shutdown_order: 1 (compute), 2 (storage), 3 (network)
+#
+# Legacy mode (no shutdown_order):
+#   Servers with parallel: false shutdown sequentially before all parallel: true servers.
+#   This is equivalent to shutdown_order for simple two-group setups.
+#
+# IMPORTANT: shutdown_order and parallel are mutually exclusive.
+#   Setting both on the same server is a hard validation error — pick one
+#   model per server. Use shutdown_order for multi-phase ordering, or
+#   parallel for the legacy two-group behavior.
 remote_servers:
   - name: "Synology NAS"
     enabled: true
@@ -207,9 +219,24 @@ remote_servers:
     # SSH options (optional)
     ssh_options:
       - "-o StrictHostKeyChecking=no"
-    # Parallel shutdown (default: true)
-    # Set to false to shutdown this server sequentially before the parallel batch
+    # Shutdown order (optional, positive integer >= 1)
+    # Servers with the same shutdown_order run in parallel.
+    # Lower orders run first. A server alone in its order runs sequentially.
+    # shutdown_order: 1
+    #
+    # Legacy alternative: parallel: false
+    # Shuts down this server sequentially before the parallel batch.
+    # Mutually exclusive with shutdown_order — setting both is a hard error.
     # parallel: false
+    #
+    # Safety margin (seconds) added on top of (pre_shutdown_commands +
+    # command_timeout + connect_timeout) when waiting for this server's
+    # parallel-shutdown thread. Covers SSH session setup, OS jitter, and
+    # the brief window between the remote shutdown command starting and
+    # SSH closing the channel. Default: 60. Tune higher for servers with
+    # battery-backed RAID or large flush windows; tune lower for fast VMs.
+    # Set to 0 to opt out of the safety buffer entirely.
+    # shutdown_safety_margin: 60
 
   # Example: Proxmox server with VMs and containers
   # - name: "Proxmox Host"
@@ -244,12 +271,47 @@ remote_servers:
   #     - action: "sync"
   #   shutdown_command: "shutdown -h now"
 
-  # Example: Server with dependency - must shutdown LAST
+  # Example: Server with dependency - must shutdown AFTER compute servers
   # - name: "Storage Server"
   #   enabled: true
   #   host: "192.168.178.200"
   #   user: "root"
-  #   parallel: false  # Shutdown sequentially (after all parallel servers)
+  #   shutdown_order: 2  # Phase 2: after compute (order 1), before network (order 3)
+  #   shutdown_command: "shutdown -h now"
+
+  # Example: Multi-phase shutdown ordering
+  # Phase 1: Compute servers shutdown in parallel
+  # - name: "App Server 1"
+  #   enabled: true
+  #   host: "192.168.178.100"
+  #   user: "root"
+  #   shutdown_order: 1
+  #   shutdown_command: "shutdown -h now"
+  # - name: "App Server 2"
+  #   enabled: true
+  #   host: "192.168.178.101"
+  #   user: "root"
+  #   shutdown_order: 1
+  #   shutdown_command: "shutdown -h now"
+  # Phase 2: Storage shuts down alone (after compute releases mounts)
+  # - name: "Storage Server"
+  #   enabled: true
+  #   host: "192.168.178.200"
+  #   user: "root"
+  #   shutdown_order: 2
+  #   shutdown_command: "shutdown -h now"
+  # Phase 3: Network infrastructure shuts down last
+  # - name: "Router"
+  #   enabled: true
+  #   host: "192.168.178.254"
+  #   user: "admin"
+  #   shutdown_order: 3
+  #   shutdown_command: "shutdown -h now"
+  # - name: "Switch"
+  #   enabled: true
+  #   host: "192.168.178.253"
+  #   user: "admin"
+  #   shutdown_order: 3
   #   shutdown_command: "shutdown -h now"
 
 # Local Server Shutdown

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from eneru.version import __version__
 from eneru.config import ConfigLoader
-from eneru.monitor import UPSGroupMonitor, MultiUPSCoordinator
+from eneru.monitor import UPSGroupMonitor, MultiUPSCoordinator, compute_effective_order
 from eneru.notifications import APPRISE_AVAILABLE
 
 # Optional import for Apprise (needed for test notifications)
@@ -36,6 +36,73 @@ def _cmd_run(args):
         monitor.run()
 
 
+def _print_shutdown_sequence(group, enabled_servers, has_local, prefix):
+    """Print the shutdown sequence tree for a UPS group."""
+    print(f"{prefix}  Shutdown sequence:")
+    step = 1
+    indent = f"{prefix}    "
+
+    if has_local:
+        if group.virtual_machines.enabled:
+            print(f"{indent}{step}. Virtual machines")
+            step += 1
+        if group.containers.enabled:
+            containers = group.containers
+            compose_count = len(containers.compose_files)
+            detail = f" ({containers.runtime}"
+            if compose_count > 0:
+                detail += f", {compose_count} compose file(s)"
+            detail += ")"
+            print(f"{indent}{step}. Containers{detail}")
+            step += 1
+        if group.filesystems.sync_enabled or group.filesystems.unmount.enabled:
+            parts = []
+            if group.filesystems.sync_enabled:
+                parts.append("sync")
+            if group.filesystems.unmount.enabled:
+                mount_count = len(group.filesystems.unmount.mounts)
+                parts.append(f"unmount {mount_count} mount(s)")
+            print(f"{indent}{step}. Filesystem {' + '.join(parts)}")
+            step += 1
+
+    if enabled_servers:
+        ordered = compute_effective_order(enabled_servers)
+        phases = {}
+        for effective, server in ordered:
+            phases.setdefault(effective, []).append(server)
+        sorted_keys = sorted(phases.keys())
+        num_phases = len(sorted_keys)
+
+        # Detect legacy mode: no server has explicit shutdown_order
+        is_legacy = all(s.shutdown_order is None for s in enabled_servers)
+
+        if num_phases == 1:
+            names = ", ".join(s.name or s.host for s in enabled_servers)
+            if len(enabled_servers) == 1:
+                print(f"{indent}{step}. Remote server: {names}")
+            else:
+                print(f"{indent}{step}. Remote servers ({len(enabled_servers)}): {names}")
+        else:
+            print(f"{indent}{step}. Remote servers ({len(enabled_servers)}, {num_phases} phases):")
+            for phase_idx, key in enumerate(sorted_keys, 1):
+                phase_servers = phases[key]
+                names = ", ".join(s.name or s.host for s in phase_servers)
+                if is_legacy:
+                    # Legacy mode: label by execution style
+                    if key < 0:
+                        print(f"{indent}   Sequential: {names}")
+                    else:
+                        print(f"{indent}   Parallel: {names}")
+                else:
+                    print(f"{indent}   Phase {phase_idx} (order={key}): {names}")
+        step += 1
+    else:
+        print(f"{indent}(no remote servers)")
+
+    if has_local:
+        print(f"{indent}{step}. Local shutdown")
+
+
 def _print_group_summary(group, idx, multi_ups):
     """Print a single UPS group summary for validate output."""
     label = group.ups.label
@@ -48,28 +115,10 @@ def _print_group_summary(group, idx, multi_ups):
         print(" [is_local]", end="")
     print()
 
-    # Only show local resources if is_local (or single-UPS legacy)
-    if group.is_local or not multi_ups:
-        print(f"{prefix}  VMs enabled: {group.virtual_machines.enabled}")
-        containers = group.containers
-        print(f"{prefix}  Containers enabled: {containers.enabled}", end="")
-        if containers.enabled:
-            compose_count = len(containers.compose_files)
-            if compose_count > 0:
-                print(f" (runtime: {containers.runtime}, {compose_count} compose file(s))")
-            else:
-                print(f" (runtime: {containers.runtime})")
-        else:
-            print()
-        print(f"{prefix}  Filesystems sync: {group.filesystems.sync_enabled}", end="")
-        if group.filesystems.unmount.enabled:
-            mount_count = len(group.filesystems.unmount.mounts)
-            print(f", unmount: {mount_count} mount(s)")
-        else:
-            print()
-
+    # Shutdown sequence tree
     enabled_servers = [s for s in group.remote_servers if s.enabled]
-    print(f"{prefix}  Remote servers: {len(enabled_servers)}")
+    has_local = group.is_local or not multi_ups
+    _print_shutdown_sequence(group, enabled_servers, has_local, prefix)
 
 
 def _cmd_validate(args):
@@ -78,7 +127,6 @@ def _cmd_validate(args):
     exit_code = 0
 
     print(f"Eneru v{__version__}")
-    print("Configuration is valid.")
 
     multi_ups = config.multi_ups
     if multi_ups:
@@ -138,6 +186,12 @@ def _cmd_validate(args):
             print(f"  {msg}")
             if msg.startswith("ERROR"):
                 exit_code = 1
+
+    print()
+    if exit_code == 0:
+        print("Configuration is valid.")
+    else:
+        print("Configuration is INVALID — fix the ERROR(s) above and re-run.")
 
     sys.exit(exit_code)
 

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -148,7 +148,17 @@ class RemoteServerConfig:
     shutdown_command: str = "sudo shutdown -h now"
     ssh_options: List[str] = field(default_factory=list)
     pre_shutdown_commands: List[RemoteCommandConfig] = field(default_factory=list)
-    parallel: bool = True  # If False, server is shutdown sequentially before parallel batch
+    # Legacy ordering flag: None = unset (default behaves like True); True = run with the
+    # parallel batch; False = run sequentially before the parallel batch. Mutually exclusive
+    # with shutdown_order — setting both is a hard validation error.
+    parallel: Optional[bool] = None
+    shutdown_order: Optional[int] = None  # None = derive from parallel flag; >= 1 for explicit phase
+    # Seconds added on top of (pre_shutdown_commands + command_timeout + connect_timeout)
+    # when waiting for this server's parallel-shutdown thread to finish. Covers SSH session
+    # setup, OS scheduling jitter, and the brief window between the remote shutdown command
+    # starting and SSH closing the channel. Tune higher for servers with battery-backed RAID
+    # or large flush windows; tune lower for fast-shutdown VMs. Zero opts out entirely.
+    shutdown_safety_margin: int = 60
 
 
 @dataclass
@@ -415,7 +425,9 @@ class ConfigLoader:
                 shutdown_command=server_data.get('shutdown_command', 'sudo shutdown -h now'),
                 ssh_options=server_data.get('ssh_options', []),
                 pre_shutdown_commands=pre_cmds,
-                parallel=server_data.get('parallel', True),
+                parallel=server_data.get('parallel'),
+                shutdown_order=server_data.get('shutdown_order'),
+                shutdown_safety_margin=server_data.get('shutdown_safety_margin', 60),
             ))
         return servers
 
@@ -744,6 +756,52 @@ class ConfigLoader:
                             f"WARNING: Top-level '{key}' section ignored in multi-UPS mode. "
                             f"Move resources under the appropriate UPS entry."
                         )
+
+        # Validate shutdown_order, shutdown_safety_margin, and the
+        # mutual-exclusion of shutdown_order vs parallel.
+        for group in config.ups_groups:
+            for server in group.remote_servers:
+                display = server.name or server.host
+
+                so = server.shutdown_order
+                so_valid = False
+                if so is not None:
+                    if not isinstance(so, int) or isinstance(so, bool):
+                        messages.append(
+                            f"ERROR: Remote server '{display}': shutdown_order "
+                            f"must be a positive integer, got {so!r}"
+                        )
+                    elif so < 1:
+                        messages.append(
+                            f"ERROR: Remote server '{display}': shutdown_order "
+                            f"must be >= 1, got {so}"
+                        )
+                    else:
+                        so_valid = True
+
+                # Mutual exclusion: shutdown_order AND parallel both explicitly set
+                # (either parallel: true or parallel: false) is a hard error.
+                if so_valid and server.parallel is not None:
+                    messages.append(
+                        f"ERROR: Remote server '{display}': cannot set both "
+                        f"'shutdown_order' ({so}) and 'parallel' ({str(server.parallel).lower()}). "
+                        f"Pick one model:\n"
+                        f"  - shutdown_order: <int>>=1   (recommended; supports multi-phase ordering)\n"
+                        f"  - parallel: true|false       (legacy two-phase behavior)\n"
+                        f"Remove the unused field from this server's config."
+                    )
+
+                margin = server.shutdown_safety_margin
+                if not isinstance(margin, int) or isinstance(margin, bool):
+                    messages.append(
+                        f"ERROR: Remote server '{display}': shutdown_safety_margin "
+                        f"must be a non-negative integer, got {margin!r}"
+                    )
+                elif margin < 0:
+                    messages.append(
+                        f"ERROR: Remote server '{display}': shutdown_safety_margin "
+                        f"must be >= 0, got {margin}"
+                    )
 
         # Validate trigger_on value
         if config.local_shutdown.trigger_on not in ("any", "none"):

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -50,6 +50,42 @@ except ImportError:
     apprise = None
 
 
+def compute_effective_order(
+    servers: List[RemoteServerConfig],
+) -> List[Tuple[int, RemoteServerConfig]]:
+    """Compute effective shutdown order for each server.
+
+    Rules:
+    - If shutdown_order is explicitly set: use that value.
+    - If shutdown_order is None and parallel is False: each gets a unique
+      negative value based on its position among parallel=False servers,
+      preserving the legacy "sequential-first" behavior.
+    - Otherwise (shutdown_order is None and parallel is None or True):
+      effective = 0 (parallel batch).
+
+    This ensures existing configs with only ``parallel`` produce identical
+    behavior to the old two-phase code.
+    """
+    result: List[Tuple[int, RemoteServerConfig]] = []
+    legacy_seq_count = sum(
+        1 for s in servers
+        if s.shutdown_order is None and s.parallel is False
+    )
+    legacy_seq_index = 0
+    for server in servers:
+        if server.shutdown_order is not None:
+            effective = server.shutdown_order
+        elif server.parallel is False:
+            # Legacy sequential: assign negative orders in config order
+            # so they all run before the parallel batch (order 0).
+            effective = -(legacy_seq_count - legacy_seq_index)
+            legacy_seq_index += 1
+        else:
+            effective = 0
+        result.append((effective, server))
+    return result
+
+
 class UPSGroupMonitor:
     """Main UPS Monitor class."""
 
@@ -845,103 +881,116 @@ class UPSGroupMonitor:
     def _shutdown_remote_servers(self):
         """Shutdown all enabled remote servers via SSH.
 
-        Servers are processed in two phases:
-        1. Sequential phase: Servers with parallel=False are shutdown one by one
-           in config order. Use this for servers with dependencies (e.g., a server
-           that hosts storage used by other servers should be shutdown last).
-        2. Parallel phase: Remaining servers (parallel=True, the default) are
-           shutdown concurrently using threads to avoid sequential timeouts.
+        Servers are grouped by their effective shutdown order and processed
+        in ascending order.  All servers within a group run in parallel.
+        A server alone in its group effectively runs sequentially.
 
-        This hybrid approach ensures dependency order while still benefiting from
-        parallel execution for independent servers.
+        When shutdown_order is not set, the legacy parallel flag determines
+        effective order:
+        - parallel: true  (default) -> effective order 0
+        - parallel: false -> unique negative orders (run before order 0)
+        This preserves exact backward compatibility with existing configs.
         """
         enabled_servers = [s for s in self.config.remote_servers if s.enabled]
 
         if not enabled_servers:
             return
 
-        # Separate servers into sequential and parallel groups
-        sequential_servers = [s for s in enabled_servers if not s.parallel]
-        parallel_servers = [s for s in enabled_servers if s.parallel]
+        # Group servers by effective shutdown order
+        ordered = compute_effective_order(enabled_servers)
+        phases: Dict[int, List[RemoteServerConfig]] = {}
+        for effective, server in ordered:
+            phases.setdefault(effective, []).append(server)
+        sorted_keys = sorted(phases.keys())
 
         server_count = len(enabled_servers)
-        seq_count = len(sequential_servers)
-        par_count = len(parallel_servers)
+        num_phases = len(sorted_keys)
 
-        if seq_count > 0 and par_count > 0:
+        if num_phases > 1:
             self._log_message(
-                f"🌐 Shutting down {server_count} remote server(s) "
-                f"({seq_count} sequential, {par_count} parallel)..."
+                f"🌐 Shutting down {server_count} remote server(s) in {num_phases} phases..."
             )
-        elif seq_count > 0:
-            self._log_message(f"🌐 Shutting down {server_count} remote server(s) sequentially...")
-        else:
+        elif server_count > 1:
             self._log_message(f"🌐 Shutting down {server_count} remote server(s) in parallel...")
+        else:
+            self._log_message(f"🌐 Shutting down 1 remote server...")
 
         completed = 0
 
-        # Phase 1: Sequential servers (in config order)
-        for server in sequential_servers:
-            display_name = server.name or server.host
-            try:
-                self._shutdown_remote_server(server)
-                completed += 1
-            except Exception as e:
-                self._log_message(f"  ❌ {display_name} shutdown failed: {e}")
+        for phase_idx, key in enumerate(sorted_keys, 1):
+            phase_servers = phases[key]
+            names = ", ".join(s.name or s.host for s in phase_servers)
 
-        # Phase 2: Parallel servers
-        if parallel_servers:
-            # Calculate max timeout for parallel servers (for the join timeout)
-            def calc_server_timeout(server: RemoteServerConfig) -> int:
-                pre_cmd_time = sum(
-                    (cmd.timeout or server.command_timeout) for cmd in server.pre_shutdown_commands
-                )
-                return pre_cmd_time + server.command_timeout + server.connect_timeout + 60
+            if num_phases > 1:
+                self._log_message(f"  📋 Phase {phase_idx}/{num_phases} (order={key}): {names}")
 
-            max_timeout = max(calc_server_timeout(s) for s in parallel_servers)
-
-            # Track results for logging
-            results: Dict[str, Tuple[bool, str]] = {}
-            results_lock = threading.Lock()
-
-            def shutdown_server_thread(server: RemoteServerConfig):
-                """Thread worker for shutting down a single server."""
+            if len(phase_servers) == 1:
+                server = phase_servers[0]
                 display_name = server.name or server.host
                 try:
                     self._shutdown_remote_server(server)
-                    with results_lock:
-                        results[display_name] = (True, "")
+                    completed += 1
                 except Exception as e:
-                    with results_lock:
-                        results[display_name] = (False, str(e))
-
-            # Start all threads
-            threads: List[threading.Thread] = []
-            for server in parallel_servers:
-                t = threading.Thread(
-                    target=shutdown_server_thread,
-                    args=(server,),
-                    name=f"remote-shutdown-{server.name or server.host}"
-                )
-                t.start()
-                threads.append(t)
-
-            # Wait for all threads to complete with global timeout
-            for t in threads:
-                t.join(timeout=max_timeout)
-
-            # Check for any threads that are still running (timed out)
-            still_running = [t for t in threads if t.is_alive()]
-            if still_running:
-                self._log_message(
-                    f"  ⚠️ {len(still_running)} remote shutdown(s) still in progress "
-                    "(continuing with local shutdown)"
-                )
-
-            completed += par_count - len(still_running)
+                    self._log_message(f"  ❌ {display_name} shutdown failed: {e}")
+            else:
+                completed += self._shutdown_servers_parallel(phase_servers)
 
         # Log summary
         self._log_message(f"  ✅ Remote shutdown complete ({completed}/{server_count} servers)")
+
+    def _shutdown_servers_parallel(self, servers: List[RemoteServerConfig]) -> int:
+        """Shutdown multiple remote servers in parallel using threads.
+
+        Returns the number of servers whose threads finished within the
+        timeout window (regardless of individual success/failure — per-server
+        errors are logged inside _shutdown_remote_server).
+        """
+        def calc_server_timeout(server: RemoteServerConfig) -> int:
+            pre_cmd_time = sum(
+                (cmd.timeout or server.command_timeout) for cmd in server.pre_shutdown_commands
+            )
+            return (
+                pre_cmd_time
+                + server.command_timeout
+                + server.connect_timeout
+                + server.shutdown_safety_margin
+            )
+
+        max_timeout = max(calc_server_timeout(s) for s in servers)
+
+        def shutdown_server_thread(server: RemoteServerConfig):
+            """Thread worker for shutting down a single server."""
+            try:
+                self._shutdown_remote_server(server)
+            except Exception:
+                pass  # Errors logged inside _shutdown_remote_server
+
+        threads: List[threading.Thread] = []
+        for server in servers:
+            t = threading.Thread(
+                target=shutdown_server_thread,
+                args=(server,),
+                name=f"remote-shutdown-{server.name or server.host}"
+            )
+            t.start()
+            threads.append(t)
+
+        # Deadline-based join: cap total wait at max_timeout regardless of
+        # how many threads are stuck. Per-thread join() with the same
+        # max_timeout would stack to N × max_timeout in the worst case.
+        deadline = time.monotonic() + max_timeout
+        for t in threads:
+            remaining = max(0.0, deadline - time.monotonic())
+            t.join(timeout=remaining)
+
+        still_running = [t for t in threads if t.is_alive()]
+        if still_running:
+            self._log_message(
+                f"  ⚠️ {len(still_running)} remote shutdown(s) still in progress "
+                "(continuing with next phase)"
+            )
+
+        return len(servers) - len(still_running)
 
     def _run_remote_command(
         self,

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "4.3.0" for tagged releases, "4.3.0-5-gabcdef1" for dev builds
-__version__ = "5.1.0-rc0"
+__version__ = "5.1.0-rc1"

--- a/tests/e2e/config-e2e-shutdown-order.yaml
+++ b/tests/e2e/config-e2e-shutdown-order.yaml
@@ -1,0 +1,98 @@
+# E2E config exercising multi-phase shutdown ordering.
+#
+# Three SSH targets across two phases:
+#   Phase 1 (shutdown_order: 1, parallel within): Target1, Target2
+#   Phase 2 (shutdown_order: 2, alone):           Target3
+#
+# After triggering shutdown, the per-target /var/log/shutdown.log timestamps
+# must satisfy: max(phase-1 timestamps) <= phase-2 timestamp.
+# Eneru's stdout must show "Phase 1/2 (order=1)" and "Phase 2/2 (order=2)".
+
+ups:
+  name: "TestUPS@localhost:3493"
+  check_interval: 1
+  max_stale_data_tolerance: 3
+
+triggers:
+  low_battery_threshold: 20
+  critical_runtime_threshold: 600
+  depletion:
+    window: 300
+    critical_rate: 15.0
+    grace_period: 30
+  extended_time:
+    enabled: false
+
+behavior:
+  dry_run: false  # Real execution against the SSH targets
+
+logging:
+  file: null
+  state_file: "/tmp/eneru-e2e-shutdown-order-state"
+  battery_history_file: "/tmp/eneru-e2e-shutdown-order-history"
+  shutdown_flag_file: "/tmp/eneru-e2e-shutdown-order-flag"
+
+notifications:
+  enabled: false
+  urls: []
+
+virtual_machines:
+  enabled: false
+
+containers:
+  enabled: false  # Avoid stopping the NUT/SSH containers in this test
+
+filesystems:
+  sync_enabled: false  # Skip sync for test speed; covered by other E2E tests
+  unmount:
+    enabled: false
+
+remote_servers:
+  - name: "Phase1-Target1"
+    enabled: true
+    host: "localhost"
+    user: "testuser"
+    connect_timeout: 5
+    command_timeout: 10
+    shutdown_safety_margin: 5  # Tight budget so test finishes quickly
+    shutdown_order: 1
+    shutdown_command: "sudo shutdown -h now"
+    ssh_options:
+      - "-o Port=2222"
+      - "-o StrictHostKeyChecking=no"
+      - "-o UserKnownHostsFile=/dev/null"
+      - "-o IdentityFile=/tmp/e2e-ssh-key"
+
+  - name: "Phase1-Target2"
+    enabled: true
+    host: "localhost"
+    user: "testuser"
+    connect_timeout: 5
+    command_timeout: 10
+    shutdown_safety_margin: 5
+    shutdown_order: 1
+    shutdown_command: "sudo shutdown -h now"
+    ssh_options:
+      - "-o Port=2223"
+      - "-o StrictHostKeyChecking=no"
+      - "-o UserKnownHostsFile=/dev/null"
+      - "-o IdentityFile=/tmp/e2e-ssh-key"
+
+  - name: "Phase2-Target3"
+    enabled: true
+    host: "localhost"
+    user: "testuser"
+    connect_timeout: 5
+    command_timeout: 10
+    shutdown_safety_margin: 5
+    shutdown_order: 2
+    shutdown_command: "sudo shutdown -h now"
+    ssh_options:
+      - "-o Port=2224"
+      - "-o StrictHostKeyChecking=no"
+      - "-o UserKnownHostsFile=/dev/null"
+      - "-o IdentityFile=/tmp/e2e-ssh-key"
+
+local_shutdown:
+  enabled: false  # CRITICAL: Never enable in CI - would kill the runner
+  command: "echo 'Local shutdown would execute here'"

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -29,6 +29,33 @@ services:
     networks:
       - eneru-e2e
 
+  # Additional SSH targets for multi-phase shutdown ordering tests.
+  # Identical image to ssh-target, exposed on different host ports so
+  # Eneru can address each one independently via SSH.
+  ssh-target-2:
+    build:
+      context: ./ssh-target
+      dockerfile: Dockerfile
+    container_name: eneru-e2e-ssh-2
+    ports:
+      - "2223:22"
+    volumes:
+      - ./ssh-target/authorized_keys:/tmp/host-authorized-keys:ro
+    networks:
+      - eneru-e2e
+
+  ssh-target-3:
+    build:
+      context: ./ssh-target
+      dockerfile: Dockerfile
+    container_name: eneru-e2e-ssh-3
+    ports:
+      - "2224:22"
+    volumes:
+      - ./ssh-target/authorized_keys:/tmp/host-authorized-keys:ro
+    networks:
+      - eneru-e2e
+
   # Target containers that Eneru will stop during shutdown sequence
   target-nginx:
     image: nginx:alpine

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,11 +108,11 @@ remote_servers:
             assert exc_info.value.code == 0
 
         captured = capsys.readouterr()
-        assert "VMs enabled: True" in captured.out
-        assert "Containers enabled: True" in captured.out
+        assert "Virtual machines" in captured.out
+        assert "Containers" in captured.out
         assert "podman" in captured.out
         assert "2 compose file(s)" in captured.out
-        assert "Remote servers: 1" in captured.out
+        assert "Remote server: Server 1" in captured.out
 
     @pytest.mark.unit
     def test_validate_config_shows_notifications(self, tmp_path, capsys):
@@ -211,8 +211,7 @@ filesystems:
             assert exc_info.value.code == 0
 
         captured = capsys.readouterr()
-        assert "sync: True" in captured.out or "Filesystems sync: True" in captured.out
-        assert "3 mount(s)" in captured.out
+        assert "Filesystem sync + unmount 3 mount(s)" in captured.out
 
     @pytest.mark.unit
     def test_validate_multi_ups_config(self, tmp_path, capsys):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -656,8 +656,13 @@ remote_servers:
         assert server.pre_shutdown_commands == []
 
     @pytest.mark.unit
-    def test_parallel_option_default_true(self, temp_config_file):
-        """Test that parallel defaults to True when not specified."""
+    def test_parallel_option_default_none(self, temp_config_file):
+        """Test that parallel defaults to None (unset) when not specified.
+
+        Absent ``parallel`` is treated as the default parallel batch by
+        ``compute_effective_order``; the None state is preserved so the
+        validator can detect mutual-exclusion conflicts with shutdown_order.
+        """
         config_data = """
 remote_servers:
   - name: "Server Without Parallel"
@@ -670,7 +675,7 @@ remote_servers:
         config = ConfigLoader.load(str(temp_config_file))
 
         server = config.remote_servers[0]
-        assert server.parallel is True
+        assert server.parallel is None
 
     @pytest.mark.unit
     def test_parallel_option_explicit_false(self, temp_config_file):
@@ -717,7 +722,7 @@ remote_servers:
         config = ConfigLoader.load(str(temp_config_file))
 
         assert len(config.remote_servers) == 3
-        assert config.remote_servers[0].parallel is True
+        assert config.remote_servers[0].parallel is None  # field omitted
         assert config.remote_servers[1].parallel is False
         assert config.remote_servers[2].parallel is True
 
@@ -967,7 +972,8 @@ remote_servers:
         assert server.shutdown_command == "sudo shutdown -h now"  # default
         assert server.ssh_options == []  # default
         assert server.pre_shutdown_commands == []  # default
-        assert server.parallel is True  # default
+        assert server.parallel is None  # default (unset; behaves as parallel batch)
+        assert server.shutdown_safety_margin == 60  # default
 
     @pytest.mark.unit
     def test_filesystems_sync_disabled(self, temp_config_file):
@@ -1084,3 +1090,430 @@ notifications:
         # Should only have one URL (deduplication logic)
         assert len(config.notifications.urls) == 1
         assert "discord://" in config.notifications.urls[0]
+
+
+class TestShutdownOrderConfig:
+    """Test shutdown_order configuration parsing and validation."""
+
+    @pytest.mark.unit
+    def test_shutdown_order_default_none(self, temp_config_file):
+        """Test that shutdown_order defaults to None when not specified."""
+        config_data = """
+remote_servers:
+  - name: "Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        assert config.remote_servers[0].shutdown_order is None
+
+    @pytest.mark.unit
+    def test_shutdown_order_positive_integer(self, temp_config_file):
+        """Test parsing a positive shutdown_order value."""
+        config_data = """
+remote_servers:
+  - name: "Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 2
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        assert config.remote_servers[0].shutdown_order == 2
+
+    @pytest.mark.unit
+    def test_shutdown_order_multiple_servers(self, temp_config_file):
+        """Test multiple servers with different shutdown_order values."""
+        config_data = """
+remote_servers:
+  - name: "App Server 1"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 1
+    shutdown_command: "shutdown -h now"
+  - name: "Storage Server"
+    enabled: true
+    host: "192.168.1.11"
+    user: "root"
+    shutdown_order: 2
+    shutdown_command: "shutdown -h now"
+  - name: "App Server 2"
+    enabled: true
+    host: "192.168.1.12"
+    user: "root"
+    shutdown_order: 1
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        assert config.remote_servers[0].shutdown_order == 1
+        assert config.remote_servers[1].shutdown_order == 2
+        assert config.remote_servers[2].shutdown_order == 1
+
+    @pytest.mark.unit
+    def test_shutdown_order_mixed_with_parallel_flag(self, temp_config_file):
+        """Test that shutdown_order and parallel are parsed independently."""
+        config_data = """
+remote_servers:
+  - name: "With Order"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 3
+    shutdown_command: "shutdown -h now"
+  - name: "Legacy Sequential"
+    enabled: true
+    host: "192.168.1.11"
+    user: "root"
+    parallel: false
+    shutdown_command: "shutdown -h now"
+  - name: "Legacy Parallel"
+    enabled: true
+    host: "192.168.1.12"
+    user: "root"
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        assert config.remote_servers[0].shutdown_order == 3
+        assert config.remote_servers[0].parallel is None  # parallel not in YAML
+        assert config.remote_servers[1].shutdown_order is None
+        assert config.remote_servers[1].parallel is False
+        assert config.remote_servers[2].shutdown_order is None
+        assert config.remote_servers[2].parallel is None  # parallel not in YAML
+
+    @pytest.mark.unit
+    def test_shutdown_order_with_gaps(self, temp_config_file):
+        """Test that gaps in shutdown_order values are accepted."""
+        config_data = """
+remote_servers:
+  - name: "Server A"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 10
+    shutdown_command: "shutdown -h now"
+  - name: "Server B"
+    enabled: true
+    host: "192.168.1.11"
+    user: "root"
+    shutdown_order: 30
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        assert config.remote_servers[0].shutdown_order == 10
+        assert config.remote_servers[1].shutdown_order == 30
+
+    @pytest.mark.unit
+    def test_validation_error_shutdown_order_with_parallel_false(self, temp_config_file):
+        """Test that validation errors when shutdown_order and parallel: false are both set."""
+        config_data = """
+remote_servers:
+  - name: "Conflicting Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 2
+    parallel: false
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [
+            m for m in messages
+            if "ERROR" in m and "cannot set both" in m
+        ]
+        assert len(error_msgs) == 1
+        assert "Conflicting Server" in error_msgs[0]
+        assert "shutdown_order" in error_msgs[0]
+        assert "parallel" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_validation_error_shutdown_order_with_parallel_true(self, temp_config_file):
+        """Test that validation errors when shutdown_order and parallel: true are both set."""
+        config_data = """
+remote_servers:
+  - name: "Conflicting Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 2
+    parallel: true
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [
+            m for m in messages
+            if "ERROR" in m and "cannot set both" in m
+        ]
+        assert len(error_msgs) == 1
+        assert "Conflicting Server" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_validation_error_shutdown_order_zero(self, temp_config_file):
+        """Test that validation rejects shutdown_order: 0."""
+        config_data = """
+remote_servers:
+  - name: "Bad Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 0
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [m for m in messages if "ERROR" in m and "shutdown_order" in m]
+        assert len(error_msgs) == 1
+        assert ">= 1" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_validation_error_shutdown_order_negative(self, temp_config_file):
+        """Test that validation rejects negative shutdown_order."""
+        config_data = """
+remote_servers:
+  - name: "Bad Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: -1
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [m for m in messages if "ERROR" in m and "shutdown_order" in m]
+        assert len(error_msgs) == 1
+        assert ">= 1" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_validation_no_message_shutdown_order_alone(self, temp_config_file):
+        """Test no validation message when shutdown_order is set without parallel."""
+        config_data = """
+remote_servers:
+  - name: "Good Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 1
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        assert not any("shutdown_order" in m for m in messages)
+        assert not any("cannot set both" in m for m in messages)
+
+    @pytest.mark.unit
+    def test_validation_error_shutdown_order_boolean(self, temp_config_file):
+        """Test that validation rejects shutdown_order: true (YAML bool is int subclass)."""
+        config_data = """
+remote_servers:
+  - name: "Bad Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: true
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [m for m in messages if "ERROR" in m and "shutdown_order" in m]
+        assert len(error_msgs) == 1
+        assert "positive integer" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_validation_error_shutdown_order_float(self, temp_config_file):
+        """Test that validation rejects shutdown_order: 2.5 (YAML float)."""
+        config_data = """
+remote_servers:
+  - name: "Bad Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: 2.5
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [m for m in messages if "ERROR" in m and "shutdown_order" in m]
+        assert len(error_msgs) == 1
+        assert "positive integer" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_validation_no_conflict_error_when_shutdown_order_invalid(self, temp_config_file):
+        """Test no 'cannot set both' error when shutdown_order itself is invalid.
+
+        When shutdown_order fails its own validation, we should not also
+        complain about the mutual-exclusion conflict — the user needs to
+        fix shutdown_order first; chaining errors would be noisy.
+        """
+        config_data = """
+remote_servers:
+  - name: "Bad Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_order: -1
+    parallel: false
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        order_error_msgs = [
+            m for m in messages
+            if "ERROR" in m and "shutdown_order" in m and ">= 1" in m
+        ]
+        conflict_msgs = [m for m in messages if "cannot set both" in m]
+        assert len(order_error_msgs) == 1
+        assert len(conflict_msgs) == 0
+
+
+class TestShutdownSafetyMargin:
+    """Test shutdown_safety_margin configuration parsing and validation."""
+
+    @pytest.mark.unit
+    def test_safety_margin_default_60(self, temp_config_file):
+        """Test that shutdown_safety_margin defaults to 60 when not specified."""
+        config_data = """
+remote_servers:
+  - name: "Default Server"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+        assert config.remote_servers[0].shutdown_safety_margin == 60
+
+    @pytest.mark.unit
+    def test_safety_margin_custom_value(self, temp_config_file):
+        """Test parsing a custom shutdown_safety_margin value."""
+        config_data = """
+remote_servers:
+  - name: "Slow NAS"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_safety_margin: 180
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+        assert config.remote_servers[0].shutdown_safety_margin == 180
+
+    @pytest.mark.unit
+    def test_safety_margin_zero_accepted(self, temp_config_file):
+        """Test that shutdown_safety_margin: 0 is accepted (opt-out of buffer)."""
+        config_data = """
+remote_servers:
+  - name: "No Margin"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_safety_margin: 0
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+        assert config.remote_servers[0].shutdown_safety_margin == 0
+
+        messages = ConfigLoader.validate_config(config)
+        assert not any("shutdown_safety_margin" in m for m in messages)
+
+    @pytest.mark.unit
+    def test_safety_margin_negative_rejected(self, temp_config_file):
+        """Test that negative shutdown_safety_margin is rejected."""
+        config_data = """
+remote_servers:
+  - name: "Bad Margin"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_safety_margin: -5
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [
+            m for m in messages
+            if "ERROR" in m and "shutdown_safety_margin" in m
+        ]
+        assert len(error_msgs) == 1
+        assert ">= 0" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_safety_margin_boolean_rejected(self, temp_config_file):
+        """Test that boolean shutdown_safety_margin is rejected."""
+        config_data = """
+remote_servers:
+  - name: "Bad Margin"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_safety_margin: true
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [
+            m for m in messages
+            if "ERROR" in m and "shutdown_safety_margin" in m
+        ]
+        assert len(error_msgs) == 1
+        assert "non-negative integer" in error_msgs[0]
+
+    @pytest.mark.unit
+    def test_safety_margin_float_rejected(self, temp_config_file):
+        """Test that float shutdown_safety_margin is rejected."""
+        config_data = """
+remote_servers:
+  - name: "Bad Margin"
+    enabled: true
+    host: "192.168.1.10"
+    user: "root"
+    shutdown_safety_margin: 30.5
+    shutdown_command: "shutdown -h now"
+"""
+        temp_config_file.write_text(config_data)
+        config = ConfigLoader.load(str(temp_config_file))
+
+        messages = ConfigLoader.validate_config(config)
+        error_msgs = [
+            m for m in messages
+            if "ERROR" in m and "shutdown_safety_margin" in m
+        ]
+        assert len(error_msgs) == 1
+        assert "non-negative integer" in error_msgs[0]

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -18,7 +18,7 @@ from eneru import (
     VMConfig, ContainersConfig, FilesystemsConfig, UnmountConfig,
     RemoteServerConfig, LocalShutdownConfig, MonitorState,
 )
-from eneru.monitor import UPSGroupMonitor
+from eneru.monitor import UPSGroupMonitor, compute_effective_order
 
 
 def make_monitor(tmp_path, **overrides):
@@ -29,6 +29,7 @@ def make_monitor(tmp_path, **overrides):
         depletion=DepletionConfig(window=300, critical_rate=15.0, grace_period=90),
         extended_time=ExtendedTimeConfig(enabled=True, threshold=900),
     ))
+    remote_servers = overrides.pop("remote_servers", [])
     config = Config(
         ups_groups=[UPSGroupConfig(
             ups=UPSConfig(name="TestUPS@localhost"),
@@ -39,6 +40,7 @@ def make_monitor(tmp_path, **overrides):
                 sync_enabled=False,
                 unmount=UnmountConfig(enabled=False),
             ),
+            remote_servers=remote_servers,
             is_local=True,
         )],
         behavior=BehaviorConfig(dry_run=True),
@@ -563,3 +565,368 @@ class TestConnectionGracePeriod:
         monitor._handle_connection_failure("Connection refused")
 
         assert monitor.state.connection_state == "FAILED"
+
+
+# ==============================================================================
+# MULTI-PHASE SHUTDOWN ORDER
+# ==============================================================================
+
+class TestComputeEffectiveOrder:
+    """Test the compute_effective_order() function."""
+
+    @pytest.mark.unit
+    def test_all_defaults_get_order_zero(self):
+        """Servers with no shutdown_order and unset parallel get order 0."""
+        servers = [
+            RemoteServerConfig(name="A"),
+            RemoteServerConfig(name="B"),
+            RemoteServerConfig(name="C"),
+        ]
+        result = compute_effective_order(servers)
+        assert all(order == 0 for order, _ in result)
+
+    @pytest.mark.unit
+    def test_legacy_sequential_gets_negative_orders(self):
+        """parallel=False servers without shutdown_order get unique negative orders."""
+        servers = [
+            RemoteServerConfig(name="A", parallel=False),
+            RemoteServerConfig(name="B", parallel=False),
+            RemoteServerConfig(name="C", parallel=True),
+        ]
+        result = compute_effective_order(servers)
+        assert result[0] == (-2, servers[0])
+        assert result[1] == (-1, servers[1])
+        assert result[2] == (0, servers[2])
+
+    @pytest.mark.unit
+    def test_explicit_shutdown_order_used_as_is(self):
+        """Explicit shutdown_order values are used directly."""
+        servers = [
+            RemoteServerConfig(name="A", shutdown_order=3),
+            RemoteServerConfig(name="B", shutdown_order=1),
+            RemoteServerConfig(name="C", shutdown_order=2),
+        ]
+        result = compute_effective_order(servers)
+        assert result[0] == (3, servers[0])
+        assert result[1] == (1, servers[1])
+        assert result[2] == (2, servers[2])
+
+    @pytest.mark.unit
+    def test_mixed_explicit_and_legacy(self):
+        """Mix of shutdown_order and legacy parallel flag."""
+        servers = [
+            RemoteServerConfig(name="Explicit", shutdown_order=5),
+            RemoteServerConfig(name="LegacyPar"),
+            RemoteServerConfig(name="LegacySeq", parallel=False),
+        ]
+        result = compute_effective_order(servers)
+        assert result[0] == (5, servers[0])   # explicit
+        assert result[1] == (0, servers[1])   # legacy parallel -> 0
+        assert result[2] == (-1, servers[2])  # legacy sequential -> -1
+
+    @pytest.mark.unit
+    def test_shutdown_order_overrides_parallel_flag(self):
+        """compute_effective_order trusts shutdown_order even if parallel is also set.
+
+        Such a config is rejected by the validator (mutual-exclusion ERROR),
+        but the function itself should be defensive: if both are present, the
+        explicit shutdown_order value wins.
+        """
+        servers = [
+            RemoteServerConfig(name="A", shutdown_order=2, parallel=False),
+            RemoteServerConfig(name="B", shutdown_order=2, parallel=True),
+        ]
+        result = compute_effective_order(servers)
+        assert result[0][0] == 2
+        assert result[1][0] == 2
+
+    @pytest.mark.unit
+    def test_legacy_backward_compat_exact(self):
+        """Legacy config A(seq), B(seq), C(par), D(par) -> A then B then C+D."""
+        servers = [
+            RemoteServerConfig(name="A", parallel=False),
+            RemoteServerConfig(name="B", parallel=False),
+            RemoteServerConfig(name="C", parallel=True),
+            RemoteServerConfig(name="D", parallel=True),
+        ]
+        result = compute_effective_order(servers)
+
+        groups = {}
+        for order, s in result:
+            groups.setdefault(order, []).append(s.name)
+        sorted_keys = sorted(groups.keys())
+
+        assert sorted_keys == [-2, -1, 0]
+        assert groups[-2] == ["A"]
+        assert groups[-1] == ["B"]
+        assert sorted(groups[0]) == ["C", "D"]
+
+    @pytest.mark.unit
+    def test_empty_server_list(self):
+        """Empty server list returns empty result."""
+        assert compute_effective_order([]) == []
+
+    @pytest.mark.unit
+    def test_single_legacy_sequential(self):
+        """Single parallel=False server gets order -1."""
+        servers = [RemoteServerConfig(name="Solo", parallel=False)]
+        result = compute_effective_order(servers)
+        assert result[0] == (-1, servers[0])
+
+
+class TestMultiPhaseShutdown:
+    """Test multi-phase shutdown execution in UPSGroupMonitor."""
+
+    @pytest.mark.unit
+    def test_three_phase_execution_order(self, tmp_path):
+        """Three-phase shutdown executes groups in ascending order."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="Compute1", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="Compute2", enabled=True, host="10.0.0.2",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="Storage", enabled=True, host="10.0.0.3",
+                               user="root", shutdown_order=2),
+            RemoteServerConfig(name="Router", enabled=True, host="10.0.0.4",
+                               user="root", shutdown_order=3),
+            RemoteServerConfig(name="Switch", enabled=True, host="10.0.0.5",
+                               user="root", shutdown_order=3),
+        ])
+
+        call_order = []
+
+        def mock_shutdown(server):
+            call_order.append(server.name)
+
+        monitor._shutdown_remote_server = mock_shutdown
+        monitor._shutdown_remote_servers()
+
+        storage_idx = call_order.index("Storage")
+        assert call_order.index("Compute1") < storage_idx
+        assert call_order.index("Compute2") < storage_idx
+        assert call_order.index("Router") > storage_idx
+        assert call_order.index("Switch") > storage_idx
+
+    @pytest.mark.unit
+    def test_legacy_two_phase_backward_compat(self, tmp_path):
+        """Legacy config with parallel flag produces same ordering as old code."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="SeqA", enabled=True, host="10.0.0.1",
+                               user="root", parallel=False),
+            RemoteServerConfig(name="SeqB", enabled=True, host="10.0.0.2",
+                               user="root", parallel=False),
+            RemoteServerConfig(name="ParC", enabled=True, host="10.0.0.3",
+                               user="root", parallel=True),
+            RemoteServerConfig(name="ParD", enabled=True, host="10.0.0.4",
+                               user="root", parallel=True),
+        ])
+
+        call_order = []
+
+        def mock_shutdown(server):
+            call_order.append(server.name)
+
+        monitor._shutdown_remote_server = mock_shutdown
+        monitor._shutdown_remote_servers()
+
+        assert call_order.index("SeqA") < call_order.index("SeqB")
+        assert call_order.index("SeqB") < call_order.index("ParC")
+        assert call_order.index("SeqB") < call_order.index("ParD")
+
+    @pytest.mark.unit
+    def test_single_server_no_threading(self, tmp_path):
+        """A group with one server calls _shutdown_remote_server directly."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="Solo", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+        ])
+
+        shutdown_called = []
+        monitor._shutdown_remote_server = lambda s: shutdown_called.append(s.name)
+        monitor._shutdown_remote_servers()
+
+        assert shutdown_called == ["Solo"]
+
+    @pytest.mark.unit
+    def test_disabled_servers_excluded(self, tmp_path):
+        """Disabled servers are not included in shutdown ordering."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="Enabled", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="Disabled", enabled=False, host="10.0.0.2",
+                               user="root", shutdown_order=1),
+        ])
+
+        shutdown_called = []
+        monitor._shutdown_remote_server = lambda s: shutdown_called.append(s.name)
+        monitor._shutdown_remote_servers()
+
+        assert shutdown_called == ["Enabled"]
+
+    @pytest.mark.unit
+    def test_no_enabled_servers_returns_early(self, tmp_path):
+        """No enabled servers means _shutdown_remote_servers returns immediately."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="Off", enabled=False, host="10.0.0.1", user="root"),
+        ])
+
+        log_messages = []
+        monitor._log_message = lambda msg, *a, **kw: log_messages.append(msg)
+        monitor._shutdown_remote_servers()
+
+        assert not any("🌐" in m for m in log_messages)
+
+    @pytest.mark.unit
+    def test_failure_in_one_phase_continues_to_next(self, tmp_path):
+        """A failure in one phase does not prevent subsequent phases from running."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="FailServer", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="GoodServer", enabled=True, host="10.0.0.2",
+                               user="root", shutdown_order=2),
+        ])
+
+        call_order = []
+
+        def mock_shutdown(server):
+            call_order.append(server.name)
+            if server.name == "FailServer":
+                raise RuntimeError("SSH failed")
+
+        monitor._shutdown_remote_server = mock_shutdown
+        monitor._shutdown_remote_servers()
+
+        assert call_order == ["FailServer", "GoodServer"]
+
+    @pytest.mark.unit
+    def test_phase_logging_multi_phase(self, tmp_path):
+        """Multi-phase shutdown logs phase headers."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="A", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="B", enabled=True, host="10.0.0.2",
+                               user="root", shutdown_order=2),
+        ])
+
+        log_messages = []
+        monitor._log_message = lambda msg, *a, **kw: log_messages.append(msg)
+        monitor._shutdown_remote_server = lambda s: None
+        monitor._shutdown_remote_servers()
+
+        phase_logs = [m for m in log_messages if "Phase" in m]
+        assert len(phase_logs) == 2
+        assert "Phase 1/2 (order=1)" in phase_logs[0]
+        assert "Phase 2/2 (order=2)" in phase_logs[1]
+
+    @pytest.mark.unit
+    def test_no_phase_logging_single_phase(self, tmp_path):
+        """Single-phase shutdown does not log phase headers."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="A", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="B", enabled=True, host="10.0.0.2",
+                               user="root", shutdown_order=1),
+        ])
+
+        log_messages = []
+        monitor._log_message = lambda msg, *a, **kw: log_messages.append(msg)
+        monitor._shutdown_remote_server = lambda s: None
+        monitor._shutdown_remote_servers()
+
+        assert not any("Phase" in m for m in log_messages)
+
+    @pytest.mark.unit
+    def test_parallel_group_uses_threads(self, tmp_path):
+        """Same-group servers run in parallel via threads."""
+        monitor = make_monitor(tmp_path, remote_servers=[
+            RemoteServerConfig(name="A", enabled=True, host="10.0.0.1",
+                               user="root", shutdown_order=1),
+            RemoteServerConfig(name="B", enabled=True, host="10.0.0.2",
+                               user="root", shutdown_order=1),
+        ])
+
+        thread_names = []
+
+        def mock_shutdown(server):
+            thread_names.append(threading.current_thread().name)
+
+        monitor._shutdown_remote_server = mock_shutdown
+        monitor._shutdown_remote_servers()
+
+        # Both servers should run in non-main threads (spawned by _shutdown_servers_parallel)
+        assert len(thread_names) == 2
+        assert all(name != "MainThread" for name in thread_names)
+        assert all(name.startswith("remote-shutdown-") for name in thread_names)
+
+    @pytest.mark.unit
+    def test_parallel_phase_join_does_not_stack(self, tmp_path):
+        """Phase total wait is bounded by the per-phase deadline, not N × budget.
+
+        Two stuck workers in the same phase must not cause the phase to wait
+        for 2 × max_timeout. Regression guard for the deadline-based join in
+        ``_shutdown_servers_parallel``.
+        """
+        # Tiny budgets so the test is fast: pre_cmd=0, command_timeout=0,
+        # connect_timeout=0, safety_margin=1 -> max_timeout = 1 second.
+        servers = [
+            RemoteServerConfig(name="StuckA", enabled=True, host="10.0.0.1", user="root",
+                               shutdown_order=1, command_timeout=0, connect_timeout=0,
+                               shutdown_safety_margin=1),
+            RemoteServerConfig(name="StuckB", enabled=True, host="10.0.0.2", user="root",
+                               shutdown_order=1, command_timeout=0, connect_timeout=0,
+                               shutdown_safety_margin=1),
+        ]
+        monitor = make_monitor(tmp_path, remote_servers=servers)
+
+        def hang_forever(server):
+            time.sleep(10)  # well beyond the 1s budget
+
+        monitor._shutdown_remote_server = hang_forever
+
+        start = time.monotonic()
+        monitor._shutdown_remote_servers()
+        elapsed = time.monotonic() - start
+
+        # Stacked behavior would be ~2 s; deadline-based should be ~1 s.
+        # Allow a generous 1.8 s ceiling for CI scheduler jitter; still well
+        # below the 2 s stacked floor and the 10 s actual hang time.
+        assert elapsed < 1.8, (
+            f"Phase took {elapsed:.2f}s — expected ~1s (deadline-based join), "
+            "looks like per-thread timeouts are stacking."
+        )
+
+
+class TestRemoteShutdownSafetyMargin:
+    """Verify shutdown_safety_margin flows through calc_server_timeout."""
+
+    @pytest.mark.unit
+    def test_calc_server_timeout_uses_per_server_margin(self, tmp_path):
+        """Each server's own margin contributes to its own budget,
+        and the phase-wide max wins for the join window."""
+        servers = [
+            RemoteServerConfig(name="Fast", enabled=True, host="10.0.0.1", user="root",
+                               shutdown_order=1, command_timeout=5, connect_timeout=2,
+                               shutdown_safety_margin=10),
+            RemoteServerConfig(name="Slow", enabled=True, host="10.0.0.2", user="root",
+                               shutdown_order=1, command_timeout=5, connect_timeout=2,
+                               shutdown_safety_margin=120),
+        ]
+        monitor = make_monitor(tmp_path, remote_servers=servers)
+
+        captured = {}
+        original_join = threading.Thread.join
+
+        def capture_join(self, timeout=None):
+            captured.setdefault("first_timeout", timeout)
+            # Don't actually wait — workers are no-ops anyway.
+            return original_join(self, timeout=0)
+
+        monitor._shutdown_remote_server = lambda s: None
+        with patch.object(threading.Thread, "join", capture_join):
+            monitor._shutdown_remote_servers()
+
+        # max_timeout = max(0+5+2+10, 0+5+2+120) = 127.
+        # Deadline-based join subtracts the tiny elapsed time between
+        # computing `deadline` and the first join, so the captured value
+        # will be just under 127.
+        assert captured["first_timeout"] == pytest.approx(127, abs=0.5)


### PR DESCRIPTION
## Summary

Introduces `shutdown_order` on `RemoteServerConfig` so users can express multi-phase shutdown sequences with dependencies (e.g. compute → storage → network). Servers sharing an order run in parallel; different orders run sequentially in ascending order. A server alone in its order effectively runs sequentially.

Backward compatibility is preserved end-to-end: existing configs that only use the legacy `parallel` flag execute in exactly the same order as before, verified by a dedicated regression test.

`eneru validate` now renders the resolved shutdown sequence as a tree and labels phases as `Phase N (order=X)` when `shutdown_order` is in use, or `Sequential/Parallel` in legacy mode.

## Behavior

| Config | Behavior |
|--------|----------|
| No `shutdown_order`, no `parallel` | Default: runs in the parallel batch |
| No `shutdown_order`, `parallel: true` | Runs in the parallel batch |
| No `shutdown_order`, `parallel: false` | Runs sequentially before the parallel batch |
| `shutdown_order: N` (no `parallel`) | Grouped with other order-N servers, all in parallel |
| `shutdown_order` + `parallel: true` or `false` | **Hard validation error** — pick one model |

## Review-finding fixes folded in

- **`shutdown_order` and `parallel` are mutually exclusive at config-load time.** Setting both is now a hard ERROR (was a silent warning) with an actionable message naming both fields, the conflicting values, and which one to remove. Implemented by promoting `RemoteServerConfig.parallel` to `Optional[bool]` so the loader can distinguish "user wrote `parallel: true`" from "user omitted it".
- **New per-server `shutdown_safety_margin` (seconds, default `60`)** replaces a hard-coded `+ 60` carried over from commit 6aa23da's pre-parallelization worst case. Tunable per server (raise for slow-flushing storage, lower for fast VMs, set `0` to opt out), documented, validated, tested.
- **Parallel-phase thread join is now deadline-based.** The previous per-thread `join(timeout=max_timeout)` could stack to `N × max_timeout` for N stuck servers, defeating the original "dead hosts don't block" intent of commit 6aa23da. Total per-phase wait is now bounded by a single monotonic deadline.

Also: `eneru validate` no longer prints "Configuration is valid." up-front before checking. The verdict prints after validation messages, where it can actually be true.

## Test plan

- [x] `pytest -q` → 338 passed (baseline 329 + 9 new tests)
- [x] `python -m eneru validate` on a config that sets both `shutdown_order` and `parallel` exits 1 with the new ERROR
- [x] `python -m eneru validate` on the reference config still prints the shutdown-sequence tree and exits 0
- [ ] CI: 7 required checks (validate × Python 3.9–3.14 + e2e-test) all green

## Follow-up (separate commit on this branch before merge)

- Add E2E coverage for multi-phase shutdown ordering (`tests/e2e/`, new `TEST 19` step)
- Tighten `CLAUDE.md` conventions: every new feature requires both synthetic AND E2E tests; always pull `main` before creating a feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `shutdown_order` configuration to orchestrate multi-phase remote server shutdowns with parallel execution within phases
  * Added `shutdown_safety_margin` configuration to customize shutdown timeout buffers
  * Enhanced shutdown sequence display in validation output

* **Bug Fixes**
  * Fixed shutdown timing behavior to prevent timeout stacking; deadline-based joins now ensure predictable shutdown windows

* **Configuration Changes**
  * `shutdown_order` and `parallel` options are now mutually exclusive; validation errors if both are set on the same server

* **Chores**
  * Version bumped to 5.1.0-rc1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->