### PR TITLE
docs(remote-servers): correct ESXi/TrueNAS shutdown commands; add systemd alt

### DIFF
--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -275,26 +275,35 @@ echo "username ALL=(ALL) NOPASSWD: /sbin/poweroff" | sudo tee /etc/sudoers.d/ups
 sudo chmod 0440 /etc/sudoers.d/ups_shutdown
 ```
 
-### TrueNAS
+### TrueNAS SCALE
 
-TrueNAS does not use sudoers. Configure via the web UI:
-1. Go to **System → Advanced → Init/Shutdown Scripts**
-2. Or use the API to grant shutdown permissions
+TrueNAS rebuilds `/etc/sudoers` from the middleware database on boot, so do not edit `/etc/sudoers.d/` by hand. Instead:
+
+1. Go to **Credentials → Local Users**, edit the SSH user
+2. In **Allowed sudo commands**, add the full path: `/usr/bin/midclt`
+3. Tick **Allow all sudo commands with no password** *or* leave it unchecked and the user will use the explicit allowed-commands list above
+4. Use the SCALE shutdown form from the table below (`sudo /usr/bin/midclt call system.shutdown "ups_event"` for 25.04+)
+
+### TrueNAS CORE
+
+CORE is FreeBSD; the orchestrated `shutdown -p now` runs the rc.d teardown sequence cleanly. Configure sudo via **Accounts → Users → Edit → Permit Sudo** in the WebUI; do not hand-edit sudoers.
 
 ---
 
 ## Common shutdown commands
 
-| System | Command |
-|--------|---------|
-| Standard Linux | `sudo shutdown -h now` |
-| Synology DSM | `sudo -i synoshutdown -s` |
-| QNAP QTS | `sudo /sbin/poweroff` |
-| TrueNAS CORE | `sudo shutdown -p now` |
-| TrueNAS SCALE | `sudo shutdown -h now` |
-| ESXi | `sudo /bin/halt` |
-| Proxmox VE | `sudo shutdown -h now` |
-| pfSense/OPNsense | `sudo /sbin/shutdown -p now` |
+| System | Command | Notes |
+|--------|---------|-------|
+| Standard Linux (systemd) | `sudo systemctl poweroff` | Modern, unambiguous form |
+| Standard Linux (portable) | `sudo shutdown -h now` | Works on systemd and SysV; on systemd `-h` powers off |
+| Synology DSM | `sudo -i synoshutdown -s` | DSM 6/7. On DSM 7, `sudo poweroff` is also valid |
+| QNAP QTS | `sudo /sbin/poweroff` | |
+| TrueNAS CORE | `sudo shutdown -p now` | `-p` cuts power on FreeBSD; `-h` only halts |
+| TrueNAS SCALE (>= 25.04) | `sudo /usr/bin/midclt call system.shutdown "ups_event"` | Vendor-recommended; orchestrates app/VM teardown. `reason` arg required since Fangtooth |
+| TrueNAS SCALE (< 25.04) | `sudo /usr/bin/midclt call system.shutdown` | Same as above without the mandatory reason arg |
+| VMware ESXi 7.x/8.x | `esxcli system shutdown poweroff --reason="UPS power event"` | No `sudo` on ESXi (SSH login is root). Reason logged to vmkernel.log |
+| Proxmox VE | `sudo shutdown -h now` | Stop guests first via `stop_proxmox_vms` / `stop_proxmox_cts` pre-shutdown actions |
+| pfSense / OPNsense | `sudo /sbin/shutdown -p now` | FreeBSD `-p` for ACPI power-off |
 
 ---
 


### PR DESCRIPTION
## Summary

Vendor-verified corrections to the per-OS SSH shutdown command table in `docs/remote-servers.md`. Two commands were materially wrong, one new modern alternative was missing, and the TrueNAS sudoers guidance was incomplete.

- **ESXi**: `sudo /bin/halt` → `esxcli system shutdown poweroff --reason="UPS power event"`. ESXi has no `sudo` (SSH login is root) and `/bin/halt` bypasses the VMkernel's orderly VM-suspend / datastore-flush path. The `esxcli` form is the documented one and writes the reason to `vmkernel.log` for audit.
- **TrueNAS SCALE**: `sudo shutdown -h now` → `sudo /usr/bin/midclt call system.shutdown "ups_event"`. Per iXsystems guidance, `midclt` runs the same orchestrated teardown as the WebUI Shutdown button — gracefully stopping apps (k3s pre-24.10, Docker 24.10+) and VMs before halting. A bare `shutdown` skips that and can leave VM disks / app state inconsistent. The `reason` argument is mandatory since 25.04 Fangtooth; pre-25.04 form retained as a separate row.
- **Standard Linux**: added `sudo systemctl poweroff` as the modern, unambiguous primary alongside the portable `sudo shutdown -h now`.
- **TrueNAS sudoers section** split into SCALE (Credentials → Local Users → Allowed sudo commands → `/usr/bin/midclt`) and CORE (Permit Sudo toggle), because TrueNAS middleware rebuilds `/etc/sudoers` from its database on boot — hand-edits don't survive.
- Added a `Notes` column with the *why* for every entry; existing Synology / QNAP / TrueNAS CORE / Proxmox / pfSense / OPNsense rows verified against current vendor docs and kept as-is. Proxmox row gained a reminder to stop guests first via `stop_proxmox_vms` / `stop_proxmox_cts`.

Docs-only change. No code, examples, or tests affected — Eneru passes the user-supplied `shutdown_command:` opaquely to SSH.

## Test plan

- [ ] CI `validate` (Python 3.9–3.14) green
- [ ] CI `e2e-test` green (no behavior change, but project policy requires it)
- [ ] `mkdocs serve` locally renders the new table with the Notes column intact
- [ ] Visual scan of `/remote-servers/` page for internal contradictions vs. the YAML examples earlier in the same page (Synology examples still use `synoshutdown -s`, consistent with the table row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced TrueNAS SCALE and CORE configuration instructions with clearer guidance on sudo setup, avoiding manual sudoers edits, and version-specific shutdown commands (including SCALE 25.04+ requirements)
* Expanded shutdown command reference table with dedicated Notes column providing detailed guidance for standard Linux systemd, TrueNAS, ESXi, pfSense/OPNsense, and Proxmox systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->