### PR TITLE
fix(actions): run Proxmox stop_proxmox_{vms,cts} via sudo

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`shutdown_order` and `parallel` are now mutually exclusive** — setting both on the same server is a hard validation error (previously a warning). Pick one model: `shutdown_order` for multi-phase ordering, or `parallel` for the legacy two-group behaviour.
 - **Parallel-phase join is now deadline-based.** Previously each thread was joined with the full per-phase timeout, so a phase with N stuck servers could wait up to `N × max_timeout` before continuing. The total wait is now bounded by a single deadline, restoring the "dead hosts don't block" guarantee from v4.6.
 
+### Fixed
+- **Proxmox `stop_proxmox_vms` / `stop_proxmox_cts` now work for non-root SSH users (#4).** Surfaced by real-world testing: `qm` and `pct` reject non-root callers regardless of PVE-level ACLs (`vm.audit` + `vm.powermgmt` are insufficient on their own), so the templates were silently broken for any SSH user that wasn't root. Both templates now invoke `qm` / `pct` via `sudo`. Root-SSH setups keep working unchanged because Proxmox VE ships sudo with `root NOPASSWD: ALL` by default. Non-root users add a one-line sudoers entry — see [Passwordless sudo → Proxmox VE](remote-servers.md#proxmox-ve) in the docs.
+
 ---
 
 ## [5.0.0] - 2026-04-11

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,8 +315,8 @@ pre_shutdown_commands:
 |--------|-------------|
 | `stop_containers` | Stop all Docker/Podman containers |
 | `stop_vms` | Gracefully shutdown libvirt/KVM VMs |
-| `stop_proxmox_vms` | Gracefully shutdown Proxmox QEMU VMs |
-| `stop_proxmox_cts` | Gracefully shutdown Proxmox LXC containers |
+| `stop_proxmox_vms` | Gracefully shutdown Proxmox QEMU VMs (runs via `sudo`) |
+| `stop_proxmox_cts` | Gracefully shutdown Proxmox LXC containers (runs via `sudo`) |
 | `stop_xcpng_vms` | Gracefully shutdown XCP-ng/XenServer VMs |
 | `stop_esxi_vms` | Gracefully shutdown VMware ESXi VMs |
 | `stop_compose` | Stop a compose stack (requires `path` parameter) |

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -60,8 +60,8 @@ Eneru can run a sequence of commands on remote servers before the final shutdown
 |--------|-------------|
 | `stop_containers` | Stop all Docker/Podman containers |
 | `stop_vms` | Gracefully shutdown libvirt/KVM VMs (then force-destroy remaining) |
-| `stop_proxmox_vms` | Gracefully shutdown Proxmox QEMU VMs (then force-stop remaining) |
-| `stop_proxmox_cts` | Gracefully shutdown Proxmox LXC containers (then force-stop remaining) |
+| `stop_proxmox_vms` | Gracefully shutdown Proxmox QEMU VMs, then force-stop remaining (runs via `sudo`) |
+| `stop_proxmox_cts` | Gracefully shutdown Proxmox LXC containers, then force-stop remaining (runs via `sudo`) |
 | `stop_xcpng_vms` | Gracefully shutdown XCP-ng/XenServer VMs (then force-shutdown remaining) |
 | `stop_esxi_vms` | Gracefully shutdown VMware ESXi VMs (then force-off remaining) |
 | `stop_compose` | Stop a compose stack (requires `path` parameter) |
@@ -274,6 +274,17 @@ sudo chmod 0440 /etc/sudoers.d/ups_shutdown
 echo "username ALL=(ALL) NOPASSWD: /sbin/poweroff" | sudo tee /etc/sudoers.d/ups_shutdown
 sudo chmod 0440 /etc/sudoers.d/ups_shutdown
 ```
+
+### Proxmox VE
+
+`stop_proxmox_vms` and `stop_proxmox_cts` invoke `qm` and `pct`, which require root regardless of PVE-level ACLs (`vm.audit` + `vm.powermgmt` are not sufficient). Required only if the SSH user is non-root — root logins work unchanged.
+
+```bash
+echo "username ALL=(ALL) NOPASSWD: /usr/sbin/qm, /usr/sbin/pct" | sudo tee /etc/sudoers.d/ups_proxmox
+sudo chmod 0440 /etc/sudoers.d/ups_proxmox
+```
+
+If you also want the same user to run the final `shutdown -h now`, add `/sbin/shutdown` to the same NOPASSWD line.
 
 ### TrueNAS SCALE
 

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -239,6 +239,10 @@ remote_servers:
     # shutdown_safety_margin: 60
 
   # Example: Proxmox server with VMs and containers
+  # stop_proxmox_vms / stop_proxmox_cts run qm and pct via sudo. The SSH user
+  # must either be root, or have NOPASSWD sudo for /usr/sbin/qm and /usr/sbin/pct
+  # (PVE-level vm.audit + vm.powermgmt are not enough on their own).
+  # See docs/remote-servers.md "Passwordless sudo → Proxmox VE".
   # - name: "Proxmox Host"
   #   enabled: true
   #   host: "192.168.178.100"

--- a/src/eneru/actions.py
+++ b/src/eneru/actions.py
@@ -23,21 +23,23 @@ REMOTE_ACTIONS: Dict[str, str] = {
         'true'
     ),
 
-    # Stop Proxmox QEMU VMs with graceful shutdown, then force stop
+    # Stop Proxmox QEMU VMs with graceful shutdown, then force stop.
+    # Runs via sudo so the SSH user can be non-root with NOPASSWD on /usr/sbin/qm.
     "stop_proxmox_vms": (
-        'qm list | awk \'NR>1 && $3=="running" {{print $1}}\' | xargs -r -n1 qm shutdown --timeout {timeout}; '
+        'sudo qm list | awk \'NR>1 && $3=="running" {{print $1}}\' | xargs -r -n1 sudo qm shutdown --timeout {timeout}; '
         'end=$((SECONDS+{timeout})); '
-        'while [ $SECONDS -lt $end ] && qm list | awk \'$3=="running"\' | grep -q .; do sleep 1; done; '
-        'qm list | awk \'NR>1 && $3=="running" {{print $1}}\' | xargs -r -n1 qm stop 2>/dev/null; '
+        'while [ $SECONDS -lt $end ] && sudo qm list | awk \'$3=="running"\' | grep -q .; do sleep 1; done; '
+        'sudo qm list | awk \'NR>1 && $3=="running" {{print $1}}\' | xargs -r -n1 sudo qm stop 2>/dev/null; '
         'true'
     ),
 
-    # Stop Proxmox LXC containers with graceful shutdown, then force stop
+    # Stop Proxmox LXC containers with graceful shutdown, then force stop.
+    # Runs via sudo so the SSH user can be non-root with NOPASSWD on /usr/sbin/pct.
     "stop_proxmox_cts": (
-        'pct list | awk \'NR>1 && $2=="running" {{print $1}}\' | xargs -r -n1 pct shutdown --timeout {timeout}; '
+        'sudo pct list | awk \'NR>1 && $2=="running" {{print $1}}\' | xargs -r -n1 sudo pct shutdown --timeout {timeout}; '
         'end=$((SECONDS+{timeout})); '
-        'while [ $SECONDS -lt $end ] && pct list | awk \'$2=="running"\' | grep -q .; do sleep 1; done; '
-        'pct list | awk \'NR>1 && $2=="running" {{print $1}}\' | xargs -r -n1 pct stop 2>/dev/null; '
+        'while [ $SECONDS -lt $end ] && sudo pct list | awk \'$2=="running"\' | grep -q .; do sleep 1; done; '
+        'sudo pct list | awk \'NR>1 && $2=="running" {{print $1}}\' | xargs -r -n1 sudo pct stop 2>/dev/null; '
         'true'
     ),
 

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "4.3.0" for tagged releases, "4.3.0-5-gabcdef1" for dev builds
-__version__ = "5.1.0-rc2"
+__version__ = "5.1.0-rc3"

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -40,6 +40,8 @@ class TestRemoteActionTemplates:
         template = REMOTE_ACTIONS["stop_proxmox_vms"]
         assert "qm" in template
         assert "shutdown" in template
+        # qm requires root; sudo is mandatory so non-root SSH users can drive it.
+        assert "sudo qm" in template
 
     @pytest.mark.unit
     def test_stop_proxmox_cts_template_exists(self):
@@ -48,6 +50,8 @@ class TestRemoteActionTemplates:
         template = REMOTE_ACTIONS["stop_proxmox_cts"]
         assert "pct" in template
         assert "shutdown" in template
+        # pct requires root; sudo is mandatory so non-root SSH users can drive it.
+        assert "sudo pct" in template
 
     @pytest.mark.unit
     def test_stop_xcpng_vms_template_exists(self):


### PR DESCRIPTION
## Summary
- `qm` and `pct` reject non-root callers regardless of PVE-level ACLs (`vm.audit` + `vm.powermgmt` aren't enough on their own), so `stop_proxmox_vms` / `stop_proxmox_cts` were silently broken for any SSH user that wasn't root.
- Fold `sudo` into the two existing templates rather than introduce parallel `sudo_*` action keys — one operation, one key. Root-SSH stays unchanged (PVE ships sudo with `root NOPASSWD: ALL`); non-root users add a one-line sudoers entry, documented under "Passwordless sudo → Proxmox VE".
- Surfaced via real-world testing in #4. Version bumped to `5.1.0-rc3`; `### Fixed` entry added under the Unreleased changelog block.

## Test plan
- [x] `pytest tests/test_remote_commands.py -v` — 29 passed, including new `assert "sudo qm"` / `assert "sudo pct"` guards
- [x] `pytest -m "unit or integration"` — 410 passed, no regressions
- [x] `mkdocs build --strict` — clean
- [x] `python -m eneru version` reports `5.1.0-rc3`
- [x] Rendered templates inspected: both produce `sudo qm ...` / `sudo pct ...` with `{timeout}` correctly substituted
- [ ] Real-world confirmation on @ckrevel's non-privileged Proxmox user setup (issue #4 follow-up after rc3 lands in unstable channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxmox VM and container shutdown operations (`stop_proxmox_vms`, `stop_proxmox_cts`) now work with non-root SSH users when configured with passwordless sudo.

* **Documentation**
  * Updated configuration documentation with Proxmox passwordless sudo setup requirements and guidance for non-root SSH users.

* **Tests**
  * Added test assertions to verify sudo usage in Proxmox stop action templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->