### PR TITLE
chore(release): cut 5.1.1 — bug-fix release from AI code review

### DIFF
--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -6,6 +6,15 @@ description: >-
   All four E2E matrix jobs invoke this action so they share an
   identical, isolated test environment.
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh
+# periodically by re-running
+# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
+# tracked actions, `gh api repos/<owner>/<repo>/branches/<branch>`)
+# and updating both the SHA and the comment in lockstep across every
+# workflow.
+
 inputs:
   e2e-dir:
     description: "Path to the tests/e2e directory inside the repo"

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         python-version: '3.11'
 
@@ -48,26 +48,38 @@ runs:
       shell: bash
       run: |
         echo "Waiting for NUT server..."
+        nut_ready=false
         for i in {1..30}; do
           if upsc TestUPS@localhost:3493 2>/dev/null | grep -q "ups.status"; then
             echo "NUT server ready!"
+            nut_ready=true
             break
           fi
           echo "  Attempt $i/30..."
           sleep 2
         done
+        if [ "$nut_ready" != "true" ]; then
+          echo "ERROR: NUT server never became ready (TestUPS@localhost:3493)" >&2
+          exit 1
+        fi
 
         echo ""
         echo "Waiting for SSH servers (ports 2222, 2223, 2224)..."
         for port in 2222 2223 2224; do
+          ssh_ready=false
           for i in {1..30}; do
             if nc -z localhost "$port" 2>/dev/null; then
               echo "  SSH server on $port ready!"
+              ssh_ready=true
               break
             fi
             echo "  Attempt $i/30 for $port..."
             sleep 2
           done
+          if [ "$ssh_ready" != "true" ]; then
+            echo "ERROR: SSH server on port $port never became ready" >&2
+            exit 1
+          fi
         done
 
         echo ""

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,23 +9,32 @@ on:
     # Run weekly on Monday at 06:00 UTC
     - cron: '0 6 * * 1'
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh by
+# re-running `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` and
+# updating both the SHA and the comment.
 jobs:
   analyze:
     name: Analyze (Python)
     runs-on: ubuntu-latest
     permissions:
+      # actions/checkout needs `contents: read` on private repos;
+      # without it the checkout step fails because every other
+      # permission defaults to `none` once any one is declared.
+      contents: read
       security-events: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
         with:
           category: "/language:python"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,15 @@ on:
 env:
   E2E_DIR: tests/e2e
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh
+# periodically by re-running
+# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
+# tracked actions like pypa/gh-action-pypi-publish@release/v1,
+# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
+# the SHA and the comment in lockstep across every workflow.
+#
 # Each E2E group runs as a separate matrix job so they execute in
 # parallel. Total wall-clock is bounded by the slowest group
 # (`Redundancy and Stats`, ~5 minutes including setup) instead of the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
           - { group: redundancy-and-stats, label: "Redundancy and Stats" }
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up E2E environment
         uses: ./.github/actions/e2e-setup

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# nFPM is pinned to a specific release AND its archive is verified
+# against the goreleaser-published checksums.txt before extraction.
+# Update both NFPM_VERSION and the comment in any future bump; the
+# checksum check will fail loudly if the published file's hash changes
+# without an explicit version pin update on our side.
+env:
+  NFPM_VERSION: "2.41.3"
+
 jobs:
   # Build packages once, then test on multiple OSes
   build-packages:
@@ -14,10 +22,10 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
 
@@ -25,16 +33,23 @@ jobs:
         id: version
         run: |
           VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/eneru/version.py)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Building version: $VERSION"
 
       - name: Install nFPM
         run: |
-          NFPM_VERSION=$(curl -s https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-          curl -sLO "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
-          tar -xzf "nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" nfpm
+          BASE="https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}"
+          ARCHIVE="nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
+          curl -sLO "${BASE}/${ARCHIVE}"
+          curl -sL "${BASE}/checksums.txt" -o nfpm_checksums.txt
+          # Verify the downloaded archive against the publisher's
+          # signed checksum file so an in-flight tamper is caught
+          # before extraction and `sudo mv` install.
+          grep " ${ARCHIVE}\$" nfpm_checksums.txt | sha256sum -c -
+          tar -xzf "${ARCHIVE}" nfpm
           sudo mv nfpm /usr/local/bin/
-          rm "nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
+          rm "${ARCHIVE}" nfpm_checksums.txt
+          nfpm --version
 
       - name: Build .deb package
         run: VERSION=${{ steps.version.outputs.VERSION }} nfpm package --packager deb --target .
@@ -43,7 +58,7 @@ jobs:
         run: VERSION=${{ steps.version.outputs.VERSION }} nfpm package --packager rpm --target .
 
       - name: Upload packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: packages
           path: |
@@ -61,10 +76,10 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -112,10 +127,10 @@ jobs:
       image: ${{ matrix.distro }}:${{ matrix.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Download packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: packages
 
@@ -125,9 +140,12 @@ jobs:
         run: |
           apt-get update
           apt-get install -y python3 python3-yaml
-          # Install the .deb package (ignore dependency on nut-client for CI)
-          dpkg --force-depends -i eneru_*.deb || true
-          apt-get install -f -y --no-install-recommends || true
+          # --force-depends lets us install even though nut-client isn't
+          # in the test container; subsequent `apt-get install -f` then
+          # resolves any dependencies it can. Real install failures must
+          # surface, so the trailing `|| true` mask is gone.
+          dpkg --force-depends -i eneru_*.deb
+          apt-get install -f -y --no-install-recommends
 
       - name: Verify installation
         run: |
@@ -169,18 +187,20 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Download packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: packages
 
       - name: Install dependencies and package
         run: |
           dnf install -y ${{ matrix.python_pkg }}
-          # Install the .rpm package (ignore dependency on nut-client for CI)
-          rpm -ivh --nodeps eneru-*.rpm || dnf install -y ./eneru-*.rpm --skip-broken || true
+          # Try rpm first (fast, with --nodeps for the missing nut-client).
+          # If that fails for non-dep reasons, fall back to dnf with
+          # --skip-broken. Real install failures still propagate.
+          rpm -ivh --nodeps eneru-*.rpm || dnf install -y ./eneru-*.rpm --skip-broken
 
       - name: Verify installation
         run: |
@@ -230,7 +250,7 @@ jobs:
       image: ${{ matrix.image || format('{0}:{1}', matrix.distro, matrix.version) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install pip and dependencies (Debian/Ubuntu)
         if: matrix.distro != ''

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh
+# periodically by re-running
+# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
+# tracked actions like pypa/gh-action-pypi-publish@release/v1,
+# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
+# the SHA and the comment in lockstep across every workflow.
+#
 # nFPM is pinned to a specific release AND its archive is verified
 # against the goreleaser-published checksums.txt before extraction.
 # Update both NFPM_VERSION and the comment in any future bump; the

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 4.9)'
+        description: 'Version to publish (e.g., 5.1.1 or 5.1.1-rc1)'
         required: true
         type: string
       ref:
@@ -15,12 +15,16 @@ on:
         type: string
         default: 'main'
 
+# Split build and publish into separate jobs so the OIDC `id-token:
+# write` permission only applies to the publish step, not to
+# `pip install build twine`. A compromised build-time dependency
+# therefore cannot exfiltrate the OIDC token used for trusted
+# publishing.
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-    environment: pypi
     permissions:
-      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -39,22 +43,32 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual trigger - use input version
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+            # Strict allow-list: the version is later interpolated into
+            # `sed`. Reject anything that isn't a PEP-440-style release
+            # or pre-release (rc/alpha/beta) identifier.
+            if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}(-(rc|alpha|beta)[0-9]+)?$'; then
+              echo "Invalid version: $VERSION" >&2
+              exit 1
+            fi
           else
-            # Release trigger - extract from tag (e.g., v4.9 -> 4.9)
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing package version: $VERSION"
 
       - name: Update version in script
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           # Update __version__ with clean version for PyPI
           # PyPI does not allow local version identifiers (+hash)
-          sed -i "s/^__version__ = .*/__version__ = \"${{ steps.version.outputs.VERSION }}\"/" src/eneru/version.py
+          sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" src/eneru/version.py
           grep "__version__" src/eneru/version.py
 
       - name: Build package
@@ -62,6 +76,25 @@ jobs:
 
       - name: Check package
         run: twine check dist/*
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,12 +27,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
 
@@ -78,7 +78,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist
           path: dist/
@@ -91,10 +91,10 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,6 +15,15 @@ on:
         type: string
         default: 'main'
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh
+# periodically by re-running
+# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
+# tracked actions like pypa/gh-action-pypi-publish@release/v1,
+# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
+# the SHA and the comment in lockstep across every workflow.
+#
 # Split build and publish into separate jobs so the OIDC `id-token:
 # write` permission only applies to the publish step, not to
 # `pip install build twine`. A compromised build-time dependency

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., 4.3.0-rc0)'
+        description: 'Version to build (e.g., 5.1.1 or 5.1.1-rc1)'
         required: true
         type: string
       ref:
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
         default: 'main'
+
+# nFPM is pinned + checksum-verified; bump NFPM_VERSION here to refresh.
+env:
+  NFPM_VERSION: "2.41.3"
 
 permissions:
   contents: write
@@ -23,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
 
@@ -99,14 +103,18 @@ jobs:
 
       - name: Install nFPM
         run: |
-          echo "Installing nFPM..."
-          # Download latest nFPM release directly from GitHub
-          NFPM_VERSION=$(curl -s https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-          echo "Installing nFPM version: $NFPM_VERSION"
-          curl -sLO "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
-          tar -xzf "nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" nfpm
+          # Pinned version + checksum verification: protect the release
+          # path against an upstream tag mutation or in-flight tamper.
+          # NFPM_VERSION is set in this workflow's `env:` block.
+          BASE="https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}"
+          ARCHIVE="nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
+          echo "Installing nFPM ${NFPM_VERSION}"
+          curl -sLO "${BASE}/${ARCHIVE}"
+          curl -sL "${BASE}/checksums.txt" -o nfpm_checksums.txt
+          grep " ${ARCHIVE}\$" nfpm_checksums.txt | sha256sum -c -
+          tar -xzf "${ARCHIVE}" nfpm
           sudo mv nfpm /usr/local/bin/
-          rm "nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
+          rm "${ARCHIVE}" nfpm_checksums.txt
           nfpm --version
 
       - name: Build .deb package
@@ -121,7 +129,7 @@ jobs:
 
       - name: Upload packages to GitHub Release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
@@ -135,7 +143,7 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d | gpg --batch --import
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: gh-pages
           path: gh-pages
@@ -481,7 +489,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Update repository for v${{ steps.version.outputs.VERSION }}" || echo "No changes to commit"
-          git push -f https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git gh-pages
+          # No --force: a non-fast-forward push (e.g. concurrent release
+          # job already updated gh-pages) should fail loudly so the
+          # operator can decide how to reconcile, not silently clobber.
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git gh-pages
 
       - name: Summary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,27 @@ on:
         type: string
         default: 'main'
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh
+# periodically by re-running
+# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
+# tracked actions like pypa/gh-action-pypi-publish@release/v1,
+# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
+# the SHA and the comment in lockstep across every workflow.
+#
 # nFPM is pinned + checksum-verified; bump NFPM_VERSION here to refresh.
 env:
   NFPM_VERSION: "2.41.3"
+
+# Serialize gh-pages deploys so concurrent releases (e.g. a tag push
+# overlapping with a manual workflow_dispatch, or two rc cuts close
+# together) don't both rebuild + sign packages and then race the
+# non-fast-forward push at the end. cancel-in-progress: false so the
+# winner finishes; the second run waits for the first to complete.
+concurrency:
+  group: release-gh-pages
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,22 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual trigger - use input version
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Manual trigger — use input version
+            VERSION="$INPUT_VERSION"
+            # Strict allow-list: the version is later interpolated into
+            # `sed` and other shell calls. Reject anything that isn't a
+            # PEP-440-style release or pre-release (rc/alpha/beta).
+            if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}(-(rc|alpha|beta)[0-9]+)?$'; then
+              echo "Invalid version: $VERSION" >&2
+              exit 1
+            fi
           else
-            # Release trigger - extract from tag (e.g., v4.3.0 -> 4.3.0)
+            # Release trigger — extract from tag (e.g., v4.3.0 -> 4.3.0)
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi
 
@@ -59,28 +69,31 @@ jobs:
           SHORT_HASH=$(git rev-parse --short HEAD)
           VERSION_FULL="${VERSION}-${SHORT_HASH}"
 
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "VERSION_FULL=$VERSION_FULL" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "VERSION_FULL=$VERSION_FULL" >> "$GITHUB_OUTPUT"
           echo "Building packages version: $VERSION"
           echo "Code version: $VERSION_FULL"
 
       - name: Determine channel
         id: channel
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
           if [[ "$VERSION" =~ -(rc|beta|alpha) ]]; then
             CHANNEL="testing"
           else
             CHANNEL="stable"
           fi
-          echo "CHANNEL=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "CHANNEL=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "Channel: $CHANNEL for version: $VERSION"
 
       - name: Update version in script
+        env:
+          VERSION_FULL: ${{ steps.version.outputs.VERSION_FULL }}
         run: |
           # Update __version__ with full version including git hash
           # This only affects the code display (--version, logs), not package versions
-          sed -i "s/^__version__ = .*/__version__ = \"${{ steps.version.outputs.VERSION_FULL }}\"/" src/eneru/version.py
+          sed -i "s/^__version__ = .*/__version__ = \"$VERSION_FULL\"/" src/eneru/version.py
           # Verify the change
           grep "__version__" src/eneru/version.py
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ main ]
 
+# All third-party action invocations are SHA-pinned (with the
+# corresponding tag in a comment) so a moved tag in the upstream
+# action repo cannot silently change what runs in CI. Refresh
+# periodically by re-running
+# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
+# tracked actions like pypa/gh-action-pypi-publish@release/v1,
+# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
+# the SHA and the comment in lockstep across every workflow.
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,10 +16,10 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -36,7 +36,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
       with:
         files: ./coverage.xml
         fail_ci_if_error: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,39 @@ For trivial PRs the CI gates (validate × 6 + E2E × 4) are sufficient. Saves qu
 
 **If you forget and trigger an auto-review:** harmless but wastes quota. Just close the auto-review and trigger manually after CI is green.
 
+## GitHub Actions SHA pin maintenance
+
+Every third-party GitHub Actions invocation across the workflows (`validate.yml`, `integration.yml`, `e2e.yml`, `codeql.yml`, `pypi.yml`, `release.yml`, plus `.github/actions/e2e-setup/action.yml`) is pinned to a full commit SHA with the corresponding tag in a trailing comment. A moved upstream tag therefore cannot silently change what runs in CI — the pinned SHA is the single source of truth.
+
+These pins drift over time as upstream actions ship security fixes, dependency bumps, and bug fixes under the same major-version tag. The repo doesn't auto-renew them; refresh **about every 3 months**, or when a security advisory lands for one of the pinned actions, or when an upstream major-version bump is needed.
+
+**How to refresh:**
+
+```bash
+# For tag-tracked actions (most cases — actions/checkout@v6, etc.):
+gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.sha'
+
+# For branch-tracked actions (pypa/gh-action-pypi-publish@release/v1):
+gh api repos/<owner>/<repo>/branches/<branch> --jq '.commit.sha'
+```
+
+Update both the SHA and the `# vX.Y` trailing comment in lockstep. After bumping, run the full CI matrix on a throwaway branch before merging — silent breakage is the failure mode the pins exist to prevent in the first place.
+
+The current pinned set (as of 2026-04-22):
+
+| Action | Tag | SHA prefix |
+|---|---|---|
+| `actions/checkout` | `v6` | `de0fac2e…` |
+| `actions/setup-python` | `v6` | `a309ff8b…` |
+| `actions/upload-artifact` | `v4` / `v7` | `ea165f8d…` / `043fb46d…` |
+| `actions/download-artifact` | `v4` / `v8` | `d3f86a10…` / `3e5f45b2…` |
+| `codecov/codecov-action` | `v6` | `57e3a136…` |
+| `github/codeql-action` | `v4` | `b25d0ebf…` |
+| `pypa/gh-action-pypi-publish` | `release/v1` | `cef22109…` |
+| `softprops/action-gh-release` | `v3` | `b4309332…` |
+
+`nFPM` is similarly pinned (`NFPM_VERSION` env var in `release.yml` and `integration.yml`) and verified against the goreleaser-published `checksums.txt` before extraction. Bump the version constant and the checksum check still verifies the new download.
+
 ## Changelog
 
 A single changelog is maintained at `docs/changelog.md`. This is the comprehensive version with detailed changes, migration notes, and version comparison tables. It is rendered on [ReadTheDocs](https://eneru.readthedocs.io/latest/changelog/).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,48 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.1.1] - 2026-04-22
 
-Bug-fix release with one small TUI improvement. Bundles fixes from a third-party AI code review (CodeRabbit Pro + Cubic.Dev) of the v5.1.0 codebase. Drop-in upgrade.
+Bug-fix release with one small TUI improvement. Bundles fixes from a third-party AI code review (CodeRabbit Pro + Cubic.Dev) of the v5.1.0 codebase. Drop-in upgrade. See `git log v5.1.0..v5.1.1` for per-commit detail with reviewer attribution.
 
 ### Added
-- **TUI events panel: full history with arrow-key scrolling.** The events panel no longer truncates to a 24h window; it pulls every event from the SQLite store and lets the operator scroll with `↑/↓` (one row), `PgUp/PgDn` (ten rows), and `Home/End` (oldest/newest). `<M>` still toggles between 8 and 500 visible rows.
+- **TUI events panel: full history with arrow-key scrolling.** Drops the 24h window; `↑/↓` scrolls one row, `PgUp/PgDn` ten, `Home/End` jumps to oldest/newest. `<M>` still toggles between 8 and 500 visible rows.
 
 ### Fixed
-- **XCP-ng VM shutdown silently no-op'd.** `stop_xcpng_vms` passed UUIDs positionally to `xe vm-shutdown uuid=`; `xe` parses arguments as `key=value` and ignored them. UUIDs are now bound via `xargs -I {}`, and the force pass uses `xe`'s `force=true` keyword instead of `--force`.
-- **Redundancy `is_local` quorum loss never powered off the host.** The executor stopped local services and remote peers but skipped the local poweroff command. The redundancy executor now delegates to the coordinator's `_handle_local_shutdown` (defense-in-depth lock + global flag) so a concurrent per-UPS trigger can't fire twice.
-- **Multi-UPS state-file write race.** `with_suffix('.tmp')` replaced each per-UPS suffix with `.tmp`, collapsing every monitor's temp file onto a shared `eneru.state.tmp` and racing the atomic rename. Same pattern fixed in the battery-history persist path.
-- **TUI live-blending key mismatch.** `_STATE_FILE_TO_COLUMN` used NUT's dotted lowercase names but the daemon writes uppercase state-file keys, so live blending received zero samples and graph right edges lagged ~10s behind SQLite.
-- **`virsh list` failure during VM wait loop produced false success.** If `libvirtd` died mid-shutdown, empty stdout was read as "all VMs stopped" and `virsh destroy` never fired. The wait loop now treats non-zero exit as transient and keeps the prior remaining-VM list.
-- **Voltage severity escalation never fired.** A brownout that crossed the severe threshold AFTER the LOW state was already pending kept the original `is_severe=False` flag, so operators waited the full hysteresis window for an immediate-class alert. Severity is now re-evaluated every poll.
-- **Silent config drops.** `notifications.suppress`, `notifications.voltage_hysteresis_seconds`, and the per-group `statistics` section in multi-UPS mode were never read from YAML; the parser quietly used dataclass defaults. All three now round-trip.
-- **Legacy `ups-monitor` syslog tag.** Power events shelled out to `logger -t ups-monitor`, the pre-v5.0 package name. Renamed to `eneru` so journalctl filtering matches the rest of the daemon's output.
-- **Long tail of robustness fixes** across `shutdown/remote.py` (`timeout=0` no longer promotes to default, thread exceptions logged instead of swallowed, `ssh_options` accepts non-`-o` flags), `shutdown/filesystems.py` (`umount` options split via `shlex`), `multi_ups.py` (drain phase signals stop_event before triggering peer shutdown), `graph.py` (numeric filtering before `min`/`max`; pixel-row aggregator picks the topmost set pixel), `health/battery.py` (anomaly drop magnitude re-validated before firing), `logger.py` (handler cleanup closes fds + disables propagation), `stats.py` (`with self._conn:` actually batches `executemany`; SQLite URI quoted against paths containing `?`/`#`), `utils.py` (`run_command` normalises None stdout/stderr to `""`), `cli.py` (validate surfaces YAML errors regardless of `--config` form), and `completion/eneru.bash` (`mapfile -t` for filenames with spaces).
+- **XCP-ng VM shutdown silently no-op'd.** `stop_xcpng_vms` passed UUIDs positionally to `xe vm-shutdown uuid=`; `xe` ignored them. Now bound via `xargs -I {}` with `force=true`.
+- **Redundancy `is_local` quorum loss never powered off the host.** The executor stopped local services and remote peers but skipped the local poweroff command. Now delegates to the coordinator's `_handle_local_shutdown`.
+- **Multi-UPS state-file write race.** `with_suffix('.tmp')` collapsed every monitor's atomic-rename temp file onto a shared name. Same fix in the battery-history persist path.
+- **TUI live-blending key mismatch.** Graph right edges lagged ~10s behind SQLite because `_STATE_FILE_TO_COLUMN` used NUT's dotted lowercase names but the daemon writes uppercase keys.
+- **`virsh list` failure during VM wait loop produced false success.** A wedged `libvirtd` made the wait loop report "all VMs stopped" and skip force-destroy. Non-zero exit is now treated as transient.
+- **Voltage severity escalation never fired** when a brownout crossed the severe threshold AFTER the LOW state was already pending. Severity is now re-evaluated every poll.
+- **Silent config drops.** `notifications.suppress`, `notifications.voltage_hysteresis_seconds`, and per-group `statistics` in multi-UPS mode were never read from YAML. All three now round-trip.
+- **Legacy `ups-monitor` syslog tag** renamed to `eneru` so journalctl filtering matches the rest of the daemon's output.
+- **Long tail of robustness fixes** across `shutdown/`, `health/`, `graph.py`, `logger.py`, `stats.py`, `utils.py`, `cli.py`, and bash completion.
 
 ### Security
-- **`stop_compose` remote-shell injection.** Template double-quoting didn't block `$()`, backticks, or `${...}` expansion on the remote host. The template no longer wraps `{path}`; `shlex.quote` runs at the call site.
-- **PyPI workflow OIDC token scope.** Publish workflow split into a `build` job (`contents: read`) and a `publish` job (`needs: build`, `id-token: write`), so `pip install build twine` can no longer reach the publishing token. The `workflow_dispatch` version input is validated against a strict PEP-440 allow-list before any shell interpolation; same fix applied to `release.yml`.
-- **CI supply-chain hardening.** Every third-party GitHub Actions invocation is now SHA-pinned. nFPM is version-pinned and verified against the goreleaser-published `checksums.txt` before extraction. Dropped `git push -f` from the gh-pages step. Dropped `|| true` masks that hid `dpkg`/`rpm` install failures.
+- **`stop_compose` remote-shell injection.** Template double-quoting didn't block `$()`/backticks/`${...}`. `shlex.quote` now runs at the call site.
+- **PyPI publish OIDC token scope.** Workflow split so `pip install build twine` can't reach the publishing token; the `workflow_dispatch` version input is validated against PEP-440 before any shell interpolation.
+- **CI supply-chain.** Every third-party GitHub Actions invocation is SHA-pinned. nFPM version-pinned + checksum-verified. Dropped `git push -f` to gh-pages and `|| true` masks on dpkg/rpm install.
 
 ### Packaging
-- **Dynamic version target.** `pyproject.toml` reads from `eneru.version.__version__` instead of `eneru.__version__`, so a future top-level import in `__init__.py` cannot break wheel builds.
-- **DEB lifecycle handling.** prerm/postrm replaced with explicit `case` statements covering the full Debian Policy enumeration (`failed-upgrade`, `deconfigure`, `abort-install`, `abort-upgrade`, `disappear`); the if/elif cascade previously fell through to "actual removal" on every non-removal lifecycle.
-- **postinstall fresh-vs-upgrade.** Disambiguated via `$2` (previous version, empty on fresh install) instead of the always-present unit file.
-- **chroot/container guard.** `systemctl daemon-reload` skipped when `/run/systemd/system` is missing, so package builds inside chroots no longer abort under `set -e`.
+- **DEB lifecycle handling.** prerm/postrm rewritten with explicit `case` for the full Debian Policy enumeration; the if/elif cascade was stopping the service on every non-removal lifecycle (`failed-upgrade`, `deconfigure`, etc.).
+- **postinstall fresh-vs-upgrade** disambiguated via `$2`; **chroot guard** on `systemctl daemon-reload`; `pyproject.toml` reads version from `eneru.version.__version__` so a future top-level `__init__.py` import can't break wheel builds.
 
 ### Examples
-- Reference and dual-UPS configs no longer ship `StrictHostKeyChecking=no` as the default; the option is commented out and marked testing-only.
-- `config-reference.yaml`: `compose_files: []` (was `compose_files:`, which parses as YAML null and the loader rejects).
+- Reference / dual-UPS configs no longer ship `StrictHostKeyChecking=no` as the default.
+- `config-reference.yaml`: `compose_files: []` (was `compose_files:`, parsing as YAML null).
 - `config-enterprise.yaml`: Slack URL switched to the documented Apprise webhook form.
-- `config-homelab.yaml`: corrected the `parallel: false` comment that promised "shut down LAST" — the legacy flag actually runs servers BEFORE the parallel-order=0 batch. Switched to `shutdown_order: 2` and documented the legacy flag's real semantics.
+- `config-homelab.yaml`: `parallel: false` does the OPPOSITE of "shut down LAST" — switched to `shutdown_order: 2` and corrected the misleading comment.
 
 ### Test quality
-- Autouse `tests/conftest.py` fixture monkeypatches `StatsConfig.__init__` and `StatsStore.__init__` so no test can leak SQLite files into `/var/lib/eneru`. Opt out via `@pytest.mark.no_stats_isolation`.
-- Failsafe tests now route through the real `_main_loop`; the redundancy-evaluator thread test asserts `is_alive()` BEFORE signalling stop; e2e shell scripts assert exit codes via `PIPESTATUS` instead of swallowing them with `|| true`; e2e SSH-target Dockerfile creates `/var/run/sshd`; the low-battery scenario runtime is now above the critical-runtime threshold so the test unambiguously exercises the low-battery path.
+Autouse fixture redirects `StatsConfig` / `StatsStore` defaults to a per-test tmp_path so tests can't leak SQLite files into `/var/lib/eneru`. Failsafe / redundancy-evaluator tests now exercise real code paths; e2e shell scripts assert exit codes via `PIPESTATUS` instead of swallowing them.
 
 ### Migration notes
-None. Every change is a bug fix or additive against the v5.1.0 contract.
-
-### See also
-- `git log v5.1.0..v5.1.1` for per-commit detail with reviewer attribution on every fix.
+None.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.1.1] - 2026-04-22
+
+Bug-fix release with one small TUI improvement. Bundles fixes from a third-party AI code review (CodeRabbit Pro + Cubic.Dev) of the v5.1.0 codebase. Drop-in upgrade.
+
+### Added
+- **TUI events panel: full history with arrow-key scrolling.** The events panel no longer truncates to a 24h window; it pulls every event from the SQLite store and lets the operator scroll with `↑/↓` (one row), `PgUp/PgDn` (ten rows), and `Home/End` (oldest/newest). `<M>` still toggles between 8 and 500 visible rows.
+
+### Fixed
+- **XCP-ng VM shutdown silently no-op'd.** `stop_xcpng_vms` passed UUIDs positionally to `xe vm-shutdown uuid=`; `xe` parses arguments as `key=value` and ignored them. UUIDs are now bound via `xargs -I {}`, and the force pass uses `xe`'s `force=true` keyword instead of `--force`.
+- **Redundancy `is_local` quorum loss never powered off the host.** The executor stopped local services and remote peers but skipped the local poweroff command. The redundancy executor now delegates to the coordinator's `_handle_local_shutdown` (defense-in-depth lock + global flag) so a concurrent per-UPS trigger can't fire twice.
+- **Multi-UPS state-file write race.** `with_suffix('.tmp')` replaced each per-UPS suffix with `.tmp`, collapsing every monitor's temp file onto a shared `eneru.state.tmp` and racing the atomic rename. Same pattern fixed in the battery-history persist path.
+- **TUI live-blending key mismatch.** `_STATE_FILE_TO_COLUMN` used NUT's dotted lowercase names but the daemon writes uppercase state-file keys, so live blending received zero samples and graph right edges lagged ~10s behind SQLite.
+- **`virsh list` failure during VM wait loop produced false success.** If `libvirtd` died mid-shutdown, empty stdout was read as "all VMs stopped" and `virsh destroy` never fired. The wait loop now treats non-zero exit as transient and keeps the prior remaining-VM list.
+- **Voltage severity escalation never fired.** A brownout that crossed the severe threshold AFTER the LOW state was already pending kept the original `is_severe=False` flag, so operators waited the full hysteresis window for an immediate-class alert. Severity is now re-evaluated every poll.
+- **Silent config drops.** `notifications.suppress`, `notifications.voltage_hysteresis_seconds`, and the per-group `statistics` section in multi-UPS mode were never read from YAML; the parser quietly used dataclass defaults. All three now round-trip.
+- **Legacy `ups-monitor` syslog tag.** Power events shelled out to `logger -t ups-monitor`, the pre-v5.0 package name. Renamed to `eneru` so journalctl filtering matches the rest of the daemon's output.
+- **Long tail of robustness fixes** across `shutdown/remote.py` (`timeout=0` no longer promotes to default, thread exceptions logged instead of swallowed, `ssh_options` accepts non-`-o` flags), `shutdown/filesystems.py` (`umount` options split via `shlex`), `multi_ups.py` (drain phase signals stop_event before triggering peer shutdown), `graph.py` (numeric filtering before `min`/`max`; pixel-row aggregator picks the topmost set pixel), `health/battery.py` (anomaly drop magnitude re-validated before firing), `logger.py` (handler cleanup closes fds + disables propagation), `stats.py` (`with self._conn:` actually batches `executemany`; SQLite URI quoted against paths containing `?`/`#`), `utils.py` (`run_command` normalises None stdout/stderr to `""`), `cli.py` (validate surfaces YAML errors regardless of `--config` form), and `completion/eneru.bash` (`mapfile -t` for filenames with spaces).
+
+### Security
+- **`stop_compose` remote-shell injection.** Template double-quoting didn't block `$()`, backticks, or `${...}` expansion on the remote host. The template no longer wraps `{path}`; `shlex.quote` runs at the call site.
+- **PyPI workflow OIDC token scope.** Publish workflow split into a `build` job (`contents: read`) and a `publish` job (`needs: build`, `id-token: write`), so `pip install build twine` can no longer reach the publishing token. The `workflow_dispatch` version input is validated against a strict PEP-440 allow-list before any shell interpolation; same fix applied to `release.yml`.
+- **CI supply-chain hardening.** Every third-party GitHub Actions invocation is now SHA-pinned. nFPM is version-pinned and verified against the goreleaser-published `checksums.txt` before extraction. Dropped `git push -f` from the gh-pages step. Dropped `|| true` masks that hid `dpkg`/`rpm` install failures.
+
+### Packaging
+- **Dynamic version target.** `pyproject.toml` reads from `eneru.version.__version__` instead of `eneru.__version__`, so a future top-level import in `__init__.py` cannot break wheel builds.
+- **DEB lifecycle handling.** prerm/postrm replaced with explicit `case` statements covering the full Debian Policy enumeration (`failed-upgrade`, `deconfigure`, `abort-install`, `abort-upgrade`, `disappear`); the if/elif cascade previously fell through to "actual removal" on every non-removal lifecycle.
+- **postinstall fresh-vs-upgrade.** Disambiguated via `$2` (previous version, empty on fresh install) instead of the always-present unit file.
+- **chroot/container guard.** `systemctl daemon-reload` skipped when `/run/systemd/system` is missing, so package builds inside chroots no longer abort under `set -e`.
+
+### Examples
+- Reference and dual-UPS configs no longer ship `StrictHostKeyChecking=no` as the default; the option is commented out and marked testing-only.
+- `config-reference.yaml`: `compose_files: []` (was `compose_files:`, which parses as YAML null and the loader rejects).
+- `config-enterprise.yaml`: Slack URL switched to the documented Apprise webhook form.
+- `config-homelab.yaml`: corrected the `parallel: false` comment that promised "shut down LAST" — the legacy flag actually runs servers BEFORE the parallel-order=0 batch. Switched to `shutdown_order: 2` and documented the legacy flag's real semantics.
+
+### Test quality
+- Autouse `tests/conftest.py` fixture monkeypatches `StatsConfig.__init__` and `StatsStore.__init__` so no test can leak SQLite files into `/var/lib/eneru`. Opt out via `@pytest.mark.no_stats_isolation`.
+- Failsafe tests now route through the real `_main_loop`; the redundancy-evaluator thread test asserts `is_alive()` BEFORE signalling stop; e2e shell scripts assert exit codes via `PIPESTATUS` instead of swallowing them with `|| true`; e2e SSH-target Dockerfile creates `/var/run/sshd`; the low-battery scenario runtime is now above the critical-runtime threshold so the test unambiguously exercises the low-battery path.
+
+### Migration notes
+None. Every change is a bug fix or additive against the v5.1.0 contract.
+
+### See also
+- `git log v5.1.0..v5.1.1` for per-commit detail with reviewer attribution on every fix.
+
+---
+
 ## [5.1.0] - 2026-04-21
 
 ### Added

--- a/examples/config-dual-ups.yaml
+++ b/examples/config-dual-ups.yaml
@@ -58,8 +58,11 @@ ups:
         connect_timeout: 10
         command_timeout: 30
         shutdown_command: "shutdown -h now"
-        ssh_options:
-          - "-o StrictHostKeyChecking=no"
+        # ssh_options block intentionally omitted: production should
+        # rely on the host's known_hosts file. Uncomment only for an
+        # ephemeral homelab box you'd never trust in production:
+        #   ssh_options:
+        #     - "-o StrictHostKeyChecking=no"  # testing only
         pre_shutdown_commands:
           - action: "stop_proxmox_vms"
             timeout: 120
@@ -82,8 +85,8 @@ ups:
         connect_timeout: 10
         command_timeout: 30
         shutdown_command: "sudo -i synoshutdown -s"
-        ssh_options:
-          - "-o StrictHostKeyChecking=no"
+        # ssh_options block intentionally omitted (see comment above on
+        # the Proxmox host). Production should rely on known_hosts.
         pre_shutdown_commands:
           - action: "sync"
 

--- a/examples/config-enterprise.yaml
+++ b/examples/config-enterprise.yaml
@@ -51,7 +51,7 @@ notifications:
   #   slack://TokenA/TokenB/TokenC/#channel-name
   # See https://github.com/caronc/apprise/wiki/Notify_slack for the
   # bot-OAuth form (slack://botname@oauth-token/#channel).
-  - "slack://TokenA/TokenB/TokenC/#operations?footer=no"
+  - "slack://TokenA/TokenB/TokenC?footer=no/#operations"
 
   # Secondary: PagerDuty - Critical alerts
   # - "pagerduty://INTEGRATION_KEY@ROUTING_KEY"

--- a/examples/config-enterprise.yaml
+++ b/examples/config-enterprise.yaml
@@ -46,8 +46,12 @@ notifications:
   retry_interval: 5
 
   urls:
-  # Primary: Slack - Operations channel
-  - "slack://xoxb-token/CHANNEL_ID?footer=no"
+  # Primary: Slack — Operations channel.
+  # Apprise's Slack incoming-webhook form is:
+  #   slack://TokenA/TokenB/TokenC/#channel-name
+  # See https://github.com/caronc/apprise/wiki/Notify_slack for the
+  # bot-OAuth form (slack://botname@oauth-token/#channel).
+  - "slack://TokenA/TokenB/TokenC/#operations?footer=no"
 
   # Secondary: PagerDuty - Critical alerts
   # - "pagerduty://INTEGRATION_KEY@ROUTING_KEY"

--- a/examples/config-homelab.yaml
+++ b/examples/config-homelab.yaml
@@ -85,13 +85,23 @@ remote_servers:
       - action: "sync"
     shutdown_command: "shutdown -h now"
 
-  # NAS - shutdown LAST since other servers may mount its storage
-  # parallel: false ensures this runs after all parallel servers complete
+  # NAS — shutdown LAST since other servers may mount its storage.
+  # Use `shutdown_order` for "later phase" ordering: every other
+  # server keeps its default order (0) and runs in parallel; the NAS
+  # gets a higher number so it runs in a later phase, after the
+  # mounting clients have stopped.
+  #
+  # NOTE: the legacy `parallel: false` flag does the OPPOSITE of what
+  # its name suggests for this use case — it runs the server in a
+  # phase BEFORE the parallel-order=0 batch (see config.py
+  # RemoteServerConfig: "False = run sequentially before the parallel
+  # batch"). Use `shutdown_order: <int>>=1` instead when you need
+  # "after the parallel batch".
   - name: "Synology NAS"
     enabled: true
     host: "192.168.1.50"
     user: "admin"
-    parallel: false  # Shutdown sequentially (after parallel batch)
+    shutdown_order: 2  # Runs in phase 2, after the order=0 parallel batch
     shutdown_command: "sudo -i synoshutdown -s"
 
 local_shutdown:

--- a/examples/config-homelab.yaml
+++ b/examples/config-homelab.yaml
@@ -65,10 +65,13 @@ filesystems:
       - path: "/mnt/nas"
         options: "-l"
 
-# Remote servers with optional pre-shutdown commands
-# Servers are processed in two phases:
-#   1. Sequential: Servers with parallel: false are shutdown one by one (in config order)
-#   2. Parallel: Remaining servers (parallel: true, the default) are shutdown concurrently
+# Remote servers with optional pre-shutdown commands.
+# Servers are processed by their effective shutdown_order (lowest first);
+# servers sharing the same order run concurrently.
+#   - Default: order 0 (parallel batch)
+#   - shutdown_order: N (>=1): explicit later phase; higher numbers run last
+#   - Legacy parallel: false: assigned a unique negative order so the server
+#     runs in a phase BEFORE the order-0 batch (NOT after — see the NAS block)
 remote_servers:
   # Proxmox hypervisor - gracefully stop VMs/CTs before shutdown
   # Runs in parallel (default) with other parallel servers

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -187,7 +187,10 @@ containers:
   # Each file is processed with 'docker/podman compose -f <path> down'
   # Compose files are stopped BEFORE remaining containers
   # Format: path string or {path: "/path", stop_timeout: 120}
-  compose_files:
+  # Explicit `[]` so a copy-paste of this file with the entries kept
+  # commented parses as an empty list, not as YAML null (which the
+  # loader rejects).
+  compose_files: []
   #  - "/opt/critical-db/docker-compose.yml"
   #  - path: "/opt/app-stack/docker-compose.yml"
   #    stop_timeout: 120  # Override global timeout for this file
@@ -248,9 +251,13 @@ remote_servers:
     command_timeout: 30
     # Shutdown command (default: "sudo shutdown -h now")
     shutdown_command: "sudo -i synoshutdown -s"
-    # SSH options (optional)
-    ssh_options:
-      - "-o StrictHostKeyChecking=no"
+    # SSH options (optional). Production deployments should rely on the
+    # default StrictHostKeyChecking=ask + a populated known_hosts so a
+    # MITM cannot replace the remote host's key without operator notice.
+    # The commented-out line below is for ephemeral testing only — DO
+    # NOT use in production.
+    # ssh_options:
+    #   - "-o StrictHostKeyChecking=no"  # testing only — DO NOT use in production
     # Shutdown order (optional, positive integer >= 1)
     # Servers with the same shutdown_order run in parallel.
     # Lower orders run first. A server alone in its order runs sequentially.

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -3,22 +3,31 @@
 # Called after package files are installed
 #
 # RPM: $1 = 1 (install), $1 = 2+ (upgrade)
-# DEB: $1 = "configure"
+# DEB: $1 = "configure"; $2 = previous version (empty on fresh install)
 set -e
 
-# Reload systemd to pick up the new/updated service file
-systemctl daemon-reload
+# Reload systemd to pick up the new/updated service file. Skip in
+# environments without a live systemd (chroot, container build layer):
+# `systemctl daemon-reload` aborts under `set -e` and leaves the package
+# half-applied if pid 1 isn't systemd.
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+fi
 
-# Detect if this is an upgrade or fresh install
+# Detect whether this invocation is an upgrade or a fresh install.
 is_upgrade=false
 was_running=false
-was_enabled=false
 
-# RPM passes a number, DEB passes action name
+# RPM passes a number, DEB passes the action name plus the previous
+# version string (when relevant).
 if [ -n "$1" ]; then
     if [ "$1" = "configure" ]; then
-        # DEB upgrade detection: check if service existed before
-        if systemctl list-unit-files eneru.service &>/dev/null; then
+        # DEB: postinst runs with `configure` for BOTH a fresh install
+        # AND an upgrade. The disambiguator is $2: empty on a fresh
+        # install, populated with the previous package version on an
+        # upgrade. (Listing the unit file is not sufficient — the unit
+        # file is part of the new package and is always present here.)
+        if [ -n "$2" ]; then
             is_upgrade=true
         fi
     elif [ "$1" -ge 2 ] 2>/dev/null; then
@@ -30,9 +39,6 @@ fi
 # Check current service state (before we potentially restart)
 if systemctl is-active --quiet eneru.service 2>/dev/null; then
     was_running=true
-fi
-if systemctl is-enabled --quiet eneru.service 2>/dev/null; then
-    was_enabled=true
 fi
 
 if [ "$is_upgrade" = true ]; then

--- a/packaging/scripts/postremove.sh
+++ b/packaging/scripts/postremove.sh
@@ -3,27 +3,36 @@
 # Called after package files are removed
 #
 # RPM: $1 = 0 (removal complete), $1 = 1+ (upgrade - old removed, new installed)
-# DEB: $1 = "remove", "purge", or "upgrade"
+# DEB: $1 ∈ {remove, purge, upgrade, failed-upgrade, abort-install,
+#            abort-upgrade, disappear}
 set -e
 
-# Detect if this is a removal or upgrade
-is_removal=true
+is_removal=false
 
-if [ -n "$1" ]; then
-    if [ "$1" = "upgrade" ]; then
-        # DEB: upgrade
-        is_removal=false
-    elif [ "$1" -ge 1 ] 2>/dev/null; then
-        # RPM: $1 >= 1 means upgrade
-        is_removal=false
-    elif [ "$1" = "0" ]; then
-        # RPM: $1 = 0 means actual removal
+case "$1" in
+    remove|purge)
         is_removal=true
-    fi
-fi
+        ;;
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        is_removal=false
+        ;;
+    0)
+        # RPM: actual removal.
+        is_removal=true
+        ;;
+    *)
+        # RPM: $1 >= 1 means upgrade; anything else: don't message.
+        is_removal=false
+        ;;
+esac
 
-# Always reload systemd
-systemctl daemon-reload
+# Reload systemd, but only when the package manager is running on a host
+# with a live systemd. Container / chroot builds (e.g. Docker layers)
+# have no systemd; calling daemon-reload there aborts under set -e and
+# leaves the package half-applied.
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+fi
 
 if [ "$is_removal" = true ]; then
     echo ""
@@ -33,4 +42,4 @@ if [ "$is_removal" = true ]; then
     echo "To remove them completely: rm -rf /etc/ups-monitor/"
     echo ""
 fi
-# UPGRADE: Silent - no message needed
+# UPGRADE: silent — no message needed

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -3,24 +3,33 @@
 # Called before package files are removed
 #
 # RPM: $1 = 0 (removal), $1 = 1+ (upgrade - old package being removed)
-# DEB: $1 = "remove" or "upgrade"
+# DEB: $1 ∈ {remove, purge, upgrade, failed-upgrade, deconfigure,
+#            abort-install, abort-upgrade, disappear}
 set -e
 
-# Detect if this is a removal or upgrade
-is_removal=true
+is_removal=false
 
-if [ -n "$1" ]; then
-    if [ "$1" = "upgrade" ]; then
-        # DEB: upgrade means new version replacing old
-        is_removal=false
-    elif [ "$1" -ge 1 ] 2>/dev/null; then
-        # RPM: $1 >= 1 means upgrade (packages remaining after this one removed)
-        is_removal=false
-    elif [ "$1" = "0" ]; then
-        # RPM: $1 = 0 means actual removal
+case "$1" in
+    remove|purge)
+        # DEB: actual removal. (purge invokes prerm with "remove" first
+        # and then with "purge" — both should stop and disable.)
         is_removal=true
-    fi
-fi
+        ;;
+    upgrade|failed-upgrade|deconfigure|abort-install|abort-upgrade|disappear)
+        # DEB: every non-removal lifecycle. The previous if/elif cascade
+        # silently treated all of these as removals.
+        is_removal=false
+        ;;
+    0)
+        # RPM: actual removal.
+        is_removal=true
+        ;;
+    *)
+        # RPM: $1 >= 1 means upgrade; anything else: leave the service
+        # alone rather than stop/disable on an unknown lifecycle arg.
+        is_removal=false
+        ;;
+esac
 
 if [ "$is_removal" = true ]; then
     # ACTUAL REMOVAL: Stop and disable the service
@@ -34,4 +43,5 @@ if [ "$is_removal" = true ]; then
         systemctl disable eneru.service
     fi
 fi
-# UPGRADE: Do nothing - let postinstall of new package handle restart
+# UPGRADE / non-removal lifecycle: do nothing — postinstall of new
+# package handles restart.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,10 @@ where = ["src"]
 "eneru.completion" = ["*.bash", "*.zsh", "*.fish"]
 
 [tool.setuptools.dynamic]
-version = {attr = "eneru.__version__"}
+# Resolve directly from src/eneru/version.py — pointing at
+# `eneru.__version__` would import src/eneru/__init__.py during build,
+# so any future top-level import added there could break wheel builds.
+version = {attr = "eneru.version.__version__"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ markers =
     unit: Unit tests (fast, isolated)
     integration: Integration tests (may require external services)
     slow: Slow tests
+    no_stats_isolation: Opt out of the autouse isolate_stats_db_directory fixture (for tests that need to verify the production /var/lib/eneru default)
 # No blanket warning filters: a project-wide `ignore::DeprecationWarning`
 # would also hide upstream-Python deprecations the daemon needs to
 # react to. If a third-party library emits noisy DeprecationWarnings

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,5 +9,8 @@ markers =
     unit: Unit tests (fast, isolated)
     integration: Integration tests (may require external services)
     slow: Slow tests
-filterwarnings =
-    ignore::DeprecationWarning
+# No blanket warning filters: a project-wide `ignore::DeprecationWarning`
+# would also hide upstream-Python deprecations the daemon needs to
+# react to. If a third-party library emits noisy DeprecationWarnings
+# in CI, scope a targeted filter (e.g. `ignore::DeprecationWarning:<module>`)
+# rather than restoring the blanket suppression.

--- a/src/eneru/actions.py
+++ b/src/eneru/actions.py
@@ -43,17 +43,20 @@ REMOTE_ACTIONS: Dict[str, str] = {
         'true'
     ),
 
-    # Stop XCP-ng/XenServer VMs with graceful shutdown, then force
+    # Stop XCP-ng/XenServer VMs with graceful shutdown, then force.
+    # `xe` parses arguments as key=value pairs, so the UUID must be bound
+    # to the `uuid=` parameter via `-I {{}}`; passing it positionally
+    # makes `xe` silently ignore it.
     "stop_xcpng_vms": (
         'ids=$(xe vm-list power-state=running is-control-domain=false --minimal); '
         '[ -z "$ids" ] && exit 0; '
-        'echo "$ids" | tr \',\' \'\\n\' | xargs -r -n1 xe vm-shutdown uuid= 2>/dev/null; '
+        'echo "$ids" | tr \',\' \'\\n\' | xargs -r -I {{}} xe vm-shutdown uuid={{}} 2>/dev/null; '
         'end=$((SECONDS+{timeout})); '
         'while [ $SECONDS -lt $end ]; do '
         'ids=$(xe vm-list power-state=running is-control-domain=false --minimal); '
         '[ -z "$ids" ] && break; sleep 1; done; '
         'xe vm-list power-state=running is-control-domain=false --minimal | tr \',\' \'\\n\' | '
-        'xargs -r -n1 xe vm-shutdown uuid= --force 2>/dev/null; '
+        'xargs -r -I {{}} xe vm-shutdown uuid={{}} force=true 2>/dev/null; '
         'true'
     ),
 
@@ -71,13 +74,17 @@ REMOTE_ACTIONS: Dict[str, str] = {
         'true'
     ),
 
-    # Stop docker/podman compose stack
+    # Stop docker/podman compose stack.
+    # {path} is shell-quoted at the format() call site (see
+    # RemoteShutdownMixin._execute_remote_pre_shutdown) — leaving the
+    # placeholder bare here so shlex.quote provides the only quoting
+    # boundary; double-quoting wouldn't block $(), backticks, or ${...}.
     "stop_compose": (
         't={timeout}; '
         'if command -v docker &>/dev/null && docker compose version &>/dev/null; then '
-        'docker compose -f "{path}" down -t $t; '
+        'docker compose -f {path} down -t $t; '
         'elif command -v podman &>/dev/null; then '
-        'podman compose -f "{path}" down -t $t; fi; '
+        'podman compose -f {path} down -t $t; fi; '
         'true'
     ),
 

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import sys
 from datetime import datetime
+from pathlib import Path
 
 from eneru.version import __version__
 from eneru.config import ConfigLoader
@@ -201,15 +202,23 @@ def _cmd_validate(args):
     else:
         print(f"    Disabled")
 
-    # Run validation checks (pass raw YAML data for top-level resource warnings)
+    # Run validation checks (pass raw YAML data for top-level resource warnings).
+    # Re-parse for both single-UPS and multi-UPS configs so the top-level
+    # warnings reach single-UPS users too. ConfigLoader.load already
+    # handles missing files gracefully and warned the user; only the
+    # "file exists but YAML is malformed" branch must surface the error
+    # here so it isn't silently swallowed.
     raw_data = None
-    if config.multi_ups and args.config:
+    if args.config and Path(args.config).exists():
         try:
             import yaml
             with open(args.config, 'r') as f:
                 raw_data = yaml.safe_load(f) or {}
-        except Exception:
-            pass
+        except Exception as exc:
+            print()
+            print(f"  ERROR: Failed to re-parse {args.config} for top-level "
+                  f"validation: {exc}")
+            exit_code = 1
     messages = ConfigLoader.validate_config(config, raw_data=raw_data)
     if messages:
         print()

--- a/src/eneru/completion/eneru.bash
+++ b/src/eneru/completion/eneru.bash
@@ -36,7 +36,10 @@ _eneru() {
     # Value-of-flag completion is shared across subcommands.
     case "$prev" in
         -c|--config)
-            COMPREPLY=( $(compgen -f -- "$cur") )
+            # mapfile -t preserves filenames containing spaces or other
+            # word-splitting metacharacters; the bare $(...) form would
+            # split each name into separate completions.
+            mapfile -t COMPREPLY < <(compgen -f -- "$cur")
             return 0
             ;;
         --graph)

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -589,6 +589,9 @@ class ConfigLoader:
         avatar_url = None
         notif_timeout = 10
         notif_retry_interval = 5
+        # Defaults match NotificationsConfig dataclass.
+        notif_suppress: List[str] = []
+        notif_voltage_hysteresis = 30
 
         if 'notifications' in data:
             notif_data = data['notifications']
@@ -596,6 +599,10 @@ class ConfigLoader:
             avatar_url = notif_data.get('avatar_url')
             notif_timeout = notif_data.get('timeout', 10)
             notif_retry_interval = notif_data.get('retry_interval', 5)
+            notif_suppress = notif_data.get('suppress', notif_suppress)
+            notif_voltage_hysteresis = notif_data.get(
+                'voltage_hysteresis_seconds', notif_voltage_hysteresis,
+            )
 
             if 'urls' in notif_data:
                 for url in notif_data.get('urls', []):
@@ -628,6 +635,8 @@ class ConfigLoader:
             avatar_url=avatar_url,
             timeout=notif_timeout,
             retry_interval=notif_retry_interval,
+            suppress=notif_suppress,
+            voltage_hysteresis_seconds=notif_voltage_hysteresis,
         )
 
     @classmethod

--- a/src/eneru/graph.py
+++ b/src/eneru/graph.py
@@ -123,10 +123,18 @@ class BrailleGraph:
         if not data:
             return [" " * width for _ in range(height)]
 
-        if y_min is None:
-            y_min = min(data)
-        if y_max is None:
-            y_max = max(data)
+        # Auto-bound from the numeric subset only — `data` may carry
+        # None or non-numeric placeholders for missing samples; min/max
+        # over a mixed list raises TypeError on Python 3.
+        if y_min is None or y_max is None:
+            numeric = [v for v in data if isinstance(v, (int, float))]
+            if not numeric:
+                # Nothing to scale against; render an empty grid.
+                return [" " * width for _ in range(height)]
+            if y_min is None:
+                y_min = min(numeric)
+            if y_max is None:
+                y_max = max(numeric)
         # Avoid a zero range: pad symmetrically.
         if y_max <= y_min:
             pad = abs(y_min) * 0.05 if y_min else 1.0
@@ -204,17 +212,21 @@ class BrailleGraph:
     @staticmethod
     def _fallback_char(grid, cell_col: int, cell_row: int) -> str:
         """Pick a single block char for the 2x4 cell sub-grid."""
-        # Count the highest "on" pixel within the cell across both columns.
-        highest_on = -1
+        # Find the TOPMOST "on" pixel within the cell across both columns
+        # (smallest row index). The block-char ladder is sized so a higher
+        # data value yields a taller block, so we must aggregate via min,
+        # not max — picking the bottommost pixel was making cells with any
+        # "on" pixel render as the tiniest block, hiding the data peaks.
+        topmost_on = -1
         for col_off in (0, 1):
             for r in range(4):
                 if grid[cell_col * 2 + col_off][cell_row * 4 + r]:
-                    if r > highest_on:
-                        highest_on = r
-        if highest_on < 0:
+                    if topmost_on < 0 or r < topmost_on:
+                        topmost_on = r
+        if topmost_on < 0:
             return _BLOCK_FALLBACK[0]
         # row 0 (top dot) -> tall block; row 3 (bottom) -> tiny block.
-        return _BLOCK_FALLBACK[8 - 2 * highest_on if highest_on > 0 else 8]
+        return _BLOCK_FALLBACK[8 - 2 * topmost_on if topmost_on > 0 else 8]
 
     @classmethod
     def render_to_window(

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -33,13 +33,24 @@ class BatteryMonitorMixin:
         self.state.battery_history.append((current_time, current_battery_float))
 
         try:
-            temp_file = self._battery_history_path.with_suffix('.tmp')
+            # with_name(name + '.tmp') preserves the per-UPS suffix on the
+            # path (e.g. 'ups-battery-history.ups1') so concurrent writers
+            # in multi-UPS mode never share a temp file. with_suffix('.tmp')
+            # would replace the per-UPS suffix and race on the rename.
+            temp_file = self._battery_history_path.with_name(
+                self._battery_history_path.name + '.tmp'
+            )
             with open(temp_file, 'w') as f:
                 for ts, bat in self.state.battery_history:
                     f.write(f"{ts}:{bat}\n")
             temp_file.replace(self._battery_history_path)
-        except Exception:
-            pass
+        except Exception as exc:
+            # Persisting battery history is best-effort; the in-memory deque
+            # is the source of truth and a single failed write doesn't break
+            # depletion calculations. Log so silent disk errors are visible.
+            self._log_message(
+                f"⚠️ Battery history persist failed: {exc}"
+            )
 
         if len(self.state.battery_history) < 30:
             return 0.0
@@ -125,9 +136,19 @@ class BatteryMonitorMixin:
             if self.state.pending_anomaly_count < 3:
                 return
 
-            # Confirmed anomaly (sustained across 3 polls)
+            # Re-validate the drop magnitude before notifying. Without this
+            # check the confirmation can fire after the charge has crept
+            # back up to within a few % of the original (drop < 20),
+            # producing a false-alarm "battery dropped X%" message that
+            # contradicts the current reading.
             anomaly_prev = self.state.pending_anomaly_prev_charge
             anomaly_drop = anomaly_prev - current_charge
+            if anomaly_drop <= 20:
+                self.state.pending_anomaly_charge = -1.0
+                self.state.pending_anomaly_count = 0
+                return
+
+            # Confirmed anomaly (sustained across 3 polls)
             anomaly_elapsed = current_time - self.state.pending_anomaly_time
             self.state.pending_anomaly_charge = -1.0
             self.state.pending_anomaly_count = 0

--- a/src/eneru/health/voltage.py
+++ b/src/eneru/health/voltage.py
@@ -317,6 +317,22 @@ class VoltageMonitorMixin:
             self._set_voltage_pending(
                 target, voltage, threshold, is_severe=is_severe,
             )
+        else:
+            # Severity escalation within the same state: a brownout that
+            # was mild on the previous poll may now have crossed the
+            # severe-deviation threshold. _set_voltage_pending only fires
+            # on state transition, so without this update the pending
+            # record keeps the original is_severe=False and the dwell
+            # bypass for severe events never triggers.
+            if (
+                is_severe
+                and self.state.voltage_pending_state in ("HIGH", "LOW")
+                and not self.state.voltage_pending_severe
+                and not self.state.voltage_pending_notified
+            ):
+                self.state.voltage_pending_severe = True
+                self.state.voltage_pending_voltage = voltage
+                self.state.voltage_pending_threshold = threshold
 
         # Re-evaluate the pending notification each poll regardless of
         # whether the state changed -- the hysteresis fires when the

--- a/src/eneru/logger.py
+++ b/src/eneru/logger.py
@@ -26,8 +26,20 @@ class UPSLogger:
         self.logger = logging.getLogger("ups-monitor")
         self.logger.setLevel(logging.INFO)
 
-        if self.logger.handlers:
-            self.logger.handlers.clear()
+        # Iterate-and-close so file descriptors held by previously
+        # registered FileHandlers are released. Bare `.handlers.clear()`
+        # leaks the underlying file objects when re-init runs against
+        # a logger that had a FileHandler attached.
+        for h in list(self.logger.handlers):
+            self.logger.removeHandler(h)
+            try:
+                h.close()
+            except Exception:
+                pass
+        # Don't propagate to the root logger — Eneru manages its own
+        # console + file output; propagation would duplicate every line
+        # if the embedding application configured root handlers.
+        self.logger.propagate = False
 
         formatter = TimezoneFormatter(
             '%(asctime)s %(timezone)s - %(message)s',

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -592,7 +592,13 @@ class UPSGroupMonitor(
             f"TIMESTAMP={datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
         )
         try:
-            temp_file = self._state_file_path.with_suffix('.tmp')
+            # with_name(name + '.tmp') appends '.tmp' to the full filename;
+            # with_suffix('.tmp') would replace the per-UPS suffix
+            # (e.g. '.ups1') and collapse every monitor's temp file onto
+            # a shared 'ups-state.tmp', racing on the atomic rename.
+            temp_file = self._state_file_path.with_name(
+                self._state_file_path.name + '.tmp'
+            )
             temp_file.write_text(state_content)
             temp_file.replace(self._state_file_path)
         except Exception:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -388,7 +388,12 @@ class UPSGroupMonitor(
 
         try:
             run_command([
-                "logger", "-t", "ups-monitor", "-p", "daemon.warning",
+                # syslog identifier renamed from the legacy "ups-monitor"
+                # to "eneru" — the package + service rebrand happened in
+                # v5.0 but this side-channel was missed, so power events
+                # showed up under a different identifier than every
+                # other journal line emitted by the daemon.
+                "logger", "-t", "eneru", "-p", "daemon.warning",
                 f"⚡ POWER EVENT: {event} - {details}"
             ])
         except Exception:

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -100,13 +100,17 @@ class MultiUPSCoordinator:
     def _start_monitors(self):
         """Create and start one UPSGroupMonitor thread per group."""
         for group in self.config.ups_groups:
-            # Build a single-group Config for this monitor
+            # Build a single-group Config for this monitor. Every shared
+            # field on Config that affects per-group behavior must be passed
+            # through here -- omissions silently fall back to dataclass
+            # defaults and the user's YAML is ignored in multi-UPS mode.
             group_config = Config(
                 ups_groups=[group],
                 behavior=self.config.behavior,
                 logging=self.config.logging,
                 notifications=self.config.notifications,
                 local_shutdown=self.config.local_shutdown,
+                statistics=self.config.statistics,
             )
 
             # Sanitize UPS name for file paths
@@ -156,6 +160,7 @@ class MultiUPSCoordinator:
                     log_prefix=f"[redundancy:{rg.name}] ",
                     stop_event=self._stop_event,
                     notification_worker=self._notification_worker,
+                    local_shutdown_callback=self._handle_local_shutdown,
                 )
                 self._redundancy_executors[rg.name] = executor
                 evaluator = RedundancyGroupEvaluator(
@@ -263,10 +268,26 @@ class MultiUPSCoordinator:
         This triggers each monitor's shutdown sequence (VMs, containers,
         remote servers) before stopping the monitoring loops. Resources
         are actively shut down, not just abandoned.
+
+        Order matters: signal stop_event first so peer monitors stop
+        their main loops, give them a brief window to drain, then run
+        the per-monitor shutdown sequence sequentially. Running shutdown
+        on peers while their loops are still active risked concurrent
+        access to the same shutdown path (notifications, state-file
+        writes) inside the peer's poll cycle.
         """
         self._log("⏳ Draining all UPS groups -- shutting down their resources...")
 
-        # First, trigger shutdown on each monitor that hasn't already shut down
+        # Phase 1: signal every peer monitor to stop its poll loop, then
+        # join with a short window so the loops exit before we run their
+        # shutdown sequences.
+        self._stop_event.set()
+        join_deadline = time.time() + max(1, timeout // 4)
+        for thread in self._threads:
+            remaining = max(0.0, join_deadline - time.time())
+            thread.join(timeout=remaining)
+
+        # Phase 2: run each monitor's shutdown sequence sequentially.
         for monitor in self._monitors:
             if not monitor._shutdown_flag_path.exists():
                 self._log(f"  ➡️ Triggering shutdown for {monitor._log_prefix.strip()}")
@@ -275,11 +296,10 @@ class MultiUPSCoordinator:
                 except Exception as e:
                     self._log(f"  ⚠️ Error during drain shutdown: {e}")
 
-        # Then stop the monitoring loops
-        self._stop_event.set()
+        # Final join window for any threads still wrapping up.
         deadline = time.time() + timeout
         for thread in self._threads:
-            remaining = max(0, deadline - time.time())
+            remaining = max(0.0, deadline - time.time())
             thread.join(timeout=remaining)
         still_running = [t for t in self._threads if t.is_alive()]
         if still_running:

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -19,7 +19,7 @@ catches concurrent calls inside one process.
 import threading
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from eneru.config import (
     Config,
@@ -63,6 +63,7 @@ class RedundancyGroupExecutor(
         log_prefix: str = "",
         stop_event: Optional[threading.Event] = None,
         notification_worker: Optional[NotificationWorker] = None,
+        local_shutdown_callback: Optional[Callable[[str], None]] = None,
     ):
         # Build a one-group Config so the shutdown mixins' lookups
         # (self.config.behavior, self.config.remote_servers,
@@ -121,6 +122,12 @@ class RedundancyGroupExecutor(
             except Exception:
                 self._container_runtime = None
                 self._compose_available = False
+
+        # Callback into the MultiUPSCoordinator's _handle_local_shutdown.
+        # The coordinator owns the in-memory lock and global flag that
+        # prevent the per-UPS path and this redundancy path from
+        # double-firing the local poweroff command.
+        self._local_shutdown_callback = local_shutdown_callback
 
         self._lock = threading.Lock()
         self._shutdown_done = False
@@ -195,6 +202,20 @@ class RedundancyGroupExecutor(
                 f"✅ ========== REDUNDANCY GROUP SHUTDOWN COMPLETE: "
                 f"{self._group.name} =========="
             )
+            # is_local quorum-loss must also fire the local poweroff.
+            # Without this, the executor stops local services and remote
+            # peers but leaves the host running. Delegate to the
+            # coordinator's _handle_local_shutdown so the in-memory lock
+            # and global flag prevent a double-fire if the per-UPS path
+            # also requested a local shutdown. The coordinator itself
+            # checks dry_run and local_shutdown.enabled.
+            if (
+                self._group.is_local
+                and self._local_shutdown_callback is not None
+            ):
+                self._local_shutdown_callback(
+                    f"redundancy:{self._group.name}"
+                )
         except Exception as e:
             self._log_message(
                 f"❌ Redundancy group '{self._group.name}' shutdown error: {e}"

--- a/src/eneru/shutdown/filesystems.py
+++ b/src/eneru/shutdown/filesystems.py
@@ -1,6 +1,7 @@
 """Filesystem sync + unmount phase of the shutdown sequence."""
 
 import os
+import shlex
 import time
 
 from eneru.utils import run_command
@@ -57,7 +58,10 @@ class FilesystemShutdownMixin:
 
             cmd = ["umount"]
             if options:
-                cmd.append(options)
+                # Multi-flag option strings like "-l -f" must be split into
+                # separate argv entries — appending the literal would make
+                # umount reject "-l -f" as a single unknown option.
+                cmd.extend(shlex.split(options))
             cmd.append(mount_point)
 
             exit_code, _, stderr = run_command(cmd, timeout=timeout)

--- a/src/eneru/shutdown/filesystems.py
+++ b/src/eneru/shutdown/filesystems.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 import time
+from typing import List
 
 from eneru.utils import run_command
 
@@ -50,30 +51,30 @@ class FilesystemShutdownMixin:
             options_display = f" {options}" if options else ""
             self._log_message(f"  ➡️ Unmounting {mount_point}{options_display}")
 
-            if self.config.behavior.dry_run:
-                self._log_message(
-                    f"  🧪 [DRY-RUN] Would execute: timeout {timeout}s umount {options} {mount_point}"
-                )
-                continue
-
-            cmd = ["umount"]
+            # Build the argv up-front so the dry-run log can render the
+            # exact tokens that would be exec'd (was: the dry-run line
+            # printed the raw `options` string, which doesn't match what
+            # actually runs after shlex.split). Malformed-options
+            # detection now also happens in dry-run mode, surfacing
+            # config errors before a real shutdown.
+            opt_args: List[str] = []
             if options:
-                # Multi-flag option strings like "-l -f" must be split into
-                # separate argv entries — appending the literal would make
-                # umount reject "-l -f" as a single unknown option.
-                # Wrap shlex.split because it raises ValueError on
-                # malformed input (unclosed quotes, etc.); a misconfigured
-                # YAML must never crash the shutdown sequence — log and
-                # skip THIS mount instead.
                 try:
-                    cmd.extend(shlex.split(options))
+                    opt_args = shlex.split(options)
                 except ValueError as exc:
                     self._log_message(
                         f"  ❌ Invalid umount options for {mount_point}: "
                         f"{exc}. Skipping this mount."
                     )
                     continue
-            cmd.append(mount_point)
+            cmd = ["umount", *opt_args, mount_point]
+
+            if self.config.behavior.dry_run:
+                rendered = " ".join(shlex.quote(a) for a in cmd)
+                self._log_message(
+                    f"  🧪 [DRY-RUN] Would execute: timeout {timeout}s {rendered}"
+                )
+                continue
 
             exit_code, _, stderr = run_command(cmd, timeout=timeout)
 

--- a/src/eneru/shutdown/filesystems.py
+++ b/src/eneru/shutdown/filesystems.py
@@ -61,7 +61,18 @@ class FilesystemShutdownMixin:
                 # Multi-flag option strings like "-l -f" must be split into
                 # separate argv entries — appending the literal would make
                 # umount reject "-l -f" as a single unknown option.
-                cmd.extend(shlex.split(options))
+                # Wrap shlex.split because it raises ValueError on
+                # malformed input (unclosed quotes, etc.); a misconfigured
+                # YAML must never crash the shutdown sequence — log and
+                # skip THIS mount instead.
+                try:
+                    cmd.extend(shlex.split(options))
+                except ValueError as exc:
+                    self._log_message(
+                        f"  ❌ Invalid umount options for {mount_point}: "
+                        f"{exc}. Skipping this mount."
+                    )
+                    continue
             cmd.append(mount_point)
 
             exit_code, _, stderr = run_command(cmd, timeout=timeout)

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -90,8 +90,12 @@ class RemoteShutdownMixin:
         errors are logged inside _shutdown_remote_server).
         """
         def calc_server_timeout(server: RemoteServerConfig) -> int:
+            # Explicit None check so a per-command timeout of 0 (e.g. for
+            # a command the user wants to fire-and-forget) isn't promoted
+            # to server.command_timeout via Python's truthiness.
             pre_cmd_time = sum(
-                (cmd.timeout or server.command_timeout) for cmd in server.pre_shutdown_commands
+                (cmd.timeout if cmd.timeout is not None else server.command_timeout)
+                for cmd in server.pre_shutdown_commands
             )
             return (
                 pre_cmd_time
@@ -106,8 +110,14 @@ class RemoteShutdownMixin:
             """Thread worker for shutting down a single server."""
             try:
                 self._shutdown_remote_server(server)
-            except Exception:
-                pass  # Errors logged inside _shutdown_remote_server
+            except Exception as exc:
+                # _shutdown_remote_server only catches SSH-style errors;
+                # bubbling exceptions (network, AttributeError, OOM…) would
+                # otherwise vanish silently in the worker thread.
+                display = server.name or server.host
+                self._log_message(
+                    f"  ❌ Remote shutdown thread for {display} crashed: {exc}"
+                )
 
         threads: List[threading.Thread] = []
         for server in servers:
@@ -152,9 +162,18 @@ class RemoteShutdownMixin:
 
         ssh_cmd = ["ssh"]
 
-        # Add configured SSH options
+        # Add configured SSH options. Three cases:
+        #   1. "-o KEY=VALUE" / "-o KEY VALUE" (single string with space):
+        #      split into two argv entries so ssh's getopt parser sees
+        #      flag and value separately.
+        #   2. Any other "-flag …" form (e.g. "-i", "-p"): pass through
+        #      unchanged. Multi-token flags like "-i /path/key" must be
+        #      provided as separate ssh_options entries by the user.
+        #   3. Bare "KEY=VALUE": prepend "-o" as the implicit form.
         for opt in server.ssh_options:
-            if opt.startswith("-o"):
+            if opt.startswith("-o "):
+                ssh_cmd.extend(opt.split(None, 1))
+            elif opt.startswith("-"):
                 ssh_cmd.append(opt)
             else:
                 ssh_cmd.extend(["-o", opt])
@@ -181,8 +200,10 @@ class RemoteShutdownMixin:
         """Execute pre-shutdown commands on a remote server.
 
         Returns:
-            True if all commands executed (success or best-effort failure)
-            False if SSH connection failed entirely
+            True once the loop has iterated through every command.
+            Per-command failures are logged and execution continues
+            (best-effort) — there is no current code path that returns
+            False.
         """
         if not server.pre_shutdown_commands:
             return True

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -229,6 +229,17 @@ class RemoteShutdownMixin:
                     )
                     continue
 
+                # Validate stop_compose has path BEFORE rendering the
+                # template; otherwise the precondition warning becomes
+                # dead code (shlex.quote("") would happily produce ''
+                # and a future template change might let the bad command
+                # slip through).
+                if action_name == "stop_compose" and not cmd_config.path:
+                    self._log_message(
+                        f"    ⚠️ [{idx}/{cmd_count}] stop_compose requires 'path' parameter (skipping)"
+                    )
+                    continue
+
                 # Get command template and substitute placeholders.
                 # `path` is shlex-quoted because the template embeds it
                 # directly into the remote shell — without quoting, a
@@ -240,13 +251,6 @@ class RemoteShutdownMixin:
                     path=shlex.quote(cmd_config.path or "")
                 )
                 description = action_name
-
-                # Validate stop_compose has path
-                if action_name == "stop_compose" and not cmd_config.path:
-                    self._log_message(
-                        f"    ⚠️ [{idx}/{cmd_count}] stop_compose requires 'path' parameter (skipping)"
-                    )
-                    continue
 
             # Handle custom command
             elif cmd_config.command:

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -5,6 +5,7 @@ Owns the multi-server orchestration (sequential vs parallel batching by
 followed by the final shutdown command.
 """
 
+import shlex
 import threading
 import time
 from typing import Dict, List, Tuple
@@ -207,11 +208,15 @@ class RemoteShutdownMixin:
                     )
                     continue
 
-                # Get command template and substitute placeholders
+                # Get command template and substitute placeholders.
+                # `path` is shlex-quoted because the template embeds it
+                # directly into the remote shell — without quoting, a
+                # malicious or malformed path could expand $(), `…`, or
+                # ${…} on the remote host.
                 command_template = REMOTE_ACTIONS[action_name]
                 command = command_template.format(
                     timeout=timeout,
-                    path=cmd_config.path or ""
+                    path=shlex.quote(cmd_config.path or "")
                 )
                 description = action_name
 

--- a/src/eneru/shutdown/vms.py
+++ b/src/eneru/shutdown/vms.py
@@ -47,18 +47,33 @@ class VMShutdownMixin:
         self._log_message(f"  ⏳ Waiting up to {max_wait}s for VMs to shutdown gracefully...")
         wait_interval = 5
         time_waited = 0
-        remaining_vms: List[str] = []
+        # Seed with the originally-running list so a transient virsh
+        # failure on the first poll doesn't make the loop think the VMs
+        # are gone (empty stdout would otherwise yield remaining_vms=[]
+        # and skip force-destroy).
+        remaining_vms: List[str] = list(running_vms)
 
         while time_waited < max_wait:
             exit_code, stdout, _ = run_command(["virsh", "list", "--name", "--state-running"])
-            still_running = set(vm.strip() for vm in stdout.strip().split('\n') if vm.strip())
-            remaining_vms = [vm for vm in running_vms if vm in still_running]
+            if exit_code != 0:
+                # libvirtd may be wedged or restarting. Don't trust empty
+                # stdout as "all stopped" — keep the previous remaining_vms
+                # and re-poll on the next interval. If we exhaust max_wait
+                # the force-destroy pass below still fires.
+                self._log_message(
+                    f"  ⚠️ virsh list returned exit {exit_code}; keeping prior "
+                    f"remaining VMs ({len(remaining_vms)}) and retrying"
+                )
+            else:
+                still_running = set(vm.strip() for vm in stdout.strip().split('\n') if vm.strip())
+                remaining_vms = [vm for vm in running_vms if vm in still_running]
 
-            if not remaining_vms:
-                self._log_message(f"  ✅ All VMs stopped gracefully after {time_waited}s.")
-                break
+                if not remaining_vms:
+                    self._log_message(f"  ✅ All VMs stopped gracefully after {time_waited}s.")
+                    break
 
-            self._log_message(f"  🕒 Still waiting for: {' '.join(remaining_vms)} (Waited {time_waited}s)")
+                self._log_message(f"  🕒 Still waiting for: {' '.join(remaining_vms)} (Waited {time_waited}s)")
+
             time.sleep(wait_interval)
             time_waited += wait_interval
 

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -16,6 +16,7 @@ import time
 from collections import deque
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
+from urllib.parse import quote as urlquote
 
 
 # Sample columns: 10 raw NUT metrics from spec 2.12 (battery.charge,
@@ -145,9 +146,14 @@ class StatsStore:
         except OSError as e:
             self._log_error_once(f"stats: mkdir {self.db_path.parent} failed: {e}")
             raise
+        # Default deferred isolation: sqlite3 opens an implicit
+        # transaction on first DML, and the `with self._conn:` blocks
+        # below commit/rollback as expected. With isolation_level=None
+        # the connection runs in autocommit mode and the `with` blocks
+        # become no-ops, so executemany() would have committed every
+        # row individually instead of batching the flush.
         self._conn = sqlite3.connect(
             str(self.db_path),
-            isolation_level=None,  # explicit transactions
             check_same_thread=False,
         )
         self._conn.execute("PRAGMA journal_mode = WAL")
@@ -602,7 +608,10 @@ class StatsStore:
         path = Path(db_path)
         if not path.exists():
             return None  # type: ignore[return-value]
-        uri = f"file:{path}?mode=ro"
+        # urlquote so a path containing '?' or '#' (legal on POSIX
+        # filesystems, illegal in a SQLite URI without escaping) doesn't
+        # truncate the path or get parsed as the URI's query / fragment.
+        uri = f"file:{urlquote(str(path))}?mode=ro"
         conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
         # Same bound as the writer connection: a slow query against the
         # writer's WAL can't stall the TUI refresh for more than 500 ms.

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -598,7 +598,7 @@ class StatsStore:
     # ----- read-only API for the TUI -----
 
     @classmethod
-    def open_readonly(cls, db_path: Path) -> sqlite3.Connection:
+    def open_readonly(cls, db_path: Path) -> Optional[sqlite3.Connection]:
         """Open a read-only ``sqlite3.Connection`` (URI mode=ro).
 
         Returns ``None`` if the file doesn't exist; otherwise the
@@ -607,7 +607,7 @@ class StatsStore:
         """
         path = Path(db_path)
         if not path.exists():
-            return None  # type: ignore[return-value]
+            return None
         # urlquote so a path containing '?' or '#' (legal on POSIX
         # filesystems, illegal in a SQLite URI without escaping) doesn't
         # truncate the path or get parsed as the URI's query / fragment.

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -33,9 +33,12 @@ TIME_RANGE_SECONDS = {
 
 # The events panel is intentionally decoupled from the graph timescale:
 # pressing T to change the graph window must not shrink/grow the events
-# list. 24h is the operational sweet spot -- short enough that the list
-# stays readable, long enough to cover an overnight power event.
-EVENTS_TIME_WINDOW = 24 * 3600
+# list. The panel pulls every event from the SQLite store (the events
+# table is one row per power event, not per poll, so even years of
+# history stay tiny) and lets the operator scroll through with the
+# arrow keys.
+EVENTS_MAX_ROWS_NORMAL = 8
+EVENTS_MAX_ROWS_MORE = 500
 
 # Map graph modes to (column, unit_suffix, y_min, y_max, value_formatter).
 # value_formatter takes a float and returns the user-facing display
@@ -308,18 +311,20 @@ def _format_event_line(ts: int, label: str, event_type: str,
 
 def query_events_for_display(
     config: Config,
-    time_range_seconds: int = 24 * 3600,
+    time_range_seconds: Optional[int] = None,
     *,
-    max_events: int = 50,
+    max_events: int = EVENTS_MAX_ROWS_MORE,
 ) -> List[str]:
-    """Pull recent events from each UPS's SQLite store, sorted by timestamp.
+    """Pull events from each UPS's SQLite store, sorted by timestamp.
 
-    Returns formatted display strings ready to drop into the TUI events
-    panel. Returns an empty list when no per-UPS DB exists -- callers
-    should fall back to ``parse_log_events`` in that case.
+    ``time_range_seconds=None`` (default) returns everything in the
+    events table; pass an explicit window to limit by age. Returns
+    formatted display strings ready to drop into the TUI events panel.
+    Returns an empty list when no per-UPS DB exists -- callers should
+    fall back to ``parse_log_events`` in that case.
     """
     end = int(time.time())
-    start = end - max(60, int(time_range_seconds))
+    start = 0 if time_range_seconds is None else end - max(60, int(time_range_seconds))
     multi_ups = config.multi_ups
     rows: List[tuple] = []  # (ts, label, event_type, detail)
     any_db_seen = False
@@ -677,7 +682,8 @@ def render_config_panel(win, y_start: int, y_end: int, width: int,
 def render_logs_panel(win, y_start: int, y_end: int, width: int,
                        events: List[str], show_more: bool,
                        *, graph_mode: str = "off", time_range: str = "1h",
-                       ups_index: int = 0, ups_total: int = 1):
+                       ups_index: int = 0, ups_total: int = 1,
+                       scroll_offset: int = 0):
     """Render the logs panel with yellow/gold background, edge to edge.
 
     The bottom-row key hints reflect the *current* graph mode, time
@@ -705,10 +711,18 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
     else:
         footer_lines = 2
         available = y_end - y - footer_lines
-        if not show_more:
-            display_events = events[-min(len(events), max(3, available)):] if available > 0 else []
+        if available <= 0:
+            display_events = []
         else:
-            display_events = events[-max(1, available):]
+            visible = max(3, available) if not show_more else max(1, available)
+            # scroll_offset = 0 anchors the bottom (most recent) on the
+            # last visible row. Larger offsets reveal older events; clamp
+            # so the user can never scroll past the oldest entry.
+            max_offset = max(0, len(events) - visible)
+            offset = max(0, min(scroll_offset, max_offset))
+            end_idx = len(events) - offset
+            start_idx = max(0, end_idx - visible)
+            display_events = events[start_idx:end_idx]
 
         for event in display_events:
             if y >= y_end - footer_lines:
@@ -742,6 +756,7 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
         ("<Q>", "Quit"),
         ("<R>", "Refresh"),
         ("<M>", "More logs"),
+        ("<↑↓>", "Scroll"),
         ("<G>", f"Graph: {graph_mode}"),
         ("<T>", f"Time: {time_range}"),
         ("<U>", ups_descr),
@@ -885,10 +900,10 @@ def run_tui(config: Config, interval: int = 5):
         stdscr.bkgd(' ', curses.color_pair(C_BORDER))
 
         show_more = False
-        max_log_events = 8
         graph_mode = "off"           # G key cycles through GRAPH_MODES
         time_range = "1h"            # T key cycles through TIME_RANGES
         ups_index = 0                # U key cycles which UPS the graph shows
+        events_scroll = 0            # ↑/↓ scrolls events panel; 0 = bottom
 
         while True:
             stdscr.erase()
@@ -944,12 +959,16 @@ def run_tui(config: Config, interval: int = 5):
             for g in config.ups_groups:
                 groups_data.append(collect_group_data(g, config))
                 update_live_buffer(g, config)
-            log_events = query_events_for_display(config, EVENTS_TIME_WINDOW,
-                                                  max_events=50 if show_more else max_log_events)
+            events_cap = (
+                EVENTS_MAX_ROWS_MORE if show_more else EVENTS_MAX_ROWS_NORMAL
+            )
+            log_events = query_events_for_display(
+                config, max_events=events_cap,
+            )
             if not log_events:
                 log_events = parse_log_events(
                     config.logging.file or "",
-                    max_events=50 if show_more else max_log_events,
+                    max_events=events_cap,
                 )
 
             # Render panels edge-to-edge
@@ -964,12 +983,17 @@ def run_tui(config: Config, interval: int = 5):
                 )
                 # Spacer between graph and logs
                 fill_row(stdscr, graph_end, curses.color_pair(C_BORDER))
+            # Bound the scroll offset to the current events list so a
+            # refresh that shrinks the list doesn't strand the user on
+            # an empty view.
+            events_scroll = max(0, min(events_scroll, max(0, len(log_events) - 1)))
             render_logs_panel(stdscr, logs_start, logs_end, width,
                               log_events, show_more,
                               graph_mode=graph_mode,
                               time_range=time_range,
                               ups_index=ups_index,
-                              ups_total=len(config.ups_groups) or 1)
+                              ups_total=len(config.ups_groups) or 1,
+                              scroll_offset=events_scroll)
 
             # Move cursor to bottom-right to avoid visual artifacts
             try:
@@ -984,6 +1008,7 @@ def run_tui(config: Config, interval: int = 5):
             if key in (ord('q'), ord('Q'), 27):
                 break
             elif key == ord('r'):
+                events_scroll = 0
                 continue
             elif key in (ord('m'), ord('M')):
                 show_more = not show_more
@@ -994,6 +1019,21 @@ def run_tui(config: Config, interval: int = 5):
             elif key in (ord('u'), ord('U')):
                 if config.ups_groups:
                     ups_index = (ups_index + 1) % len(config.ups_groups)
+            elif key == curses.KEY_UP:
+                # Scroll one event toward older history. The render
+                # function clamps to the current list size.
+                events_scroll += 1
+            elif key == curses.KEY_DOWN:
+                events_scroll = max(0, events_scroll - 1)
+            elif key == curses.KEY_PPAGE:    # PgUp
+                events_scroll += 10
+            elif key == curses.KEY_NPAGE:    # PgDn
+                events_scroll = max(0, events_scroll - 10)
+            elif key == curses.KEY_HOME:
+                # Jump to the oldest event currently in the list.
+                events_scroll = max(0, len(log_events))
+            elif key == curses.KEY_END:
+                events_scroll = 0
 
     curses.wrapper(_main)
 

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -898,6 +898,12 @@ def run_tui(config: Config, interval: int = 5):
         curses.curs_set(0)
         stdscr.timeout(interval * 1000)
         stdscr.bkgd(' ', curses.color_pair(C_BORDER))
+        # Enable keypad translation so curses delivers KEY_UP / KEY_DOWN /
+        # KEY_PPAGE / KEY_NPAGE / KEY_HOME / KEY_END for the events-panel
+        # scroll bindings. Without this, arrow keys arrive as raw escape
+        # sequences (ESC + [ + A) and the leading ESC byte (27) hits the
+        # quit branch instead of scrolling.
+        stdscr.keypad(True)
 
         show_more = False
         graph_mode = "off"           # G key cycles through GRAPH_MODES
@@ -1019,19 +1025,29 @@ def run_tui(config: Config, interval: int = 5):
             elif key in (ord('u'), ord('U')):
                 if config.ups_groups:
                     ups_index = (ups_index + 1) % len(config.ups_groups)
-            elif key == curses.KEY_UP:
-                # Scroll one event toward older history. The render
-                # function clamps to the current list size.
-                events_scroll += 1
+            elif key in (curses.KEY_UP, curses.KEY_PPAGE, curses.KEY_HOME):
+                # First scroll auto-promotes to More mode so the cap is
+                # the bigger 500-row window. Without this, normal mode's
+                # 8-row cap means there's nothing to scroll back to and
+                # the arrow keys are a silent no-op despite the visible
+                # `<↑↓> Scroll` hint.
+                if not show_more:
+                    show_more = True
+                if key == curses.KEY_UP:
+                    # Scroll one event toward older history. The render
+                    # function clamps to the current list size.
+                    events_scroll += 1
+                elif key == curses.KEY_PPAGE:    # PgUp
+                    events_scroll += 10
+                else:                            # KEY_HOME
+                    # Jump to the oldest event currently in the list.
+                    # render_logs_panel clamps so the value just needs
+                    # to overshoot the visible window.
+                    events_scroll = len(log_events)
             elif key == curses.KEY_DOWN:
                 events_scroll = max(0, events_scroll - 1)
-            elif key == curses.KEY_PPAGE:    # PgUp
-                events_scroll += 10
             elif key == curses.KEY_NPAGE:    # PgDn
                 events_scroll = max(0, events_scroll - 10)
-            elif key == curses.KEY_HOME:
-                # Jump to the oldest event currently in the list.
-                events_scroll = max(0, len(log_events))
             elif key == curses.KEY_END:
                 events_scroll = 0
 

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -108,19 +108,20 @@ _LIVE_BUFFER_MAXLEN = 60
 _live_buffers: Dict[str, "deque[Tuple[int, Dict[str, float]]]"] = {}
 
 # State-file keys (left) we promote into deque samples, mapped to the
-# stats schema's column names (right). Only the columns we render
-# graphs for need to be here -- adding a new graph metric means adding
-# its column to METRIC_INFO + the corresponding state-file key here.
+# stats schema's column names (right). The daemon writes the state
+# file as uppercase ``KEY=value`` lines (see UPSGroupMonitor._save_state),
+# NOT in NUT's dotted lowercase form -- the keys here must match the
+# state-file format or live blending receives zero samples and the
+# rightmost edge of the graph lags behind the SQLite write cadence
+# by ~10 s. Metrics whose values aren't persisted to the state file
+# (battery voltage, temperature, frequencies) cannot be live-blended
+# and are intentionally absent.
 _STATE_FILE_TO_COLUMN: Dict[str, str] = {
-    "battery.charge": "battery_charge",
-    "battery.runtime": "battery_runtime",
-    "ups.load": "ups_load",
-    "input.voltage": "input_voltage",
-    "output.voltage": "output_voltage",
-    "battery.voltage": "battery_voltage",
-    "ups.temperature": "ups_temperature",
-    "input.frequency": "input_frequency",
-    "output.frequency": "output_frequency",
+    "BATTERY": "battery_charge",
+    "RUNTIME": "battery_runtime",
+    "LOAD": "ups_load",
+    "INPUT_VOLTAGE": "input_voltage",
+    "OUTPUT_VOLTAGE": "output_voltage",
 }
 
 

--- a/src/eneru/utils.py
+++ b/src/eneru/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for Eneru."""
 
+import math
 import subprocess
 import os
 from typing import Any, List, Tuple
@@ -12,7 +13,6 @@ def is_numeric(value: Any) -> bool:
     expect a real comparable number, and `int(float("nan"))` raises
     while `float("inf")` propagates into bucket math as garbage.
     """
-    import math
     if value is None:
         return False
     if isinstance(value, bool):

--- a/src/eneru/utils.py
+++ b/src/eneru/utils.py
@@ -6,15 +6,24 @@ from typing import Any, List, Tuple
 
 
 def is_numeric(value: Any) -> bool:
-    """Check if a value is numeric (int or float)."""
+    """Check if a value is numeric (int or float).
+
+    Rejects NaN and ±Inf — callers (UPS metrics, voltages, runtimes)
+    expect a real comparable number, and `int(float("nan"))` raises
+    while `float("inf")` propagates into bucket math as garbage.
+    """
+    import math
     if value is None:
         return False
+    if isinstance(value, bool):
+        # bool is a subtype of int — NUT/UPS data should never be a
+        # bool, and treating True as 1 silently conceals upstream bugs.
+        return False
     if isinstance(value, (int, float)):
-        return True
+        return math.isfinite(value)
     if isinstance(value, str):
         try:
-            float(value)
-            return True
+            return math.isfinite(float(value))
         except (ValueError, TypeError):
             return False
     return False
@@ -57,10 +66,16 @@ def command_exists(cmd: str) -> bool:
 
 
 def format_seconds(seconds: Any) -> str:
-    """Format seconds into a human-readable string."""
+    """Format seconds into a human-readable string.
+
+    Negative inputs are clamped to 0 — UPS runtime/uptime values are
+    never negative semantically, but a misbehaving driver can briefly
+    return one (e.g. clock-skew during a hot-swap), and "-1m 30s" in
+    the TUI is more confusing than "0s".
+    """
     if not is_numeric(seconds):
         return "N/A"
-    seconds = int(float(seconds))
+    seconds = max(0, int(float(seconds)))
     if seconds < 60:
         return f"{seconds}s"
     elif seconds < 3600:

--- a/src/eneru/utils.py
+++ b/src/eneru/utils.py
@@ -34,7 +34,14 @@ def run_command(
             timeout=timeout,
             env={**os.environ, 'LC_NUMERIC': 'C'}
         )
-        return result.returncode, result.stdout, result.stderr
+        # subprocess.run returns stdout/stderr=None when capture_output
+        # is False; normalize to empty strings so callers can always
+        # `.strip()` / index the values without a TypeError.
+        return (
+            result.returncode,
+            result.stdout if result.stdout is not None else "",
+            result.stderr if result.stderr is not None else "",
+        )
     except subprocess.TimeoutExpired:
         return 124, "", "Command timed out"
     except FileNotFoundError:

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -1,5 +1,5 @@
 """Version information for Eneru."""
 
 # Version is set at build time via git describe --tags
-# Format: "4.3.0" for tagged releases, "4.3.0-5-gabcdef1" for dev builds
+# Format: "5.1.0" for tagged releases, "5.1.0-5-gabcdef1" for dev builds
 __version__ = "5.1.0"

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.1.0" for tagged releases, "5.1.0-5-gabcdef1" for dev builds
-__version__ = "5.1.0"
+__version__ = "5.1.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,23 +36,70 @@ from eneru import (
     ConfigLoader,
 )
 from eneru import config as eneru_config_module
+from eneru import stats as eneru_stats_module
 
 
 @pytest.fixture(autouse=True)
-def isolate_stats_db_directory(tmp_path, monkeypatch):
-    """Redirect every test's StatsConfig.db_directory default to a
-    per-test tmp_path so any code that constructs StatsConfig() without
-    overriding the field doesn't write SQLite files into the real
-    /var/lib/eneru. Without this fixture every test that instantiates
-    UPSGroupMonitor (or StatsStore directly) leaks `default.db` and
-    per-UPS DBs onto the host."""
+def isolate_stats_db_directory(request, tmp_path, monkeypatch):
+    """Redirect every test's StatsConfig.db_directory default and any
+    direct StatsStore(db_path=...) call to a per-test tmp_path, so no
+    test leaks SQLite files into the real /var/lib/eneru.
+
+    Tests that specifically need to verify the unmodified production
+    default (e.g. asserting StatsConfig().db_directory == "/var/lib/
+    eneru") can opt out via @pytest.mark.no_stats_isolation.
+
+    Two layers of defense are required when the fixture is active:
+
+    1. ``StatsConfig.__init__`` — the dataclass-generated ``__init__``
+       captures the literal default ``"/var/lib/eneru"`` at class
+       decoration time, so monkeypatching the class attribute is a
+       no-op for new instances. We replace ``__init__`` with a
+       wrapper that substitutes the isolated path when the caller
+       didn't supply one, regardless of how the dataclass was
+       generated.
+
+    2. ``StatsStore.__init__`` — direct ``StatsStore(Path("/var/lib/
+       eneru/foo.db"))`` calls (e.g. via TUI helpers) bypass
+       StatsConfig entirely. Redirect any ``db_path`` whose parent is
+       ``/var/lib/eneru`` into the isolated dir so it lands in
+       tmp_path instead.
+    """
+    if request.node.get_closest_marker("no_stats_isolation"):
+        yield None
+        return
+
     isolated = tmp_path / "stats"
     isolated.mkdir(parents=True, exist_ok=True)
+    isolated_str = str(isolated)
+    real_dir = Path("/var/lib/eneru")
+
+    # Layer 1: StatsConfig default.
+    original_cfg_init = eneru_config_module.StatsConfig.__init__
+
+    def patched_cfg_init(self, db_directory=isolated_str, **kw):
+        return original_cfg_init(self, db_directory=db_directory, **kw)
+
     monkeypatch.setattr(
-        eneru_config_module.StatsConfig,
-        "db_directory",
-        str(isolated),
+        eneru_config_module.StatsConfig, "__init__", patched_cfg_init,
     )
+
+    # Layer 2: direct StatsStore instantiation.
+    original_store_init = eneru_stats_module.StatsStore.__init__
+
+    def patched_store_init(self, db_path, *args, **kw):
+        try:
+            p = Path(db_path)
+        except TypeError:
+            return original_store_init(self, db_path, *args, **kw)
+        if p.parent == real_dir:
+            p = isolated / p.name
+        return original_store_init(self, p, *args, **kw)
+
+    monkeypatch.setattr(
+        eneru_stats_module.StatsStore, "__init__", patched_store_init,
+    )
+
     yield isolated
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,11 @@ def patch_run_command_everywhere():
     ``(0, "", "")`` by default; override per-test as needed.
     """
     targets = [
+        # eneru.utils is the home of `run_command`; patching it here too
+        # catches indirect callers that resolve through utils at call
+        # time (e.g. command_exists() in eneru.utils, which would
+        # otherwise still shell out during shutdown tests).
+        "eneru.utils.run_command",
         "eneru.monitor.run_command",
         "eneru.multi_ups.run_command",
         "eneru.shutdown.vms.run_command",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,10 +75,18 @@ def isolate_stats_db_directory(request, tmp_path, monkeypatch):
     real_dir = Path("/var/lib/eneru")
 
     # Layer 1: StatsConfig default.
+    # Use *args/**kw rather than baking `db_directory` into the
+    # signature. Today db_directory is the first dataclass field so
+    # `StatsConfig("/path")` works; if a future field is added before
+    # it, a positional call would misroute. Detect whether the caller
+    # actually supplied db_directory and only inject the isolated
+    # default when they didn't.
     original_cfg_init = eneru_config_module.StatsConfig.__init__
 
-    def patched_cfg_init(self, db_directory=isolated_str, **kw):
-        return original_cfg_init(self, db_directory=db_directory, **kw)
+    def patched_cfg_init(self, *args, **kw):
+        if "db_directory" not in kw and not args:
+            kw["db_directory"] = isolated_str
+        return original_cfg_init(self, *args, **kw)
 
     monkeypatch.setattr(
         eneru_config_module.StatsConfig, "__init__", patched_cfg_init,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,25 @@ from eneru import (
     MonitorState,
     ConfigLoader,
 )
+from eneru import config as eneru_config_module
+
+
+@pytest.fixture(autouse=True)
+def isolate_stats_db_directory(tmp_path, monkeypatch):
+    """Redirect every test's StatsConfig.db_directory default to a
+    per-test tmp_path so any code that constructs StatsConfig() without
+    overriding the field doesn't write SQLite files into the real
+    /var/lib/eneru. Without this fixture every test that instantiates
+    UPSGroupMonitor (or StatsStore directly) leaks `default.db` and
+    per-UPS DBs onto the host."""
+    isolated = tmp_path / "stats"
+    isolated.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        eneru_config_module.StatsConfig,
+        "db_directory",
+        str(isolated),
+    )
+    yield isolated
 
 
 @pytest.fixture
@@ -174,6 +193,39 @@ def mock_run_command():
     with patch("eneru.monitor.run_command") as mock:
         mock.return_value = (0, "", "")
         yield mock
+
+
+@pytest.fixture
+def patch_run_command_everywhere():
+    """Patch ``run_command`` in every module that imported it under its
+    own name. ``from eneru.utils import run_command`` binds the symbol
+    at import time, so ``patch("eneru.utils.run_command")`` is a no-op
+    for already-imported modules — tests that go through a shutdown
+    mixin (vms/containers/filesystems/remote) must patch each binding
+    explicitly or the mixin's call will hit real ``virsh``/``umount``/
+    ``ssh`` despite the test's intent.
+
+    Yields a dict mapping the module path → MagicMock so a test can
+    assert against any specific binding. Each mock returns
+    ``(0, "", "")`` by default; override per-test as needed.
+    """
+    targets = [
+        "eneru.monitor.run_command",
+        "eneru.multi_ups.run_command",
+        "eneru.shutdown.vms.run_command",
+        "eneru.shutdown.containers.run_command",
+        "eneru.shutdown.filesystems.run_command",
+        "eneru.shutdown.remote.run_command",
+    ]
+    patchers = [patch(t) for t in targets]
+    mocks = {t: p.start() for t, p in zip(targets, patchers)}
+    for m in mocks.values():
+        m.return_value = (0, "", "")
+    try:
+        yield mocks
+    finally:
+        for p in patchers:
+            p.stop()
 
 
 @pytest.fixture

--- a/tests/e2e/groups/multi-ups.sh
+++ b/tests/e2e/groups/multi-ups.sh
@@ -387,6 +387,13 @@ parse_epoch() {
   local line
   line=$(docker compose exec -T "$svc" cat /var/log/shutdown.log)
   local ts="${line%%: Shutdown*}"
+  # Fail loudly on empty timestamp instead of letting `date` produce a
+  # bogus "now" epoch that would silently corrupt the phase-ordering
+  # comparison below.
+  if [ -z "$ts" ]; then
+    echo "ERROR: parse_epoch($svc): /var/log/shutdown.log is empty or missing the expected prefix" >&2
+    return 1
+  fi
   date -d "$ts" +%s
 }
 

--- a/tests/e2e/groups/single-ups.sh
+++ b/tests/e2e/groups/single-ups.sh
@@ -34,14 +34,17 @@ sleep 3
 # Run Eneru for 5 seconds — should NOT trigger shutdown.
 # Capture eneru's exit code explicitly; the previous `|| true` masked
 # any crash (e.g. exit 1) and let the test pass even when eneru never
-# actually ran. 124 is timeout's SIGTERM (expected here); 0 is also
-# acceptable; anything else is a real failure.
+# actually ran. The ONLY acceptable exit is 124 (SIGTERM from timeout),
+# which proves the daemon was still running when the timer hit. A
+# clean 0 here would mean the daemon exited on its own — premature
+# termination during a "monitor normal state" check is itself a bug
+# this test must surface.
 set +e
 timeout 5 eneru run --config $E2E_DIR/config-e2e-dry-run.yaml 2>&1 | tee /tmp/test2.log
 RC=${PIPESTATUS[0]}
 set -e
-if [ "$RC" -ne 124 ] && [ "$RC" -ne 0 ]; then
-  echo "FAIL: eneru exited with code $RC (expected 0 or 124)"
+if [ "$RC" -ne 124 ]; then
+  echo "FAIL: eneru exited with code $RC (expected 124 = killed by timeout)"
   cat /tmp/test2.log
   exit 1
 fi

--- a/tests/e2e/groups/single-ups.sh
+++ b/tests/e2e/groups/single-ups.sh
@@ -31,8 +31,20 @@ echo "=== Test 2: Normal State Monitoring ==="
 cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
 sleep 3
 
-# Run Eneru for 5 seconds - should NOT trigger shutdown
-timeout 5 eneru run --config $E2E_DIR/config-e2e-dry-run.yaml 2>&1 | tee /tmp/test2.log || true
+# Run Eneru for 5 seconds — should NOT trigger shutdown.
+# Capture eneru's exit code explicitly; the previous `|| true` masked
+# any crash (e.g. exit 1) and let the test pass even when eneru never
+# actually ran. 124 is timeout's SIGTERM (expected here); 0 is also
+# acceptable; anything else is a real failure.
+set +e
+timeout 5 eneru run --config $E2E_DIR/config-e2e-dry-run.yaml 2>&1 | tee /tmp/test2.log
+RC=${PIPESTATUS[0]}
+set -e
+if [ "$RC" -ne 124 ] && [ "$RC" -ne 0 ]; then
+  echo "FAIL: eneru exited with code $RC (expected 0 or 124)"
+  cat /tmp/test2.log
+  exit 1
+fi
 
 # Verify no shutdown was triggered
 if grep -q "SHUTDOWN SEQUENCE" /tmp/test2.log; then
@@ -59,8 +71,18 @@ rm -f /tmp/eneru-e2e-shutdown-flag
 cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply.dev
 sleep 3
 
-# Run Eneru in dry-run mode
-eneru run --config $E2E_DIR/config-e2e-dry-run.yaml --exit-after-shutdown 2>&1 | tee /tmp/test3.log || true
+# Run Eneru in dry-run mode. With --exit-after-shutdown, eneru should
+# exit 0 once the dry-run shutdown sequence completes; anything else
+# is a real failure that the previous `|| true` was masking.
+set +e
+eneru run --config $E2E_DIR/config-e2e-dry-run.yaml --exit-after-shutdown 2>&1 | tee /tmp/test3.log
+RC=${PIPESTATUS[0]}
+set -e
+if [ "$RC" -ne 0 ]; then
+  echo "FAIL: eneru exited with code $RC (expected 0)"
+  cat /tmp/test3.log
+  exit 1
+fi
 
 # Verify shutdown was triggered (in dry-run)
 if ! grep -q "SHUTDOWN SEQUENCE" /tmp/test3.log; then

--- a/tests/e2e/scenarios/low-battery.dev
+++ b/tests/e2e/scenarios/low-battery.dev
@@ -1,9 +1,14 @@
-# Scenario: Low battery - should trigger shutdown (below 20% threshold)
+# Scenario: Low battery — should trigger shutdown via the LOW BATTERY
+# (charge < 20%) trigger, NOT via the critical-runtime trigger.
+# runtime is set ABOVE the 600 s critical-runtime threshold so the
+# shutdown is unambiguously attributable to the low-battery path; the
+# previous value of 180 s also crossed the critical-runtime threshold,
+# making test failures hard to localise.
 ups.status: OB DISCHRG LB
 ups.load: 35
 
 battery.charge: 15
-battery.runtime: 180
+battery.runtime: 900
 battery.voltage: 44.0
 
 input.voltage: 0.0

--- a/tests/e2e/scenarios/low-battery.dev
+++ b/tests/e2e/scenarios/low-battery.dev
@@ -1,13 +1,17 @@
 # Scenario: Low battery — should trigger shutdown via the LOW BATTERY
-# (charge < 20%) trigger, NOT via the critical-runtime trigger.
-# runtime is set ABOVE the 600 s critical-runtime threshold so the
-# shutdown is unambiguously attributable to the low-battery path; the
-# previous value of 180 s also crossed the critical-runtime threshold,
-# making test failures hard to localise.
+# (charge < threshold) trigger, NOT via the critical-runtime trigger.
+# runtime is ABOVE the 600 s critical-runtime threshold so the shutdown
+# is unambiguously attributable to the low-battery path; the previous
+# value of 180 s also crossed the critical-runtime threshold and made
+# failures hard to localise.
+# charge is 14 (not 15) so it fires both UPS1 (threshold 20, single-UPS
+# tests) AND UPS2 in tests/e2e/config-e2e-multi-ups.yaml (threshold 15).
+# The trigger uses strict `<`, so a value equal to the threshold doesn't
+# fire and Test 15 in multi-ups.sh would never trigger UPS2's shutdown.
 ups.status: OB DISCHRG LB
 ups.load: 35
 
-battery.charge: 15
+battery.charge: 14
 battery.runtime: 900
 battery.voltage: 44.0
 

--- a/tests/e2e/ssh-target/Dockerfile
+++ b/tests/e2e/ssh-target/Dockerfile
@@ -13,8 +13,11 @@ RUN adduser -D -s /bin/bash testuser && \
     echo "testuser:testpass" | chpasswd && \
     echo "testuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Generate host keys
-RUN ssh-keygen -A
+# Generate host keys. Alpine's openssh-server doesn't create
+# /var/run/sshd at install time, and sshd refuses to start without it
+# (it uses the directory as the privsep chroot). Without this mkdir
+# the container exits immediately after launch.
+RUN mkdir -p /var/run/sshd && ssh-keygen -A
 
 # Setup SSH directory for testuser
 RUN mkdir -p /home/testuser/.ssh && \

--- a/tests/e2e/ssh-target/entrypoint.sh
+++ b/tests/e2e/ssh-target/entrypoint.sh
@@ -21,5 +21,9 @@ echo "SSH target server starting..."
 echo "User: testuser"
 echo "Password: testpass (also accepts SSH keys)"
 
+# Defensive: re-create /var/run/sshd if a tmpfs / volume mount wiped
+# what the Dockerfile created. Cheap when the directory already exists.
+mkdir -p /var/run/sshd
+
 # Start sshd in foreground
 exec /usr/sbin/sshd -D -e

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,9 +232,19 @@ notifications:
 
     @pytest.mark.unit
     def test_validate_config_nonexistent_file(self, capsys):
-        """Test validating a non-existent configuration file."""
+        """Validate against a non-existent path: ConfigLoader.load
+        prints a warning and falls back to defaults; the resulting
+        defaults are valid, so exit is 0.
+
+        The original test asserted only `exit 0` and "Configuration
+        is valid", which would have passed even if the typo'd path
+        was silently ignored. This now also asserts the fallback
+        warning containing the typo'd path appears in stdout, so a
+        future regression that swallowed the warning would fail loud.
+        """
+        typo_path = "/nonexistent/path/config.yaml"
         with patch.object(sys, "argv", [
-            "eneru", "validate", "-c", "/nonexistent/path/config.yaml"
+            "eneru", "validate", "-c", typo_path,
         ]):
             with pytest.raises(SystemExit) as exc_info:
                 main()
@@ -243,6 +253,8 @@ notifications:
 
         captured = capsys.readouterr()
         assert "Configuration is valid" in captured.out
+        assert "Config file not found" in captured.out
+        assert typo_path in captured.out
 
     @pytest.mark.unit
     def test_validate_config_without_apprise(self, tmp_path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,7 +231,7 @@ notifications:
         assert "Title: UPS Alert" in captured.out
 
     @pytest.mark.unit
-    def test_validate_config_nonexistent_file(self, capsys):
+    def test_validate_config_nonexistent_file(self, tmp_path, capsys):
         """Validate against a non-existent path: ConfigLoader.load
         prints a warning and falls back to defaults; the resulting
         defaults are valid, so exit is 0.
@@ -241,8 +241,13 @@ notifications:
         was silently ignored. This now also asserts the fallback
         warning containing the typo'd path appears in stdout, so a
         future regression that swallowed the warning would fail loud.
+        Uses tmp_path so the assertion is deterministic across
+        environments (the previous hard-coded /nonexistent/path could
+        in theory exist on a developer machine).
         """
-        typo_path = "/nonexistent/path/config.yaml"
+        typo_path = str(tmp_path / "missing-config.yaml")
+        # Sanity: ensure we're not racing a pre-existing file in tmp_path.
+        assert not (tmp_path / "missing-config.yaml").exists()
         with patch.object(sys, "argv", [
             "eneru", "validate", "-c", typo_path,
         ]):

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -310,19 +310,25 @@ class TestFailsafe:
 
     @pytest.mark.unit
     def test_connection_lost_while_ob_triggers_shutdown(self, tmp_path):
-        """Connection failure while on battery triggers immediate shutdown."""
+        """Connection failure while on battery triggers immediate shutdown.
+
+        Routes through the real ``_main_loop`` via ``_run_one_iteration``
+        rather than inlining the failsafe logic — otherwise a regression
+        in the loop's failsafe path would leave this test green because
+        the assertions only check the inline simulation.
+        """
         monitor = make_monitor(tmp_path)
+        monitor._in_redundancy_group = False
         monitor.state.previous_status = "OB DISCHRG"
         monitor.state.connection_state = "OK"
+        # Trigger failsafe immediately (non-stale-data path).
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            TestAdvisoryTriggers._run_one_iteration(
+                monitor, (False, {}, "Network error"),
+            )
 
-        # Simulate the failsafe logic from _main_loop
-        is_failsafe_trigger = True
-        if is_failsafe_trigger and "OB" in monitor.state.previous_status:
-            monitor.state.connection_state = "FAILED"
-            monitor._shutdown_flag_path.touch()
-
+        mock_exec.assert_called_once()
         assert monitor.state.connection_state == "FAILED"
-        assert monitor._shutdown_flag_path.exists()
 
     @pytest.mark.unit
     def test_connection_lost_while_ol_enters_grace_period(self, tmp_path):
@@ -418,8 +424,14 @@ class TestShutdownSequence:
         assert flag_existed
 
     @pytest.mark.unit
-    def test_shutdown_continues_on_step_failure(self, tmp_path):
-        """Shutdown sequence continues even if a step raises an exception."""
+    def test_shutdown_aborts_on_step_failure(self, tmp_path):
+        """Documents current behavior: an unhandled exception inside a
+        shutdown step propagates up and ABORTS the remaining steps. The
+        steps themselves handle expected failures internally; only an
+        unexpected raise reaches the orchestrator. If we ever decide to
+        wrap each step in try/except so subsequent steps run as
+        best-effort, this test must change to assert the new contract.
+        """
         monitor = make_monitor(tmp_path)
         call_order = []
 
@@ -433,15 +445,11 @@ class TestShutdownSequence:
         monitor._unmount_filesystems = lambda: call_order.append("unmount")
         monitor._shutdown_remote_servers = lambda: call_order.append("remote")
 
-        # The sequence should not abort on VM failure
-        # (current implementation doesn't wrap each step in try/except,
-        # but the steps themselves handle errors internally)
-        try:
+        with pytest.raises(RuntimeError, match="VM shutdown failed"):
             monitor._execute_shutdown_sequence()
-        except RuntimeError:
-            pass
 
-        assert "vms" in call_order
+        # Only the failing step ran; subsequent steps did NOT execute.
+        assert call_order == ["vms"]
 
 
 # ==============================================================================

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -59,6 +59,30 @@ def make_monitor(tmp_path, **overrides):
     return monitor
 
 
+def _run_one_iteration(monitor, ups_data_response):
+    """Run ``_main_loop`` for exactly one iteration.
+
+    ``_main_loop`` calls ``self._stop_event.wait(timeout)`` at every
+    natural pause; we monkey-patch the wait so the first invocation
+    also sets the event. This guarantees one full pass through the
+    loop body before the loop exits. Promoted to module scope so any
+    test class can route through the real loop instead of inlining
+    the failsafe simulation.
+    """
+    original_wait = monitor._stop_event.wait
+    called = {"n": 0}
+
+    def wait_then_stop(timeout=None):
+        called["n"] += 1
+        monitor._stop_event.set()
+        return original_wait(0)
+
+    with patch.object(monitor, "_get_all_ups_data",
+                      return_value=ups_data_response):
+        with patch.object(monitor._stop_event, "wait", wait_then_stop):
+            monitor._main_loop()
+
+
 # ==============================================================================
 # STATUS STATE MACHINE
 # ==============================================================================
@@ -323,9 +347,7 @@ class TestFailsafe:
         monitor.state.connection_state = "OK"
         # Trigger failsafe immediately (non-stale-data path).
         with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
-            TestAdvisoryTriggers._run_one_iteration(
-                monitor, (False, {}, "Network error"),
-            )
+            _run_one_iteration(monitor, (False, {}, "Network error"))
 
         mock_exec.assert_called_once()
         assert monitor.state.connection_state == "FAILED"
@@ -1022,27 +1044,12 @@ class TestAdvisoryTriggers:
         mock_shutdown.assert_called_once()
         assert monitor.state.trigger_active is False  # legacy path doesn't set advisory
 
-    @staticmethod
-    def _run_one_iteration(monitor, ups_data_response):
-        """Run ``_main_loop`` for exactly one iteration.
-
-        ``_main_loop`` calls ``self._stop_event.wait(timeout)`` at every
-        natural pause; we monkey-patch the wait so the first invocation also
-        sets the event. This guarantees one full pass through the loop body
-        before the loop exits.
-        """
-        original_wait = monitor._stop_event.wait
-        called = {"n": 0}
-
-        def wait_then_stop(timeout=None):
-            called["n"] += 1
-            monitor._stop_event.set()
-            return original_wait(0)
-
-        with patch.object(monitor, "_get_all_ups_data",
-                          return_value=ups_data_response):
-            with patch.object(monitor._stop_event, "wait", wait_then_stop):
-                monitor._main_loop()
+    # _run_one_iteration moved to module scope (see top of this file)
+    # so other test classes can route through the real loop without
+    # cross-class coupling. Class-level shim kept for backward
+    # compatibility with the existing self._run_one_iteration calls
+    # below.
+    _run_one_iteration = staticmethod(_run_one_iteration)
 
     @pytest.mark.unit
     def test_fsd_advisory_in_redundancy_group(self, tmp_path):

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1276,7 +1276,10 @@ class TestCoordinatorDrainEdgeCases:
 
         coord._drain_all_groups(timeout=0)
 
-        live_thread.join.assert_called_once()
+        # _drain_all_groups now joins twice per thread: a short window after
+        # signaling stop_event so peer monitors finish their poll cycle,
+        # then a final wait once the per-monitor shutdown sequences have run.
+        assert live_thread.join.called
         assert any("still running after drain timeout" in m for m in logs)
 
 

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -705,3 +705,73 @@ class TestExecutorNotificationContent:
         assert "quorum lost" in body
         assert "UPS-X@\u200Bh" in body
         assert "UPS-Y@\u200Bh" in body
+
+
+class TestLocalShutdownCallback:
+    """5.1.1 fix: an is_local redundancy group must invoke the
+    coordinator's _handle_local_shutdown after the remote-shutdown
+    phase. Without this, quorum loss completed cleanly with the local
+    host still running."""
+
+    @pytest.mark.unit
+    def test_callback_fires_on_is_local_quorum_loss(self, tmp_path):
+        callback = MagicMock()
+        group = _redundancy_group(name="rack-local", is_local=True)
+        ex = RedundancyGroupExecutor(
+            group, base_config=_base_config(tmp_path=tmp_path),
+            local_shutdown_callback=callback,
+        )
+        ex.shutdown(reason="quorum lost")
+        callback.assert_called_once()
+        # The reason carries the redundancy group's name so the
+        # coordinator's defense-in-depth lock log can attribute it.
+        assert "rack-local" in callback.call_args[0][0]
+
+    @pytest.mark.unit
+    def test_callback_NOT_invoked_for_non_local_group(self, tmp_path):
+        # is_local=False is the typical "managed remote rack" case;
+        # the local poweroff must NEVER fire on this path even when
+        # a callback is wired up.
+        callback = MagicMock()
+        group = _redundancy_group(name="rack-remote", is_local=False)
+        ex = RedundancyGroupExecutor(
+            group, base_config=_base_config(tmp_path=tmp_path),
+            local_shutdown_callback=callback,
+        )
+        ex.shutdown(reason="quorum lost")
+        callback.assert_not_called()
+
+    @pytest.mark.unit
+    def test_callback_optional_no_crash_when_unset(self, tmp_path):
+        # Single-UPS-coordinator-less setups won't wire a callback.
+        # The executor must not raise when local_shutdown_callback=None.
+        group = _redundancy_group(name="standalone", is_local=True)
+        ex = RedundancyGroupExecutor(
+            group, base_config=_base_config(tmp_path=tmp_path),
+            # No local_shutdown_callback supplied -> defaults to None.
+        )
+        # Must not raise.
+        assert ex.shutdown(reason="quorum lost") is True
+
+    @pytest.mark.unit
+    def test_callback_skipped_when_remote_shutdown_raises(self, tmp_path):
+        # The callback is positioned AFTER _shutdown_remote_servers
+        # inside the try-block, so an exception in remote shutdown
+        # short-circuits the callback. The coordinator's monitor-side
+        # path can still trigger local shutdown via its own lock; the
+        # redundancy callback is a redundant signal in that scenario.
+        callback = MagicMock()
+        group = _redundancy_group(name="rack-local", is_local=True)
+        ex = RedundancyGroupExecutor(
+            group, base_config=_base_config(tmp_path=tmp_path),
+            local_shutdown_callback=callback,
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            def boom():
+                raise RuntimeError("ssh dead")
+            mp.setattr(ex, "_shutdown_remote_servers", boom)
+            ex.shutdown(reason="quorum lost")
+        # Exception was caught by the executor's try/except; the
+        # callback was NOT invoked because the raise happened before
+        # the callback line in the try-block.
+        callback.assert_not_called()

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -362,6 +362,12 @@ class TestEvaluatorThreadLifecycle:
         )
         ev.start()
         time.sleep(0.15)
+        # F3: assert the evaluator thread survived the exception storm
+        # BEFORE we signal stop. A thread killed by the unhandled
+        # RuntimeError would still leave `not ev.is_alive()` True after
+        # join (a dead thread joins instantly), so the original test
+        # would silently pass even if the swallowing contract broke.
+        assert ev.is_alive()
         stop_event.set()
         ev.join(timeout=2)
         assert not ev.is_alive()

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -119,6 +119,33 @@ class TestRemoteActionTemplates:
         assert "{path}" not in result
         assert "t=30" in result
 
+    @pytest.mark.unit
+    def test_stop_xcpng_vms_binds_uuid_via_xargs_placeholder(self):
+        """The xe template must bind UUIDs into uuid= via xargs -I {},
+        not pass them positionally — `xe` parses arguments as key=value
+        pairs and silently ignores positional UUIDs."""
+        template = REMOTE_ACTIONS["stop_xcpng_vms"]
+        rendered = template.format(timeout=120)
+        # Both the graceful and force passes must bind UUID via xargs -I {}.
+        assert "xargs -r -I {} xe vm-shutdown uuid={}" in rendered
+        # Force pass uses xe's key=value form, not --force.
+        assert "force=true" in rendered
+        assert "--force" not in rendered
+        # The bug pattern (uuid= with no following bound value) must not appear.
+        assert "uuid= " not in rendered
+        assert "uuid=\n" not in rendered
+        assert "uuid=2" not in rendered  # not joined with the next arg either
+
+    @pytest.mark.unit
+    def test_stop_compose_template_does_not_double_quote_path(self):
+        """stop_compose must leave {path} unquoted in the template; quoting
+        happens via shlex.quote at the format() call site so $(), backticks,
+        and ${...} cannot expand on the remote host."""
+        template = REMOTE_ACTIONS["stop_compose"]
+        # Bare placeholder, no surrounding double quotes.
+        assert '"{path}"' not in template
+        assert "-f {path}" in template
+
 
 class TestRemotePreShutdownExecution:
     """Test remote pre-shutdown command execution logic."""
@@ -400,6 +427,38 @@ class TestRemotePreShutdownExecution:
 
             assert result is True
             mock_run.assert_not_called()
+
+    @pytest.mark.unit
+    def test_stop_compose_path_is_shell_quoted(self, remote_monitor):
+        """A path containing shell metacharacters must be shlex-quoted by
+        _execute_remote_pre_shutdown before it lands in the rendered command,
+        so $(), backticks, and ${...} cannot expand on the remote host."""
+        import shlex
+
+        malicious_path = "/tmp/$(rm -rf /)/docker-compose.yml"
+        server = RemoteServerConfig(
+            name="Test Server",
+            enabled=True,
+            host="192.168.1.50",
+            user="root",
+            command_timeout=30,
+            pre_shutdown_commands=[
+                RemoteCommandConfig(
+                    action="stop_compose",
+                    path=malicious_path,
+                    timeout=30,
+                ),
+            ],
+        )
+
+        with patch.object(remote_monitor, "_run_remote_command") as mock_run:
+            mock_run.return_value = (True, "")
+            remote_monitor._execute_remote_pre_shutdown(server)
+
+        rendered = mock_run.call_args[0][1]
+        # The path must appear in its shlex-quoted form so the remote shell
+        # treats it as a literal string.
+        assert shlex.quote(malicious_path) in rendered
 
     @pytest.mark.unit
     def test_dry_run_skips_remote_commands(self, remote_monitor):

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -273,6 +273,35 @@ class TestRemotePreShutdownExecution:
             mock_run.assert_not_called()
 
     @pytest.mark.unit
+    def test_stop_compose_without_path_does_not_render_template(self, remote_monitor):
+        """5.1.1 fix: the path-presence check now runs BEFORE the
+        REMOTE_ACTIONS template is fetched/rendered with shlex.quote("").
+        Validate by patching .format on the template string and asserting
+        it was never called when path is missing — proves the precondition
+        is authoritative rather than a dead-code warning after rendering.
+        """
+        from eneru import REMOTE_ACTIONS
+        server = RemoteServerConfig(
+            name="Test Server",
+            enabled=True,
+            host="192.168.1.50",
+            user="root",
+            command_timeout=30,
+            pre_shutdown_commands=[
+                RemoteCommandConfig(action="stop_compose"),  # No path!
+            ],
+        )
+        with patch.dict(
+            REMOTE_ACTIONS,
+            {"stop_compose": MagicMock(wraps=REMOTE_ACTIONS["stop_compose"])},
+        ) as patched:
+            with patch.object(remote_monitor, "_run_remote_command") as mock_run:
+                remote_monitor._execute_remote_pre_shutdown(server)
+            # The template's .format must not have been invoked at all.
+            patched["stop_compose"].format.assert_not_called()
+            mock_run.assert_not_called()
+
+    @pytest.mark.unit
     def test_execute_pre_shutdown_unknown_action_skipped(self, remote_monitor):
         """Test that unknown action is skipped."""
         server = RemoteServerConfig(

--- a/tests/test_shutdown_filesystems.py
+++ b/tests/test_shutdown_filesystems.py
@@ -134,6 +134,47 @@ def test_unmount_filesystems_includes_options(tmp_path):
 
 
 @pytest.mark.unit
+def test_unmount_filesystems_multi_flag_options_split(tmp_path):
+    """Multi-flag option strings like "-l -f" must be split into
+    separate argv entries; the previous cmd.append(options) was passing
+    them as one argument and umount rejected the literal as unknown."""
+    monitor = _make_fs_monitor(
+        tmp_path, mounts=[{"path": "/mnt/data", "options": "-l -f"}],
+    )
+    with patch("eneru.shutdown.filesystems.run_command", return_value=(0, "", "")) as mock_run:
+        monitor._unmount_filesystems()
+    cmd = mock_run.call_args.args[0]
+    assert cmd == ["umount", "-l", "-f", "/mnt/data"]
+
+
+@pytest.mark.unit
+def test_unmount_filesystems_malformed_options_skip_mount(tmp_path, capsys):
+    """A malformed options string (unclosed quote) used to crash the
+    shutdown sequence with ValueError out of shlex.split. Cubic P1:
+    catch and skip the offending mount instead of propagating."""
+    monitor = _make_fs_monitor(
+        tmp_path,
+        mounts=[
+            {"path": "/mnt/bad", "options": '"unclosed'},
+            {"path": "/mnt/good", "options": "-l"},
+        ],
+    )
+    monitor.logger = MagicMock()
+    with patch("eneru.shutdown.filesystems.run_command", return_value=(0, "", "")) as mock_run:
+        # Must not raise.
+        monitor._unmount_filesystems()
+    # Only the good mount reached run_command; the bad one was skipped.
+    cmds = [c.args[0] for c in mock_run.call_args_list]
+    assert ["umount", "-l", "/mnt/good"] in cmds
+    assert all(c[1] != "/mnt/bad" for c in cmds), \
+        "malformed-options mount must NOT reach umount"
+    # And the failure was logged with the offending mount path.
+    log_lines = [str(c) for c in monitor.logger.log.call_args_list]
+    assert any("/mnt/bad" in line and "Invalid umount options" in line
+               for line in log_lines)
+
+
+@pytest.mark.unit
 def test_unmount_filesystems_timeout_proceeds(tmp_path):
     """umount returning 124 (timeout) is logged but does not raise."""
     monitor = _make_fs_monitor(tmp_path)

--- a/tests/test_shutdown_filesystems.py
+++ b/tests/test_shutdown_filesystems.py
@@ -111,6 +111,47 @@ def test_unmount_filesystems_dry_run_skips_real_call(tmp_path):
 
 
 @pytest.mark.unit
+def test_unmount_filesystems_dry_run_log_renders_actual_argv(tmp_path):
+    """5.1.1 (CodeRabbit): the dry-run log line used to print the raw
+    `options` string (`umount -l -f /mnt`), which doesn't match the
+    actual argv that would be exec'd after shlex.split. Confirm the
+    log renders the same tokenized form as a real run."""
+    monitor = _make_fs_monitor(
+        tmp_path, mounts=[{"path": "/mnt/data", "options": "-l -f"}],
+        dry_run=True,
+    )
+    monitor.logger = MagicMock()
+    monitor._unmount_filesystems()
+    log_lines = [str(c) for c in monitor.logger.log.call_args_list]
+    # The dry-run line must contain the tokens as they would appear in
+    # the argv (separately quoted by shlex.quote where needed).
+    dry_run_line = next(line for line in log_lines if "DRY-RUN" in line)
+    assert "umount -l -f /mnt/data" in dry_run_line, (
+        f"dry-run log must show real argv form; got: {dry_run_line!r}"
+    )
+
+
+@pytest.mark.unit
+def test_unmount_filesystems_dry_run_catches_malformed_options(tmp_path):
+    """5.1.1: malformed options are caught even in dry-run so a config
+    error surfaces BEFORE the operator runs the daemon for real."""
+    monitor = _make_fs_monitor(
+        tmp_path,
+        mounts=[{"path": "/mnt/bad", "options": '"unclosed'}],
+        dry_run=True,
+    )
+    monitor.logger = MagicMock()
+    with patch("eneru.shutdown.filesystems.run_command") as mock_run:
+        monitor._unmount_filesystems()  # Must not raise
+    mock_run.assert_not_called()
+    log_lines = [str(c) for c in monitor.logger.log.call_args_list]
+    assert any("Invalid umount options" in line and "/mnt/bad" in line
+               for line in log_lines), (
+        "dry-run must surface the malformed-options error too"
+    )
+
+
+@pytest.mark.unit
 def test_unmount_filesystems_success(tmp_path):
     """Successful umount logs success and stops."""
     monitor = _make_fs_monitor(tmp_path)

--- a/tests/test_shutdown_vms.py
+++ b/tests/test_shutdown_vms.py
@@ -111,9 +111,20 @@ def test_shutdown_vms_graceful_shutdown_completes_first_poll(tmp_path):
         (0, "", ""),                # poll: no VMs running
     ]
     with patch("eneru.shutdown.vms.command_exists", return_value=True), \
-         patch("eneru.shutdown.vms.run_command", side_effect=call_outputs), \
+         patch("eneru.shutdown.vms.run_command", side_effect=call_outputs) as mock_run, \
          patch("eneru.shutdown.vms.time.sleep"):
         monitor._shutdown_vms()
+
+    # Assert the actual virsh command sequence — without this, the test
+    # passed even when the wrong command (or no command at all) was
+    # issued during shutdown.
+    issued = [c.args[0] for c in mock_run.call_args_list]
+    assert issued[0] == ["virsh", "list", "--name", "--state-running"]
+    # Per-VM shutdowns are issued in the order virsh list returned them.
+    assert ["virsh", "shutdown", "vm1"] in issued
+    assert ["virsh", "shutdown", "vm2"] in issued
+    # No `destroy` should fire when graceful shutdown completes cleanly.
+    assert not any(c[:2] == ["virsh", "destroy"] for c in issued)
 
 
 @pytest.mark.unit

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1110,3 +1110,54 @@ ups:
         config = ConfigLoader.load(str(cfg_path))
         assert config.statistics.db_directory == "/var/lib/eneru"
         assert config.statistics.retention.raw_hours == 24
+
+
+# ===========================================================================
+# 5.1.1 (CodeRabbit): isolate_stats_db_directory fixture must tolerate
+# StatsConfig signature growth. The fixture is the user-facing guard
+# against test runs writing into /var/lib/eneru, so its `*args/**kw`
+# wrapper has to be exercised across the supported call shapes.
+# ===========================================================================
+
+
+class TestIsolateStatsDbDirectoryFixture:
+    """The autouse fixture wraps StatsConfig.__init__ with a *args/**kw
+    shim. Verify it injects the isolated default ONLY when the caller
+    didn't supply one — keyword and positional callers must keep their
+    explicit value."""
+
+    @pytest.mark.unit
+    def test_default_construction_uses_isolated_path(self, tmp_path):
+        # No args, no kwargs → the autouse fixture must inject its
+        # tmp_path-rooted default; the production "/var/lib/eneru" must
+        # never appear here.
+        cfg = StatsConfig()
+        assert cfg.db_directory != "/var/lib/eneru"
+        assert "stats" in cfg.db_directory  # fixture writes under tmp_path/stats
+
+    @pytest.mark.unit
+    def test_explicit_keyword_db_directory_is_preserved(self):
+        # Caller passed db_directory by keyword → fixture must NOT
+        # overwrite it.
+        cfg = StatsConfig(db_directory="/srv/explicit")
+        assert cfg.db_directory == "/srv/explicit"
+
+    @pytest.mark.unit
+    def test_explicit_positional_db_directory_is_preserved(self):
+        # Caller passed db_directory positionally → fixture must NOT
+        # overwrite it. Today db_directory is the first dataclass
+        # field; if a future field is added before it, this test will
+        # fail loud and the fixture wrapper needs another look.
+        cfg = StatsConfig("/srv/positional")
+        assert cfg.db_directory == "/srv/positional"
+
+    @pytest.mark.unit
+    def test_other_kwargs_pass_through(self):
+        # The wrapper must forward unrelated kwargs untouched.
+        from eneru.config import StatsRetentionConfig
+        retention = StatsRetentionConfig(raw_hours=48)
+        cfg = StatsConfig(retention=retention)
+        # db_directory still gets the isolated default…
+        assert cfg.db_directory != "/var/lib/eneru"
+        # …and the explicit retention came through.
+        assert cfg.retention.raw_hours == 48

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1060,6 +1060,7 @@ class TestEdgeCases:
 class TestStatsConfig:
 
     @pytest.mark.unit
+    @pytest.mark.no_stats_isolation
     def test_defaults(self):
         cfg = StatsConfig()
         assert cfg.db_directory == "/var/lib/eneru"
@@ -1098,6 +1099,7 @@ statistics:
         assert config.statistics.retention.agg_hourly_days == 90
 
     @pytest.mark.unit
+    @pytest.mark.no_stats_isolation
     def test_default_yaml_omitted_section(self, tmp_path):
         from eneru import ConfigLoader
         cfg_path = tmp_path / "config.yaml"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -128,6 +128,60 @@ class TestEventsTimescaleDecoupled:
         )
 
 
+class TestKeypadEnabled:
+    """5.1.1 (cubic P1): the curses TUI must enable keypad translation
+    or arrow / page / home / end keys arrive as raw escape sequences and
+    the leading ESC byte hits the quit branch instead of scrolling."""
+
+    @pytest.mark.unit
+    def test_run_tui_enables_keypad_mode(self):
+        import inspect
+        import re as _re
+        from eneru import tui as tui_mod
+
+        src = inspect.getsource(tui_mod.run_tui)
+        # `stdscr.keypad(True)` must be called before the input loop
+        # binds curses.KEY_* constants; without it those constants are
+        # never delivered (curses returns the raw escape sequence).
+        assert _re.search(r"stdscr\.keypad\s*\(\s*True\s*\)", src), (
+            "run_tui must call stdscr.keypad(True) so KEY_UP/KEY_DOWN/"
+            "KEY_PPAGE/KEY_NPAGE/KEY_HOME/KEY_END are delivered as the "
+            "expected curses key codes."
+        )
+
+
+class TestEventsScrollAutoPromote:
+    """5.1.1 (CodeRabbit): scrolling toward older history while in
+    normal-cap mode (8 rows) used to be a silent no-op because the
+    cap matched the visible window. ↑ / PgUp / Home now auto-promote
+    show_more=True so scroll has somewhere to scroll to."""
+
+    @pytest.mark.unit
+    def test_arrow_keys_auto_promote_show_more(self):
+        import inspect
+        from eneru import tui as tui_mod
+
+        src = inspect.getsource(tui_mod.run_tui)
+        # The branch must group KEY_UP / KEY_PPAGE / KEY_HOME together
+        # and assign show_more = True before performing the scroll math.
+        # Match the structural pattern rather than exact whitespace so
+        # a re-format doesn't break the test.
+        assert "curses.KEY_UP" in src
+        assert "curses.KEY_PPAGE" in src
+        assert "curses.KEY_HOME" in src
+        # show_more flips to True inside the auto-promote branch.
+        idx_up = src.find("curses.KEY_UP, curses.KEY_PPAGE, curses.KEY_HOME")
+        assert idx_up >= 0, (
+            "auto-promote branch must group KEY_UP / KEY_PPAGE / KEY_HOME "
+            "into a single elif so show_more flips before scrolling"
+        )
+        following = src[idx_up:idx_up + 800]
+        assert "show_more = True" in following, (
+            "auto-promote branch must set show_more = True before the "
+            "scroll math runs"
+        )
+
+
 class TestGraphPanelHeader:
     """Item 3: graph panel renders a now/min/max stat header with units."""
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -97,40 +97,34 @@ class TestFillRow:
 
 
 class TestEventsTimescaleDecoupled:
-    """Item 4: events panel must NOT change when graph timescale changes."""
+    """Events panel pulls every event and ignores the graph timescale."""
 
     @pytest.mark.unit
-    def test_events_use_fixed_window_independent_of_time_range(self):
-        """The events query window is a fixed constant -- pressing T to
-        cycle the graph timescale must not pass a new window into
-        query_events_for_display.
+    def test_events_query_passes_no_time_window(self):
+        """``query_events_for_display`` must be called WITHOUT a
+        time_range_seconds argument (or with None), so the panel always
+        sees every event in the SQLite store. Pressing T to cycle the
+        graph timescale must not feed a dynamic window in here.
         """
         import inspect
         import re as _re
-        from eneru.tui import EVENTS_TIME_WINDOW
         from eneru import tui as tui_mod
 
-        # The constant exists and is the documented 24 hours.
-        assert EVENTS_TIME_WINDOW == 24 * 3600
-
-        # The actual call site to query_events_for_display must pass
-        # EVENTS_TIME_WINDOW as the window argument. Match the call
-        # specifically rather than just looking for the symbol anywhere
-        # in the function body, so a stray comment can't hide a real
-        # regression where the call site goes back to the dynamic
-        # TIME_RANGE_SECONDS pattern.
         src = inspect.getsource(tui_mod.run_tui)
+        # The call must NOT pass TIME_RANGE_SECONDS or any positional
+        # time-range argument; only `config` and the keyword `max_events`.
+        assert "TIME_RANGE_SECONDS.get(time_range" not in src, (
+            "run_tui re-introduces a dynamic time-range window for events; "
+            "the panel must scan the full events table."
+        )
+        # Confirm the call site uses keyword max_events (no positional
+        # second argument that could become a window).
         call_re = _re.compile(
-            r"query_events_for_display\s*\(\s*config\s*,\s*EVENTS_TIME_WINDOW",
+            r"query_events_for_display\s*\(\s*config\s*,\s*max_events\s*=",
         )
         assert call_re.search(src), (
-            "run_tui must call query_events_for_display(config, EVENTS_TIME_WINDOW, ...) "
-            "-- not a dynamic TIME_RANGE_SECONDS-based window."
-        )
-        # And the dynamic pattern must not appear at the events call site.
-        assert "TIME_RANGE_SECONDS.get(time_range" not in src, (
-            "run_tui re-introduces the dynamic events window pattern; "
-            "see the EVENTS_TIME_WINDOW decoupling fix."
+            "run_tui must call query_events_for_display(config, max_events=...) "
+            "with no positional time-range argument."
         )
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -557,13 +557,15 @@ class TestLiveBufferBlending:
         )
 
     def _write_state_file(self, path: Path, charge: float, voltage: float):
+        # Match UPSGroupMonitor._save_state's actual on-disk format:
+        # uppercase KEY=value lines, NOT NUT's dotted lowercase.
         path.write_text(
-            "ups.status=OL CHRG\n"
-            f"battery.charge={charge}\n"
-            "battery.runtime=1800\n"
-            "ups.load=30\n"
-            f"input.voltage={voltage}\n"
-            "output.voltage=230\n"
+            "STATUS=OL CHRG\n"
+            f"BATTERY={charge}\n"
+            "RUNTIME=1800\n"
+            "LOAD=30\n"
+            f"INPUT_VOLTAGE={voltage}\n"
+            "OUTPUT_VOLTAGE=230\n"
         )
 
     @pytest.mark.unit

--- a/tests/test_voltage.py
+++ b/tests/test_voltage.py
@@ -558,6 +558,86 @@ class TestSeverityBypass:
 
 
 # ===========================================================================
+# F1 (5.1.1): severity escalation within the same LOW/HIGH state must
+# refresh `voltage_pending_severe` so the immediate-notify bypass fires.
+# ===========================================================================
+
+class TestVoltageSeverityEscalation:
+    """A brownout that worsens past the severe threshold AFTER the LOW
+    state was already pending must lift the pending record's severe
+    flag (and refresh the recorded voltage / threshold) so the next
+    `_maybe_notify_voltage_pending` fires immediately. Without this,
+    operators would wait the full hysteresis window for an alert that
+    should have been immediate."""
+
+    @pytest.mark.unit
+    def test_mild_then_severe_escalates_to_immediate_notify(self):
+        h = _TestHost(ups_vars={"input.voltage.nominal": "230"}, hysteresis=30)
+        h._initialize_voltage_thresholds()
+
+        # Poll 1: mild brownout (200V, 13.0% below 230V). Pending state
+        # is opened but no notification — dwell in effect.
+        h._check_voltage_issues("OL", "200")
+        assert h.state.voltage_state == "LOW"
+        assert h.state.voltage_pending_state == "LOW"
+        assert h.state.voltage_pending_severe is False
+        assert h.notifications == []
+        assert h.state.voltage_pending_voltage == 200.0
+
+        # Poll 2: deviation worsens past the 15% severe threshold
+        # (180V, 21.7% below). State is unchanged (still LOW), so the
+        # state-transition branch in _check_voltage_issues doesn't fire.
+        # The escalation branch must lift `voltage_pending_severe` and
+        # refresh the recorded voltage / threshold; then
+        # _maybe_notify_voltage_pending fires immediately.
+        h._check_voltage_issues("OL", "180")
+        assert h.state.voltage_state == "LOW"  # unchanged
+        assert h.state.voltage_pending_severe is True
+        assert h.state.voltage_pending_voltage == 180.0
+        assert h.notifications, "severity escalation must fire immediate notify"
+        body, _ = h.notifications[0]
+        assert "BROWNOUT_DETECTED" in body
+        assert "(severe," in body
+        assert "Notifying immediately" in body
+
+    @pytest.mark.unit
+    def test_escalation_does_not_fire_after_already_notified(self):
+        # Once a notification has been dispatched, the escalation branch
+        # must NOT re-mark the record severe (would be harmless but
+        # would muddy the state machine). Reuse the severe-bypass path
+        # to consume the notification, then push a more severe reading.
+        h = _TestHost(ups_vars={"input.voltage.nominal": "230"}, hysteresis=30)
+        h._initialize_voltage_thresholds()
+        h._check_voltage_issues("OL", "180")  # severe immediately
+        assert h.state.voltage_pending_notified is True
+        notif_count = len(h.notifications)
+
+        # Worsen further; pending_notified gate must keep us silent.
+        h._check_voltage_issues("OL", "150")
+        assert h.state.voltage_pending_notified is True
+        assert len(h.notifications) == notif_count, (
+            "no second notification should fire while pending is already notified"
+        )
+
+    @pytest.mark.unit
+    def test_high_side_escalation_also_refreshes(self):
+        # Symmetry check on the OVER_VOLTAGE path.
+        h = _TestHost(ups_vars={"input.voltage.nominal": "230"}, hysteresis=30)
+        h._initialize_voltage_thresholds()
+        h._check_voltage_issues("OL", "260")  # mild HIGH (~13%)
+        assert h.state.voltage_pending_state == "HIGH"
+        assert h.state.voltage_pending_severe is False
+        assert h.notifications == []
+
+        h._check_voltage_issues("OL", "280")  # 21.7% — severe
+        assert h.state.voltage_pending_severe is True
+        assert h.notifications
+        body, _ = h.notifications[0]
+        assert "OVER_VOLTAGE_DETECTED" in body
+        assert "(severe," in body
+
+
+# ===========================================================================
 # rc9: notification text -- grid-quality framing + UPS-switch context
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Bug-fix release with one small TUI improvement. Bundles the actionable findings from a third-party AI code review (CodeRabbit Pro + Cubic.Dev) of the v5.1.0 codebase. Drop-in upgrade.

Each commit is one themed group; see the commit body for the per-fix bullets with reviewer attribution.

## Commit groups

- **fix(security)** — XCP-ng vm-shutdown UUID binding, shell-quoted compose path, pypi workflow input validation + build/publish split for OIDC scope.
- **fix(operational)** — silent config drops (`notifications.suppress` + multi-UPS `statistics`), `is_local` redundancy local poweroff, multi-UPS state-file write race, TUI live-blending key mismatch, virsh-list exit unchecked in wait loop, umount multi-flag options, voltage severity escalation (F1), shutdown/remote.py robustness, graph.py correctness, battery.py / logger.py / stats.py / utils.py / cli.py fixes, bash completion quoting.
- **fix(packaging)** — pyproject version target, DEB prerm/postrm lifecycle handling, `daemon-reload` chroot guard, postinstall fresh-vs-upgrade disambiguation.
- **fix(ci)** — gh-pages force-push removal, nFPM pinning + checksum, integration `|| true` removal, e2e readiness fail-fast, codeql `contents:read`, every action SHA-pinned across all workflows, ssh-target `/var/run/sshd` creation, reference-config corrections (SSH host key checking, Apprise URL formats, `compose_files: []`, F2 homelab `parallel: false` comment).
- **test** — autouse `StatsConfig`/`StatsStore` isolation fixture (production `/var/lib/eneru` no longer leaks from tests), multi-namespace `run_command` patching helper, failsafe tests routed through real `_main_loop`, F3 thread-survival assertion in redundancy evaluator, e2e exit-code capture via `PIPESTATUS`, low-battery scenario runtime above critical threshold, virsh happy-path command sequence assertions.
- **chore(cleanup)** — version docstring refresh, `format_seconds` negative clamp, `is_numeric` rejects bool/NaN/Inf, hardened logger handler cleanup, **legacy `ups-monitor` syslog tag renamed to `eneru`** (power events were going to journalctl under the pre-v5.0 identifier).
- **feat(tui)** — events panel drops the 24h truncation; `↑/↓` / `PgUp`/`PgDn` / `Home`/`End` scroll through full history; `<M>` toggles 8↔500 visible rows.
- **chore(release)** — version bump to 5.1.1 + changelog entry (subsequently trimmed to bug-fix-release scale).

## Test plan

- [ ] All 10 required CI checks pass (`validate` × 6 Python versions + 4 E2E matrix jobs)
- [ ] Manual smoke: `sudo python3 /opt/ups-monitor/eneru.py --validate-config <example>` after building the deb
- [ ] Verify TUI events panel scrolling against a UPS with multi-day history (`<↑>`/`<↓>`, `<Home>`/`<End>`)
- [ ] Verify journalctl now shows power events under `-t eneru` (was `-t ups-monitor`)
- [ ] Confirm no test run leaks new files into `/var/lib/eneru/`

## Notes

- AI re-review (`@coderabbitai full review` + `@cubic-dev-ai review this pull request`) is gated on operator approval per the project's quota-conservation policy in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bug-fix release with one TUI improvement: the events panel now scrolls through full history. Includes security hardening, CI/packaging fixes, and multiple correctness fixes. Drop‑in upgrade.

- **Bug Fixes**
  - TUI: events panel shows full history with arrow/page/home scrolling; keypad enabled so keys work reliably; first scroll auto-expands; <M> toggles 8↔500 rows.
  - Filesystems: multi‑flag umount options are split correctly; malformed options are logged and skipped (also in dry‑run), and dry‑run logs show the exact argv.
  - XCP‑ng/XenServer shutdown binds UUIDs correctly and uses `force=true`.
  - Live graph blending uses uppercase state‑file keys; no right‑edge lag.
  - Multi‑UPS: per‑UPS temp files prevent state/history write races.
  - Redundancy `is_local`: quorum loss now powers off the host.
  - VM shutdown: `virsh list` failures no longer yield false “all stopped”; force‑destroy still runs.
  - Voltage alerts escalate to severe while pending when thresholds are crossed.
  - Config parsing restores `notifications.suppress`, `voltage_hysteresis_seconds`, and multi‑UPS `statistics`.
  - Power events syslog tag renamed to `eneru` (was `ups-monitor`).

- **Security, CI, and Packaging**
  - Remote `stop_compose` path is `shlex.quote`d; template no longer double‑quotes.
  - PyPI workflow split: build and publish separated; version input validated; OIDC `id-token: write` limited to publish.
  - All GitHub Actions SHA‑pinned; refresh instructions added to each workflow; maintenance guide added to `CLAUDE.md`.
  - Release workflow serializes `gh-pages` deploys to avoid concurrent races; no `git push -f` to `gh-pages`.
  - CI installs fail fast (dropped `|| true` masks); readiness checks error on timeout; added CodeQL `contents: read`; E2E low‑battery scenario tuned to fire against all thresholds.
  - DEB lifecycle scripts handle all states; guarded `systemctl daemon-reload` when systemd isn’t present.
  - `pyproject.toml` now reads version from `eneru.version.__version__`; examples use safer SSH defaults, correct Slack Apprise URL, `compose_files: []`, and fixed NAS shutdown ordering.

<sup>Written for commit e9ae4fcf70ba0ed42dd40ffed798e5c08007d0ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 5.1.1

* **New Features**
  * TUI now displays full event history with arrow-key, page, and home/end scrolling instead of fixed 24-hour window.
  * Added toggle to adjust maximum visible event rows.

* **Bug Fixes**
  * Fixed VM shutdown parameter binding for XCP-ng/XenServer.
  * Corrected voltage severity re-evaluation logic.
  * Resolved battery anomaly false-alert suppression.
  * Fixed multi-UPS temp file race conditions.
  * Improved VM shutdown loop stability.
  * Fixed shell command timeout handling.

* **Security**
  * Removed insecure SSH defaults; now enforces known_hosts verification.
  * Added shell injection mitigation in remote commands.
  * Enabled SHA-pinning in CI/build workflows.

* **Documentation**
  * Updated configuration examples for security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->