### PR TITLE
feat(notifications): v5.2.0 stateful notifications + lossless delivery

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,14 @@ jobs:
           e2e-dir: ${{ env.E2E_DIR }}
 
       - name: "Run E2E group: ${{ matrix.label }}"
+        env:
+          # Test 7 (single-ups.sh) needs this secret to actually verify
+          # notification delivery; without it the test SKIPs. The per-
+          # step env was dropped when this workflow was split into the
+          # matrix groups in commit ade1d16 — restoring it on every
+          # matrix entry is harmless (only Test 7 reads it) and avoids
+          # making the workflow group-aware.
+          E2E_NOTIFICATION_URL: ${{ secrets.E2E_NOTIFICATION_URL }}
         run: bash tests/e2e/groups/${{ matrix.group }}.sh
 
       - name: Collect logs on failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,17 @@ This repo deliberately keeps individual files small (`monitor.py` is now ~830 li
 ```
 1. Pull latest main:   git checkout main && git pull --ff-only origin main
 2. Create feature branch from the up-to-date main
-3. Develop, commit, push
-4. Open PR against main
-5. CI checks must pass (all 11)
-6. Merge via GitHub (branch auto-deletes)
+3. Develop, commit, push the first logical chunk
+4. Open the PR against main *as soon as you have something pushable* — CI
+   does NOT fire on pushes to a feature branch until a PR exists. Mark it
+   draft if it's WIP
+5. Continue iterating: each subsequent push to the branch triggers one CI
+   run on top of the cumulative diff. Push in logical chunks (one per
+   slice / logical unit of work) — NOT one commit per push (CI flood,
+   AI-reviewer quota burn) and NOT "20 commits → finally open PR" (single
+   huge CI run, hard to bisect when something breaks)
+6. CI checks must pass (all 11) before merge
+7. Merge via GitHub (branch auto-deletes)
 ```
 
 **Always pull `main` before creating a feature branch.** Branching from a stale local `main` forces a rebase later and risks landing PRs against an obsolete base.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased] — v5.2.0 — Stateful, lossless notifications
+
+Architectural rework of the notification subsystem. v5.1's notifications were stateless and noisy: a `systemctl restart` produced two unrelated events, a shutdown sequence produced ~22 mid-flight "ℹ️ Shutdown Detail" lines that mirrored the log, and a power outage that took the internet down meant no notifications ever got delivered. v5.2 fixes all of that.
+
+(Verbose `[Unreleased]` block per project convention — trimmed at release-tag time. See `git log v5.1.2..HEAD` for per-commit detail with rationale.)
+
+### Added
+- **DB-backed notification queue (Slice 2).** `NotificationWorker` now reads/writes through each registered `StatsStore`'s `notifications` table (schema v3 → v4). Pending rows survive process death and prolonged endpoint outages and deliver in age order when the network returns. Per-message exponential backoff (capped at `retry_backoff_max`, default 5 min) so a multi-day outage doesn't hammer an unreachable endpoint while it's down. New CRUD: `enqueue_notification`, `next_pending_notifications`, `mark_notification_sent`, `mark_notification_attempt`, `cancel_notification`, `pending_notification_count`, `cap_pending_notifications`, `prune_old_notifications`, `find_pending_by_category`, `get_meta` / `set_meta`.
+- **Stateful lifecycle classifier (Slice 3).** Replaces the v5.1 unconditional "🚀 Started" with one of: `📦 Upgraded vX → vY` (deb/rpm postinstall marker OR pip-path version comparison via `meta.last_seen_version`), `📊 Recovered` (graceful exit reason=`sequence_complete` — power-loss-triggered shutdown), `🚀 Restarted (fatal)` (last instance died), `🔄 Restarted (downtime: Ns)` (clean signal exit + downtime < 30s), `🚀 Started (last seen Nh ago)` (clean signal exit + older), `🚀 Started (after crash)` (no marker but `last_seen_version` set), or `🚀 Started` (fresh install). New module `src/eneru/lifecycle.py` with marker-file CRUD + pure `classify_startup` function.
+- **Shutdown markers.** Daemon writes `/var/lib/eneru/.shutdown_state.json` on graceful exit with `shutdown_at` / `version` / `reason` (`signal` / `sequence_complete` / `fatal`). Postinstall.sh writes `.upgrade_marker.json` with `old_version` BEFORE `systemctl restart` on deb/rpm upgrade.
+- **Brief-outage coalescing (Slice 4).** `NotificationWorker._coalesce_pending_outages` runs once per worker iteration: when a pending `ON_BATTERY` and a pending `POWER_RESTORED` from the same outage both sit in the queue (network was down for the duration of a short blip), it folds them into one "📊 Brief Power Outage" summary and cancels the originals with `cancel_reason='coalesced'`.
+- **Recovered + previous shutdown coalescing (Slice 4 bonus).** When startup classification returns "Recovered", `lifecycle.coalesce_recovered_with_prev_shutdown` folds the previous instance's pending shutdown headline + summary into a single richer message that includes the trigger reason lifted from the headline, the time-of-day at both ends, and the downtime. Saves the user from seeing 3 messages for what's really one power-outage round trip.
+- **Outage-survival defaults (Slice 2).** Five new `notifications.*` config knobs sized for a multi-day weekend internet outage: `retention_days=7` (TTL on sent/cancelled rows; pending NEVER pruned), `max_attempts=0` (unlimited — Apprise's bool can't tell "bad URL" from "internet down"), `max_age_days=30` (only cap on pending), `max_pending=10000` (backlog overflow, oldest cancelled), `retry_backoff_max=300` (5 min ceiling on per-message exponential backoff).
+- **`flush(timeout)` on the worker (Slice 5).** Drains the queue before `stop()` joins the worker thread. Wired into all four shutdown paths (`monitor._cleanup_and_exit`, `monitor._execute_shutdown_sequence`, `multi_ups._handle_signal`, `multi_ups._handle_local_shutdown`). Closes the v5.1 `Stopping notification worker with 1 message(s) pending` SIGTERM race.
+- **TUI events panel: full date prefix (Slice 6).** Rows render `2026-04-24 14:23:05` instead of just `14:23:05`, so multi-day events are distinguishable.
+
+### Changed
+- **Shutdown notifications: 22 → 2 (Slice 1).** Removed the per-`_log_message` auto-mirror that wrapped every shutdown log line as an "ℹ️ Shutdown Detail:" notification. The notification channel now only carries: the headline ("🚨 EMERGENCY SHUTDOWN INITIATED!" with the trigger reason), per-remote-server "Starting" notifications (failures still notify), and a single "✅ Shutdown Sequence Complete" summary at the end (now also fires when `local_shutdown.enabled=false`). journalctl carries the per-step trace.
+- **`local_shutdown.wall` defaults to `false` (Slice 1).** Holdover from the v2 `ups-monitor` era when the shell was the only notification channel; Apprise covers the modern path. Flip to `true` if you still want the tty broadcasts on top.
+- **`_send_notification` API.** New `category` keyword argument (default `general`) — used by the worker for coalescing and per-category queries. Common values: `lifecycle`, `power_event`, `voltage`, `shutdown`, `shutdown_summary`. The `blocking` parameter is now a back-compat shim (the v5.2 queue is always asynchronous; delivery happens on the worker thread).
+- **`========== BANNER ==========` formatting dropped (Slice 1).** The padded `==========` style across `monitor.py` and `redundancy.py` was a v2 shell-scanning legacy. The ALL CAPS body remains (still grep-friendly, still an externally-observable string the E2E tests assert against).
+- **Schema migration v3 → v4.** New `notifications` table + index; idempotent via `CREATE TABLE IF NOT EXISTS` so a partially-migrated DB self-heals on next open. Append-only per the project pattern in `src/eneru/CLAUDE.md`.
+
+### Removed
+- **`get_retry_count()` / `get_queue_size()`** on `NotificationWorker`. The new persistent worker exposes `get_pending_count()` (sum across registered stores) instead. `_retry_count` was a single-message in-memory counter; `attempts` per row now lives in SQLite.
+- **`time.sleep(5)`** at the local-shutdown gate. Replaced by `flush(timeout=5)` which returns as soon as pending hits 0 instead of always waiting the full 5s.
+- **Per-server "Remote Shutdown Sent" success notifications.** Redundant with the per-server "Starting" + the aggregate "Sequence Complete" summary. Failures still notify.
+
+### Migration notes
+- **deb/rpm upgrades**: postinstall.sh now drops `/var/lib/eneru/.upgrade_marker.json` before `systemctl restart`. Pip users get the same effect via the `meta.last_seen_version` comparison.
+- **Wall broadcasts**: if you relied on the v5.1 default of "wall fires on every shutdown", set `local_shutdown.wall: true` in your config.
+- **Stats DB schema**: bumps from v3 to v4 on first start. Schema migration is idempotent and append-only; existing rows are preserved.
+
+---
+
 ## [5.1.2] - 2026-04-23
 
 Bug-fix release for issue #4: voltage warning thresholds were misleading on narrow-firmware UPSes (US 120V APC defaults, EU managed units). Drop-in upgrade for the common wide-firmware case. Sites with narrow firmware get a one-time startup warning and a documented migration tip. See `git log v5.1.1..v5.1.2` for per-commit detail.
@@ -667,6 +702,36 @@ During power outages, network connectivity is often unreliable. The previous blo
 ---
 
 ## Version Comparison
+
+### v5.2 vs v5.1
+
+| Feature | v5.1 | v5.2 |
+|---------|------|------|
+| Notification queue | In-memory FIFO; messages dropped on shutdown | Persistent SQLite-backed; lossless across restarts and prolonged outages |
+| Lifecycle messaging | Always `🚀 Started` + `🛑 Stopped` (2 unrelated events per restart) | Stateful classifier: `Started` / `Restarted` / `Recovered` / `Upgraded` |
+| Power-loss recovery | Stop + Start (2 messages, no context) | Single `📊 Recovered` message folding the trigger reason + downtime |
+| Brief power outages | 2 separate messages (on_battery + on_line) | Coalesced into 1 `📊 Brief Power Outage` summary if both still pending |
+| Shutdown noise | ~22 mid-flight `ℹ️ Shutdown Detail` lines per sequence | 2 messages: headline + summary; journalctl carries the rest |
+| `wall(1)` broadcasts | Always-on (legacy from v2 ups-monitor era) | Opt-in via `local_shutdown.wall: false` |
+| Long-outage delivery | Best-effort retries; can drop on shutdown | Per-message exponential backoff capped at 5min, default 30-day max age |
+| Schema version | v3 (raw NUT + agg + events.notification_sent) | v4 (notifications table) |
+| TUI events panel | `HH:MM:SS` only | Full `YYYY-MM-DD HH:MM:SS` (multi-day rows distinguishable) |
+| Test count | 615 | 871 (+1 new E2E for panic-attack coalescing) |
+
+### v5.1 vs v5.0
+
+| Feature | v5.0 | v5.1 |
+|---------|------|------|
+| Redundancy groups | Not available | Quorum-based via `min_healthy`; supports A+B PSU pairs and dual-feed racks |
+| UPS health model | Implicit (per-poll status) | `HEALTHY` / `DEGRADED` / `CRITICAL` / `UNKNOWN` with configurable mapping |
+| Stats persistence | Not available | Per-UPS SQLite DB with 13 raw NUT metrics + Eneru-derived; tier-aware retention (24h raw / 30d 5-min / 5y hourly) |
+| TUI graphs | Not available | Braille time-series for any tracked metric, blended live (state-file → SQLite) |
+| TUI events panel | Log-tail parsing only | SQLite events table with arrow-key scroll (5.1.1) |
+| Voltage warning thresholds | Hardcoded `±10% / EN 50160 envelope` | Per-UPS-group `voltage_sensitivity` preset: `tight` / `normal` / `loose` (5.1.2) |
+| Schema version | N/A | v3 (raw NUT + agg tiers + events.notification_sent audit trail) |
+| Module decomposition | Single `monitor.py` (~1900 lines) | Split into `shutdown/` (4 mixins) + `health/` (2 mixins); `monitor.py` ~830 lines |
+| E2E test scenarios | 18 (single + multi-UPS) | 33 (+ stats, redundancy, voltage-autodetect groups) |
+| Test count | 300 | 615 |
 
 ### v5.0 vs v4.11
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,38 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased] — v5.2.0 — Stateful, lossless notifications
+## [5.2.0] - 2026-04-24
 
-Architectural rework of the notification subsystem. v5.1's notifications were stateless and noisy: a `systemctl restart` produced two unrelated events, a shutdown sequence produced ~22 mid-flight "ℹ️ Shutdown Detail" lines that mirrored the log, and a power outage that took the internet down meant no notifications ever got delivered. v5.2 fixes all of that.
-
-(Verbose `[Unreleased]` block per project convention — trimmed at release-tag time. See `git log v5.1.2..HEAD` for per-commit detail with rationale.)
+Notifications get a rewrite. v5.1's were stateless and noisy: a `systemctl restart` emitted two unrelated events, a shutdown sequence emitted ~22 mid-flight "Shutdown Detail" lines that mirrored the log, and a power outage that took the internet down meant nothing was ever delivered. v5.2 makes them persistent, classified, and coalesced. See `git log v5.1.2..v5.2.0` for per-commit detail.
 
 ### Added
-- **DB-backed notification queue (Slice 2).** `NotificationWorker` now reads/writes through each registered `StatsStore`'s `notifications` table (schema v3 → v4). Pending rows survive process death and prolonged endpoint outages and deliver in age order when the network returns. Per-message exponential backoff (capped at `retry_backoff_max`, default 5 min) so a multi-day outage doesn't hammer an unreachable endpoint while it's down. New CRUD: `enqueue_notification`, `next_pending_notifications`, `mark_notification_sent`, `mark_notification_attempt`, `cancel_notification`, `pending_notification_count`, `cap_pending_notifications`, `prune_old_notifications`, `find_pending_by_category`, `get_meta` / `set_meta`.
-- **Stateful lifecycle classifier (Slice 3).** Replaces the v5.1 unconditional "🚀 Started" with one of: `📦 Upgraded vX → vY` (deb/rpm postinstall marker OR pip-path version comparison via `meta.last_seen_version`), `📊 Recovered` (graceful exit reason=`sequence_complete` — power-loss-triggered shutdown), `🚀 Restarted (fatal)` (last instance died), `🔄 Restarted (downtime: Ns)` (clean signal exit + downtime < 30s), `🚀 Started (last seen Nh ago)` (clean signal exit + older), `🚀 Started (after crash)` (no marker but `last_seen_version` set), or `🚀 Started` (fresh install). New module `src/eneru/lifecycle.py` with marker-file CRUD + pure `classify_startup` function.
-- **Shutdown markers.** Daemon writes `/var/lib/eneru/.shutdown_state.json` on graceful exit with `shutdown_at` / `version` / `reason` (`signal` / `sequence_complete` / `fatal`). Postinstall.sh writes `.upgrade_marker.json` with `old_version` BEFORE `systemctl restart` on deb/rpm upgrade.
-- **Brief-outage coalescing (Slice 4).** `NotificationWorker._coalesce_pending_outages` runs once per worker iteration: when a pending `ON_BATTERY` and a pending `POWER_RESTORED` from the same outage both sit in the queue (network was down for the duration of a short blip), it folds them into one "📊 Brief Power Outage" summary and cancels the originals with `cancel_reason='coalesced'`.
-- **Recovered + previous shutdown coalescing (Slice 4 bonus).** When startup classification returns "Recovered", `lifecycle.coalesce_recovered_with_prev_shutdown` folds the previous instance's pending shutdown headline + summary into a single richer message that includes the trigger reason lifted from the headline, the time-of-day at both ends, and the downtime. Saves the user from seeing 3 messages for what's really one power-outage round trip.
-- **Outage-survival defaults (Slice 2).** Five new `notifications.*` config knobs sized for a multi-day weekend internet outage: `retention_days=7` (TTL on sent/cancelled rows; pending NEVER pruned), `max_attempts=0` (unlimited — Apprise's bool can't tell "bad URL" from "internet down"), `max_age_days=30` (only cap on pending), `max_pending=10000` (backlog overflow, oldest cancelled), `retry_backoff_max=300` (5 min ceiling on per-message exponential backoff).
-- **`flush(timeout)` on the worker (Slice 5).** Drains the queue before `stop()` joins the worker thread. Wired into all four shutdown paths (`monitor._cleanup_and_exit`, `monitor._execute_shutdown_sequence`, `multi_ups._handle_signal`, `multi_ups._handle_local_shutdown`). Closes the v5.1 `Stopping notification worker with 1 message(s) pending` SIGTERM race.
-- **TUI events panel: full date prefix (Slice 6).** Rows render `2026-04-24 14:23:05` instead of just `14:23:05`, so multi-day events are distinguishable.
+- **Persistent SQLite-backed notification queue.** Each notification is a `pending` row in the per-UPS stats DB. The worker thread reads and writes through SQLite, so messages survive process death, network outages, and reboots; pending rows ship in age order once the endpoint is reachable. Per-message exponential backoff (capped at `retry_backoff_max`, default 5 min) so the worker doesn't hammer an unreachable endpoint while it's down.
+- **Stateful lifecycle classifier.** Replaces the unconditional "🚀 Started" with one of: `📦 Upgraded vX → vY`, `📊 Recovered` (resumed after a power-loss-triggered shutdown), `🔄 Restarted` (graceful exit, downtime under 30 s), `🚀 Restarted (fatal)`, `🚀 Started (last seen Nh ago)`, `🚀 Started (after crash)`, or plain `🚀 Started`. Uses an on-disk shutdown marker plus `meta.last_seen_version` in the stats DB.
+- **Brief-outage coalescing.** A pending `ON_BATTERY` + `POWER_RESTORED` pair from the same outage gets folded into one `📊 Brief Power Outage: Ns on battery` summary before delivery. Same for the post-power-loss recovery: a `Recovered` notification absorbs the previous instance's pending shutdown headline + summary into one message that includes the trigger reason and the downtime.
+- **Outage-survival config knobs:** `notifications.retention_days` (default 7, applies to sent/cancelled only; pending is never pruned by TTL), `max_attempts` (default 0 = unlimited; Apprise's bool can't distinguish "bad URL" from "internet down"), `max_age_days` (default 30, the only cap on pending), `max_pending` (default 10000, backlog overflow), `retry_backoff_max` (default 300, 5 min). Sized for a long weekend with the internet down.
+- **`flush(timeout=5)` drain on shutdown.** Wired into every shutdown path (signal + sequence-complete, single-UPS + coordinator). Closes the v5.1 "1 message pending" SIGTERM race; whatever doesn't drain stays in SQLite for the next start.
+- **TUI events panel: full date.** Rows render `YYYY-MM-DD HH:MM:SS` so multi-day events are distinguishable.
 
 ### Changed
-- **Shutdown notifications: 22 → 2 (Slice 1).** Removed the per-`_log_message` auto-mirror that wrapped every shutdown log line as an "ℹ️ Shutdown Detail:" notification. The notification channel now only carries: the headline ("🚨 EMERGENCY SHUTDOWN INITIATED!" with the trigger reason), per-remote-server "Starting" notifications (failures still notify), and a single "✅ Shutdown Sequence Complete" summary at the end (now also fires when `local_shutdown.enabled=false`). journalctl carries the per-step trace.
-- **`local_shutdown.wall` defaults to `false` (Slice 1).** Holdover from the v2 `ups-monitor` era when the shell was the only notification channel; Apprise covers the modern path. Flip to `true` if you still want the tty broadcasts on top.
-- **`_send_notification` API.** New `category` keyword argument (default `general`) — used by the worker for coalescing and per-category queries. Common values: `lifecycle`, `power_event`, `voltage`, `shutdown`, `shutdown_summary`. The `blocking` parameter is now a back-compat shim (the v5.2 queue is always asynchronous; delivery happens on the worker thread).
-- **`========== BANNER ==========` formatting dropped (Slice 1).** The padded `==========` style across `monitor.py` and `redundancy.py` was a v2 shell-scanning legacy. The ALL CAPS body remains (still grep-friendly, still an externally-observable string the E2E tests assert against).
-- **Schema migration v3 → v4.** New `notifications` table + index; idempotent via `CREATE TABLE IF NOT EXISTS` so a partially-migrated DB self-heals on next open. Append-only per the project pattern in `src/eneru/CLAUDE.md`.
+- **Shutdown notifications: 22 → 2.** Dropped the per-`_log_message` auto-mirror. The channel now carries the headline (`🚨 EMERGENCY SHUTDOWN INITIATED!` with reason) and a single `✅ Shutdown Sequence Complete` summary at the end. The summary now also fires when `local_shutdown.enabled=false`. Per-step detail stays in journalctl.
+- **`wall(1)` opt-in.** Defaults to off via `local_shutdown.wall: false`. Holdover from the v2 `ups-monitor` era when the shell was the only channel; Apprise covers the modern path.
+- **Schema v3 → v4.** New `notifications` table + index; append-only migration heals partial state via `CREATE TABLE IF NOT EXISTS`. See `src/eneru/CLAUDE.md` "Stats schema evolution".
+- **`_send_notification` API.** Adds a `category` keyword (default `general`); used by the coalescer and per-category queries. The `blocking` parameter is now a back-compat shim because the v5.2 queue is always asynchronous.
+- **Banner formatting cleanup.** Dropped the `========== BANNER ==========` padding from `monitor.py` and `redundancy.py`. The ALL CAPS body stays (grep-friendly).
 
 ### Removed
-- **`get_retry_count()` / `get_queue_size()`** on `NotificationWorker`. The new persistent worker exposes `get_pending_count()` (sum across registered stores) instead. `_retry_count` was a single-message in-memory counter; `attempts` per row now lives in SQLite.
-- **`time.sleep(5)`** at the local-shutdown gate. Replaced by `flush(timeout=5)` which returns as soon as pending hits 0 instead of always waiting the full 5s.
-- **Per-server "Remote Shutdown Sent" success notifications.** Redundant with the per-server "Starting" + the aggregate "Sequence Complete" summary. Failures still notify.
+- `get_retry_count()` / `get_queue_size()` on `NotificationWorker`, replaced by `get_pending_count()`.
+- `time.sleep(5)` at the local-shutdown gate, replaced by `flush(timeout=5)` which returns as soon as pending hits 0.
+- Per-server "Remote Shutdown Sent" success notifications, covered by the aggregate summary; failures still notify.
 
 ### Migration notes
-- **deb/rpm upgrades**: postinstall.sh now drops `/var/lib/eneru/.upgrade_marker.json` before `systemctl restart`. Pip users get the same effect via the `meta.last_seen_version` comparison.
-- **Wall broadcasts**: if you relied on the v5.1 default of "wall fires on every shutdown", set `local_shutdown.wall: true` in your config.
-- **Stats DB schema**: bumps from v3 to v4 on first start. Schema migration is idempotent and append-only; existing rows are preserved.
+- **deb/rpm upgrades:** postinstall now drops `/var/lib/eneru/.upgrade_marker.json` before `systemctl restart`, so the next start emits a single `📦 Upgraded` notification. Pip users get the same effect via the `meta.last_seen_version` comparison.
+- **Wall broadcasts:** if you relied on the v5.1 default of "wall fires on every shutdown", set `local_shutdown.wall: true` explicitly.
+- **Stats DB:** schema bumps from v3 to v4 on first start. Idempotent and append-only; existing rows are preserved.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,7 @@ local_shutdown:
   message: "UPS battery critical - emergency shutdown"
   drain_on_local_shutdown: false     # multi-UPS: drain all groups before local shutdown
   trigger_on: "any"                  # multi-UPS: "any" or "none"
+  wall: false                        # broadcast shutdown via wall(1) to every tty (off since v5.2)
 ```
 
 ---
@@ -465,6 +466,7 @@ Global.
 | `message` | `UPS battery critical - emergency shutdown` | Optional message for `shutdown -h` |
 | `drain_on_local_shutdown` | `false` | Multi-UPS only. When the local UPS goes critical, also shut down every other group's resources before powering off the host. `false` (default) = only the local group's resources are touched |
 | `trigger_on` | `any` | Multi-UPS only. `any` = any group's shutdown triggers local shutdown (default). `none` = local shutdown is opt-in per group; useful when the host is on its own dedicated UPS that never participates in cascades |
+| `wall` | `false` | Broadcast shutdown warnings to every logged-in tty via `wall(1)`. Off by default since v5.2 — Apprise covers the modern path. Flip to `true` if you still want the tty blast on top (legacy from the v2 ups-monitor era) |
 
 ### Redundancy groups section
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ Recently shipped: v5.0 (2026-04-11) and v5.1 (2026-04-21). See the [changelog](c
 
 ---
 
-## v5.2 -- API and observability (planned)
+## v5.3 -- API and observability (planned)
 
 Right now nothing can talk to Eneru programmatically. This version adds the plumbing for that.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ Planned direction for Eneru. None of this is built yet -- things will change as 
 
 Feature requests and feedback: [GitHub Issues](https://github.com/m4r1k/Eneru/issues).
 
-Recently shipped: v5.0 (2026-04-11) and v5.1 (2026-04-21). See the [changelog](changelog.md) for details.
+Recently shipped: v5.0 (2026-04-11), v5.1 (2026-04-21), v5.2 (2026-04-24). See the [changelog](changelog.md) for details.
 
 ---
 

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -384,6 +384,11 @@ local_shutdown:
   # "any" = any group's shutdown triggers local shutdown (default)
   # "none" = Eneru host never shuts itself down (recommended for multi-UPS)
   trigger_on: "any"
+  # Broadcast a wall(1) warning to every logged-in tty when a shutdown is
+  # triggered. Off by default since v5.2 — Apprise covers the modern
+  # notification path. Flip to true if you still want the tty blast on top
+  # (legacy from the v2 ups-monitor era when shell was the only channel).
+  wall: false
 
 # ==============================================================================
 # STATISTICS (always-on per-UPS SQLite store)

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -169,6 +169,13 @@ contents:
       owner: root
       group: root
 
+  - src: src/eneru/lifecycle.py
+    dst: /opt/ups-monitor/eneru/lifecycle.py
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
   # eneru.shutdown subpackage (mixin per shutdown phase)
   - src: src/eneru/shutdown/__init__.py
     dst: /opt/ups-monitor/eneru/shutdown/__init__.py

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -44,6 +44,23 @@ fi
 if [ "$is_upgrade" = true ]; then
     # UPGRADE: Restart service if it was running, otherwise leave it alone
     if [ "$was_running" = true ]; then
+        # v5.2: drop an upgrade marker before the restart so the daemon's
+        # startup classifier emits "📦 Upgraded vX → vY" instead of a
+        # generic "Started" (and so it can fold the previous instance's
+        # pending "Stopped" notification, avoiding the stop+start pair).
+        # Marker only needs old_version — new_version defaults to the
+        # daemon's own __version__ at read time. Best-effort: a write
+        # failure just means the user gets the legacy classification.
+        # Marker is consumed (deleted) by the daemon on the next start.
+        STATS_DIR="/var/lib/eneru"
+        MARKER_PATH="${STATS_DIR}/.upgrade_marker.json"
+        OLD_VERSION="${2:-unknown}"      # DEB: $2 = previous version
+        # RPM passes "$1 = 2" on upgrade with no version string; we leave
+        # OLD_VERSION as "unknown" in that case rather than guessing.
+        mkdir -p "${STATS_DIR}" 2>/dev/null || true
+        printf '{"old_version":"%s"}\n' "${OLD_VERSION}" \
+            > "${MARKER_PATH}" 2>/dev/null || true
+
         echo "Restarting Eneru service..."
         systemctl restart eneru.service
     fi

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -52,11 +52,27 @@ if [ "$is_upgrade" = true ]; then
         # daemon's own __version__ at read time. Best-effort: a write
         # failure just means the user gets the legacy classification.
         # Marker is consumed (deleted) by the daemon on the next start.
-        STATS_DIR="/var/lib/eneru"
-        MARKER_PATH="${STATS_DIR}/.upgrade_marker.json"
         OLD_VERSION="${2:-unknown}"      # DEB: $2 = previous version
         # RPM passes "$1 = 2" on upgrade with no version string; we leave
         # OLD_VERSION as "unknown" in that case rather than guessing.
+        # Resolve the stats directory the daemon will actually use.
+        # Defaults to /var/lib/eneru but is overridable via
+        # statistics.db_directory in /etc/ups-monitor/config.yaml
+        # (Cubic P2: previously hardcoded). Fall back to /var/lib/eneru
+        # if the config can't be parsed.
+        STATS_DIR=$(python3 - <<'PY' 2>/dev/null || echo "/var/lib/eneru"
+import sys
+try:
+    import yaml
+    with open("/etc/ups-monitor/config.yaml") as f:
+        data = yaml.safe_load(f) or {}
+    stats = data.get("statistics") or {}
+    print((stats.get("db_directory") or "/var/lib/eneru").strip())
+except Exception:
+    print("/var/lib/eneru")
+PY
+)
+        MARKER_PATH="${STATS_DIR}/.upgrade_marker.json"
         mkdir -p "${STATS_DIR}" 2>/dev/null || true
         printf '{"old_version":"%s"}\n' "${OLD_VERSION}" \
             > "${MARKER_PATH}" 2>/dev/null || true

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -670,19 +670,34 @@ class ConfigLoader:
             notif_voltage_hysteresis = notif_data.get(
                 'voltage_hysteresis_seconds', notif_voltage_hysteresis,
             )
-            notif_retention_days = notif_data.get(
+            # Coerce numeric YAML values to int defensively (Cubic P2).
+            # Strings like "7" parse cleanly; garbage raises ValueError
+            # which would otherwise surface as a TypeError deep inside
+            # the worker's backoff math at runtime, far from the source.
+            def _as_int(key, default):
+                v = notif_data.get(key, default)
+                try:
+                    return int(v)
+                except (TypeError, ValueError):
+                    print(
+                        f"⚠️ Notifications config: {key}={v!r} not numeric; "
+                        f"using default {default}"
+                    )
+                    return default
+
+            notif_retention_days = _as_int(
                 'retention_days', notif_retention_days,
             )
-            notif_max_attempts = notif_data.get(
+            notif_max_attempts = _as_int(
                 'max_attempts', notif_max_attempts,
             )
-            notif_max_age_days = notif_data.get(
+            notif_max_age_days = _as_int(
                 'max_age_days', notif_max_age_days,
             )
-            notif_max_pending = notif_data.get(
+            notif_max_pending = _as_int(
                 'max_pending', notif_max_pending,
             )
-            notif_retry_backoff_max = notif_data.get(
+            notif_retry_backoff_max = _as_int(
                 'retry_backoff_max', notif_retry_backoff_max,
             )
 

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -230,6 +230,12 @@ class LocalShutdownConfig:
     message: str = "UPS battery critical - emergency shutdown"
     drain_on_local_shutdown: bool = False  # Drain all groups before local shutdown
     trigger_on: str = "any"  # "any" or "none" — when to trigger local shutdown in multi-UPS
+    # Whether to broadcast shutdown warnings via wall(1) to every logged-in
+    # tty. Off by default since v5.2 — the `wall` blast was a holdover from
+    # the v2 "ups-monitor" days when the shell was the only notification
+    # channel. Apprise covers the modern path; opt in here if you still want
+    # tty broadcasts on top.
+    wall: bool = False
 
 
 @dataclass
@@ -706,6 +712,7 @@ class ConfigLoader:
                 message=local_data.get('message', 'UPS battery critical - emergency shutdown'),
                 drain_on_local_shutdown=local_data.get('drain_on_local_shutdown', False),
                 trigger_on=local_data.get('trigger_on', 'any'),
+                wall=local_data.get('wall', False),
             )
 
         # Parse global triggers (used as defaults for per-UPS triggers)

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -114,6 +114,31 @@ class NotificationsConfig:
     # the response to a real sustained event. 0 = immediate (legacy).
     voltage_hysteresis_seconds: int = 30
 
+    # ---- v5.2 persistent-queue knobs ----
+    # Days to keep ``sent`` and ``cancelled`` rows around for forensic
+    # inspection via sqlite3. ``pending`` rows are NEVER pruned by TTL.
+    retention_days: int = 7
+    # Per-message attempt cap. 0 (default, unlimited) means a stuck
+    # message keeps retrying with exponential backoff until it succeeds
+    # or hits ``max_age_days``. Apprise's success/fail signal is a bool
+    # — we can't tell "bad URL" from "internet down" — so giving up on
+    # attempts alone risks dropping legitimate messages during a long
+    # outage. Set this only if you want a poison-message kill switch.
+    max_attempts: int = 0
+    # Pending notifications older than this become ``cancelled``
+    # (reason: ``too_old``). 30 d covers a month-long absence; longer
+    # than that the message is probably stale. Set 0 to disable.
+    max_age_days: int = 30
+    # Backlog cap. When pending exceeds this, the oldest are cancelled
+    # with reason ``backlog_overflow``. 10000 is well above normal use
+    # but bounds DB growth on runaway-event days.
+    max_pending: int = 10000
+    # Exponential backoff ceiling, in seconds. The per-message wait
+    # doubles on each failure (starting at ``retry_interval``) up to
+    # this cap. 5 min keeps reconnection quick once the endpoint
+    # returns without hammering the network during a long outage.
+    retry_backoff_max: int = 300
+
 
 # Power events whose notifications cannot be suppressed via
 # `notifications.suppress`. Allowing a user to silence these would
@@ -628,6 +653,12 @@ class ConfigLoader:
         # Defaults match NotificationsConfig dataclass.
         notif_suppress: List[str] = []
         notif_voltage_hysteresis = 30
+        # v5.2 persistent-queue defaults.
+        notif_retention_days = 7
+        notif_max_attempts = 0
+        notif_max_age_days = 30
+        notif_max_pending = 10000
+        notif_retry_backoff_max = 300
 
         if 'notifications' in data:
             notif_data = data['notifications']
@@ -638,6 +669,21 @@ class ConfigLoader:
             notif_suppress = notif_data.get('suppress', notif_suppress)
             notif_voltage_hysteresis = notif_data.get(
                 'voltage_hysteresis_seconds', notif_voltage_hysteresis,
+            )
+            notif_retention_days = notif_data.get(
+                'retention_days', notif_retention_days,
+            )
+            notif_max_attempts = notif_data.get(
+                'max_attempts', notif_max_attempts,
+            )
+            notif_max_age_days = notif_data.get(
+                'max_age_days', notif_max_age_days,
+            )
+            notif_max_pending = notif_data.get(
+                'max_pending', notif_max_pending,
+            )
+            notif_retry_backoff_max = notif_data.get(
+                'retry_backoff_max', notif_retry_backoff_max,
             )
 
             if 'urls' in notif_data:
@@ -673,6 +719,11 @@ class ConfigLoader:
             retry_interval=notif_retry_interval,
             suppress=notif_suppress,
             voltage_hysteresis_seconds=notif_voltage_hysteresis,
+            retention_days=notif_retention_days,
+            max_attempts=notif_max_attempts,
+            max_age_days=notif_max_age_days,
+            max_pending=notif_max_pending,
+            retry_backoff_max=notif_retry_backoff_max,
         )
 
     @classmethod

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -163,5 +163,6 @@ class BatteryMonitorMixin:
                 f"Charge dropped from {anomaly_prev:.0f}% to {current_charge:.0f}% "
                 f"({anomaly_drop:.0f}% drop in {anomaly_elapsed:.0f}s) while on line power.\n"
                 f"Possible causes: firmware recalibration, battery aging, or hardware issue.",
-                self.config.NOTIFY_WARNING
+                self.config.NOTIFY_WARNING,
+                category="health",
             )

--- a/src/eneru/health/voltage.py
+++ b/src/eneru/health/voltage.py
@@ -560,7 +560,9 @@ class VoltageMonitorMixin:
         # bypassing _log_power_event to avoid double-logging.
         body = f"⚠️ **VOLTAGE ISSUE:** {event}\nDetails: {detail}"
         try:
-            self._send_notification(body, self.config.NOTIFY_WARNING)
+            self._send_notification(
+                body, self.config.NOTIFY_WARNING, category="voltage",
+            )
         except Exception:
             pass
 

--- a/src/eneru/lifecycle.py
+++ b/src/eneru/lifecycle.py
@@ -1,0 +1,230 @@
+"""Stateful lifecycle classifier for v5.2 startup notifications.
+
+Today's startup is stateless: every ``_initialize()`` emits a generic
+"🚀 Started" notification regardless of how the previous instance
+exited. v5.2 distinguishes:
+
+- **Started**: cold start (no marker, fresh install or first ever boot).
+- **Restarted**: graceful exit + new start within ~30 s.
+- **Recovered**: graceful exit triggered by a power-loss shutdown
+  sequence; the user sees one message that retroactively explains why
+  the system went down and confirms it's back.
+- **Upgraded**: deb/rpm postinstall set the upgrade marker before
+  ``systemctl restart``; the daemon reads it and emits a single
+  "📦 Upgraded vX → vY" message instead of stop+start.
+- **Started after crash**: marker absent but ``meta.last_seen_version``
+  is set — the previous instance died without writing its marker.
+
+Two on-disk markers (under the stats directory) drive the
+classification:
+
+- ``.shutdown_state.json`` — written on graceful exit, contains
+  ``shutdown_at`` (unix), ``version``, and ``reason`` (one of
+  ``signal`` / ``sequence_complete`` / ``fatal``).
+- ``.upgrade_marker.json`` — written by ``packaging/scripts/postinstall.sh``
+  before restarting the unit, contains ``old_version`` and ``new_version``.
+
+The pip path has no postinstall hook, so for pip users the upgrade is
+detected by comparing ``meta.last_seen_version`` (in the stats DB) to
+the current ``__version__`` on startup.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+from eneru.utils import format_seconds
+
+
+SHUTDOWN_MARKER_NAME = ".shutdown_state.json"
+UPGRADE_MARKER_NAME = ".upgrade_marker.json"
+
+# Below this many seconds, a shutdown+start cycle reads as a restart
+# rather than a fresh start. Picked to match the typical
+# `systemctl restart` window without being so wide that an unrelated
+# manual stop+start gets misclassified.
+RESTART_DOWNTIME_THRESHOLD_SECS = 30
+
+# Valid `reason` values for the shutdown marker. Anything else gets
+# treated as "signal" by the classifier.
+REASON_SIGNAL = "signal"
+REASON_SEQUENCE_COMPLETE = "sequence_complete"
+REASON_FATAL = "fatal"
+
+
+def _marker_path(directory: Path, name: str) -> Path:
+    return Path(directory) / name
+
+
+def write_shutdown_marker(directory: Path, *, version: str,
+                          reason: str = REASON_SIGNAL,
+                          shutdown_at: Optional[int] = None) -> None:
+    """Persist the shutdown context that the next startup will read.
+
+    Best-effort: a write failure logs nothing and silently degrades the
+    next startup classification to "Started after crash" — no harm
+    done, just a less informative notification.
+    """
+    path = _marker_path(directory, SHUTDOWN_MARKER_NAME)
+    payload = {
+        "shutdown_at": int(shutdown_at if shutdown_at is not None
+                           else time.time()),
+        "version": str(version),
+        "reason": str(reason),
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
+    except OSError:
+        pass
+
+
+def read_shutdown_marker(directory: Path) -> Optional[dict]:
+    """Return the shutdown marker dict, or ``None`` if absent / unreadable."""
+    path = _marker_path(directory, SHUTDOWN_MARKER_NAME)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def delete_shutdown_marker(directory: Path) -> None:
+    """Remove the shutdown marker. Idempotent."""
+    try:
+        _marker_path(directory, SHUTDOWN_MARKER_NAME).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def read_upgrade_marker(directory: Path) -> Optional[dict]:
+    """Return the upgrade marker dict, or ``None`` if absent / unreadable.
+
+    The marker is dropped by ``packaging/scripts/postinstall.sh`` BEFORE
+    ``systemctl restart``, so the daemon's startup classifier finds it
+    and emits a single "Upgraded" notification instead of stop+start.
+    """
+    path = _marker_path(directory, UPGRADE_MARKER_NAME)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def delete_upgrade_marker(directory: Path) -> None:
+    """Remove the upgrade marker. Idempotent."""
+    try:
+        _marker_path(directory, UPGRADE_MARKER_NAME).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def classify_startup(*, current_version: str,
+                     shutdown_marker: Optional[dict],
+                     upgrade_marker: Optional[dict],
+                     last_seen_version: Optional[str],
+                     now_ts: Optional[int] = None,
+                     ) -> Tuple[str, str]:
+    """Pick the lifecycle notification body + notify_type for this start.
+
+    Args:
+        current_version: ``__version__`` at the moment of this start.
+        shutdown_marker: Result of :func:`read_shutdown_marker`.
+        upgrade_marker: Result of :func:`read_upgrade_marker` (postinstall
+            path) — falls back to a version-comparison check below.
+        last_seen_version: Last value of ``meta.last_seen_version`` from
+            the stats DB, used as the pip-path upgrade detector when no
+            on-disk upgrade marker is present.
+        now_ts: Override "now" for deterministic tests.
+
+    Returns ``(body, notify_type)``. ``notify_type`` is one of
+    ``info`` / ``success`` / ``warning`` / ``failure``.
+    """
+    now = int(now_ts if now_ts is not None else time.time())
+
+    # 1) Postinstall-set marker: deb/rpm upgrade. Authoritative.
+    if upgrade_marker:
+        old = str(upgrade_marker.get("old_version", "?"))
+        new = str(upgrade_marker.get("new_version", current_version))
+        return (
+            f"📦 **Eneru Upgraded** v{old} → v{new}\n"
+            "Service is back online with the new version.",
+            "success",
+        )
+
+    # 2) Pip-path upgrade detection: no postinstall, but the version
+    #    string changed since the previous start.
+    if (last_seen_version and last_seen_version != current_version
+            and not shutdown_marker):
+        # Treat as upgrade only when there's no recent shutdown marker —
+        # otherwise the marker's classification (Restarted / Recovered)
+        # is more informative.
+        return (
+            f"📦 **Eneru Upgraded** v{last_seen_version} → v{current_version}\n"
+            "Service is back online with the new version.",
+            "success",
+        )
+
+    if shutdown_marker:
+        downtime = max(0, now - int(shutdown_marker.get("shutdown_at", now)))
+        prev_version = str(shutdown_marker.get("version", current_version))
+        reason = str(shutdown_marker.get("reason", REASON_SIGNAL))
+
+        # Pip-path upgrade BUT we also have a shutdown marker:
+        # explain both via the upgrade phrasing — the version change
+        # is the bigger story, the shutdown reason is secondary.
+        if (last_seen_version and last_seen_version != current_version):
+            return (
+                f"📦 **Eneru Upgraded** v{last_seen_version} → v{current_version}\n"
+                f"Resumed after {format_seconds(downtime)} downtime.",
+                "success",
+            )
+
+        if reason == REASON_SEQUENCE_COMPLETE:
+            return (
+                f"📊 **Eneru Recovered**\n"
+                f"Resumed after {format_seconds(downtime)} downtime "
+                f"following a power-loss-triggered shutdown "
+                f"(was v{prev_version}).",
+                "success",
+            )
+        if reason == REASON_FATAL:
+            return (
+                f"🚀 **Eneru Restarted**\n"
+                f"Last instance exited fatally; back up after "
+                f"{format_seconds(downtime)} (was v{prev_version}).",
+                "warning",
+            )
+        # reason == "signal" or unknown: distinguish quick restart from
+        # a true cold start (manual stop, then later start).
+        if downtime < RESTART_DOWNTIME_THRESHOLD_SECS:
+            return (
+                f"🔄 **Eneru Restarted** (downtime: "
+                f"{format_seconds(downtime)})\nService is back online.",
+                "info",
+            )
+        return (
+            f"🚀 **Eneru Started** (last seen "
+            f"{format_seconds(downtime)} ago)\nResumed monitoring.",
+            "info",
+        )
+
+    # 3) No marker at all. Either a fresh install (no last_seen_version
+    #    either) or a hard crash that didn't get to write a marker.
+    if last_seen_version:
+        return (
+            f"🚀 **Eneru v{current_version} Started** (after crash)\n"
+            f"Last clean run was v{last_seen_version}.",
+            "warning",
+        )
+    return (
+        f"🚀 **Eneru v{current_version} Started**\n"
+        "Monitoring active.",
+        "info",
+    )

--- a/src/eneru/lifecycle.py
+++ b/src/eneru/lifecycle.py
@@ -172,7 +172,14 @@ def classify_startup(*, current_version: str,
         )
 
     if shutdown_marker:
-        downtime = max(0, now - int(shutdown_marker.get("shutdown_at", now)))
+        # Marker is on-disk JSON written by an older daemon — defend
+        # against malformed values (string in shutdown_at, missing
+        # keys, etc.) that would otherwise raise and break startup.
+        try:
+            shutdown_at = int(shutdown_marker.get("shutdown_at", now))
+        except (TypeError, ValueError):
+            shutdown_at = now
+        downtime = max(0, now - shutdown_at)
         prev_version = str(shutdown_marker.get("version", current_version))
         reason = str(shutdown_marker.get("reason", REASON_SIGNAL))
 
@@ -247,6 +254,7 @@ def _extract_reason_from_body(body: str) -> Optional[str]:
 
 def coalesce_recovered_with_prev_shutdown(
     store, *, downtime_secs: int, now_ts: Optional[int] = None,
+    shutdown_at: Optional[int] = None,
 ) -> Optional[str]:
     """Fold the previous instance's pending shutdown headline + summary
     into a single richer "Recovered" body that mentions when the
@@ -260,11 +268,23 @@ def coalesce_recovered_with_prev_shutdown(
 
     The coalescing only fires when classification is "Recovered"
     (sequence_complete) — see ``UPSGroupMonitor._emit_lifecycle_startup_notification``.
+
+    ``shutdown_at`` (Cubic P2) bounds which pending rows count as "from
+    this outage". Without it, an unrelated older pending shutdown
+    notification (e.g. from a previous outage that never delivered)
+    would also get cancelled. Defaults to "no bound" for back-compat
+    but the monitor caller passes ``shutdown_marker.shutdown_at - 60``
+    so anything from before this outage is left alone.
     """
     now = int(now_ts if now_ts is not None else time.time())
+    floor_ts = int(shutdown_at) - 60 if shutdown_at is not None else None
 
-    shutdown_rows = store.find_pending_by_category("shutdown") or []
-    summary_rows = store.find_pending_by_category("shutdown_summary") or []
+    shutdown_rows = store.find_pending_by_category(
+        "shutdown", since_ts=floor_ts,
+    ) or []
+    summary_rows = store.find_pending_by_category(
+        "shutdown_summary", since_ts=floor_ts,
+    ) or []
     if not shutdown_rows and not summary_rows:
         return None
 

--- a/src/eneru/lifecycle.py
+++ b/src/eneru/lifecycle.py
@@ -1,4 +1,4 @@
-"""Stateful lifecycle classifier for v5.2 startup notifications.
+"""Stateful lifecycle classifier + coalescing helpers for v5.2.
 
 Today's startup is stateless: every ``_initialize()`` emits a generic
 "🚀 Started" notification regardless of how the previous instance
@@ -228,3 +228,81 @@ def classify_startup(*, current_version: str,
         "Monitoring active.",
         "info",
     )
+
+
+# ==============================================================================
+# Coalescing helpers (Slice 4 — fold related notifications into one)
+# ==============================================================================
+
+def _extract_reason_from_body(body: str) -> Optional[str]:
+    """Best-effort: pull the ``Reason: ...`` line out of an emergency
+    shutdown headline body. Returns ``None`` when the convention isn't
+    matched."""
+    for line in str(body).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Reason: "):
+            return stripped[len("Reason: "):]
+    return None
+
+
+def coalesce_recovered_with_prev_shutdown(
+    store, *, downtime_secs: int, now_ts: Optional[int] = None,
+) -> Optional[str]:
+    """Fold the previous instance's pending shutdown headline + summary
+    into a single richer "Recovered" body that mentions when the
+    shutdown was triggered, what the trigger reason was, and the
+    downtime.
+
+    Cancels the prev-instance shutdown rows with
+    ``cancel_reason='coalesced'`` so the worker doesn't deliver them
+    redundantly. Returns the new body string, or ``None`` if there's
+    nothing to fold (caller falls back to the classifier's default).
+
+    The coalescing only fires when classification is "Recovered"
+    (sequence_complete) — see ``UPSGroupMonitor._emit_lifecycle_startup_notification``.
+    """
+    now = int(now_ts if now_ts is not None else time.time())
+
+    shutdown_rows = store.find_pending_by_category("shutdown") or []
+    summary_rows = store.find_pending_by_category("shutdown_summary") or []
+    if not shutdown_rows and not summary_rows:
+        return None
+
+    # Prefer the headline row for richer context (it carries the
+    # reason). Fall back to summary if no headline survived.
+    if shutdown_rows:
+        head = shutdown_rows[-1]  # most recent pending shutdown headline
+        head_id, head_ts, head_body, _ = head
+        reason = _extract_reason_from_body(head_body) or "power loss"
+        from datetime import datetime
+        shutdown_str = datetime.fromtimestamp(head_ts).strftime("%H:%M:%S")
+        recovered_str = datetime.fromtimestamp(now).strftime("%H:%M:%S")
+        body = (
+            f"📊 **Eneru Recovered**\n"
+            f"Power outage triggered shutdown at {shutdown_str} "
+            f"({reason}); recovered at {recovered_str} after "
+            f"{format_seconds(downtime_secs)} downtime."
+        )
+        store.cancel_notification(head_id, "coalesced")
+        # Older shutdown rows from the same outage also get folded.
+        for row in shutdown_rows[:-1]:
+            store.cancel_notification(row[0], "coalesced")
+        for row in summary_rows:
+            store.cancel_notification(row[0], "coalesced")
+        return body
+
+    # Only summary rows are pending (the headline already shipped).
+    head = summary_rows[-1]
+    head_id, head_ts, _, _ = head
+    from datetime import datetime
+    shutdown_str = datetime.fromtimestamp(head_ts).strftime("%H:%M:%S")
+    recovered_str = datetime.fromtimestamp(now).strftime("%H:%M:%S")
+    body = (
+        f"📊 **Eneru Recovered**\n"
+        f"Shutdown completed at {shutdown_str}; recovered at "
+        f"{recovered_str} after {format_seconds(downtime_secs)} downtime."
+    )
+    for row in summary_rows:
+        store.cancel_notification(row[0], "coalesced")
+    return body
+

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -723,9 +723,13 @@ class UPSGroupMonitor(
                     self.config.NOTIFY_FAILURE,
                     category="shutdown_summary",
                 )
-                # Give notification time to send. Slice 5 replaces this with
-                # NotificationWorker.flush(timeout=5).
-                time.sleep(5)
+                # Give the persistent worker a chance to drain before the
+                # halt cuts power. Returns as soon as pending hits 0,
+                # rather than always waiting the full 5s. Whatever doesn't
+                # drain stays in SQLite as 'pending' and ships on the
+                # next start (the lossless guarantee).
+                if self._notification_worker:
+                    self._notification_worker.flush(timeout=5)
 
                 cmd_parts = self.config.local_shutdown.command.split()
                 if self.config.local_shutdown.message:
@@ -775,6 +779,9 @@ class UPSGroupMonitor(
         """Handle clean exit on signals."""
         if self._shutdown_flag_path.exists():
             if self._notification_worker:
+                # Mid-shutdown signal: still try to drain any in-flight
+                # rows; whatever's left persists for the next start.
+                self._notification_worker.flush(timeout=5)
                 self._notification_worker.stop()
             self._stop_stats()
             sys.exit(0)
@@ -791,6 +798,13 @@ class UPSGroupMonitor(
         )
 
         if self._notification_worker:
+            # Closes the SIGTERM race that produced the v5.1 "Stopping
+            # notification worker with 1 message(s) pending" warning:
+            # we now WAIT for the worker to actually deliver the
+            # 'Stopped' notification before joining its thread.
+            # Returns as soon as pending hits 0; bounded at 5s so a
+            # systemctl stop doesn't hang on an unreachable endpoint.
+            self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
         self._stop_stats()
 

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -394,10 +394,17 @@ class UPSGroupMonitor(
                 and shutdown_marker.get("reason") == REASON_SEQUENCE_COMPLETE
                 and self._stats_store._conn is not None):
             import time as _time
-            downtime = max(0, int(_time.time())
-                           - int(shutdown_marker.get("shutdown_at", 0)))
+            try:
+                marker_shutdown_at = int(shutdown_marker.get("shutdown_at", 0))
+            except (TypeError, ValueError):
+                marker_shutdown_at = 0
+            downtime = max(0, int(_time.time()) - marker_shutdown_at)
             coalesced_body = coalesce_recovered_with_prev_shutdown(
-                self._stats_store, downtime_secs=downtime,
+                self._stats_store,
+                downtime_secs=downtime,
+                # Bound the coalesce to the current outage so unrelated
+                # older pending shutdown rows aren't cancelled (Cubic P2).
+                shutdown_at=marker_shutdown_at or None,
             )
             if coalesced_body:
                 body = coalesced_body
@@ -935,9 +942,15 @@ class UPSGroupMonitor(
         # Slice 3: drop the shutdown marker so the next start can
         # classify this exit (signal → "🔄 Restarted" if it comes back
         # within RESTART_DOWNTIME_THRESHOLD_SECS, else cold "Started").
-        write_shutdown_marker(
-            stats_dir, version=__version__, reason=REASON_SIGNAL,
-        )
+        # Don't downgrade an existing sequence_complete marker — that
+        # would mask a power-loss shutdown when systemd's stop signal
+        # arrives during the shutdown sequence (Cubic P2).
+        existing = read_shutdown_marker(stats_dir)
+        if not (existing
+                and existing.get("reason") == REASON_SEQUENCE_COMPLETE):
+            write_shutdown_marker(
+                stats_dir, version=__version__, reason=REASON_SIGNAL,
+            )
 
         self._shutdown_flag_path.unlink(missing_ok=True)
         sys.exit(0)

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -1209,7 +1209,8 @@ class UPSGroupMonitor(
                             "🚨 **FAILSAFE (FSB) TRIGGERED!**\n"
                             "Connection to UPS lost or data stale while system was running On Battery.\n"
                             "Assuming critical failure. Executing immediate shutdown.",
-                            self.config.NOTIFY_FAILURE
+                            self.config.NOTIFY_FAILURE,
+                            category="shutdown",
                         )
                         self._execute_shutdown_sequence()
 
@@ -1257,7 +1258,8 @@ class UPSGroupMonitor(
                         f"{self.state.connection_flap_count} times "
                         f"(recovered within grace period each time). "
                         f"Check your UPS network connection or NUT server configuration.",
-                        self.config.NOTIFY_WARNING
+                        self.config.NOTIFY_WARNING,
+                        category="health",
                     )
                     self.state.connection_flap_count = 0
                     self.state.connection_first_flap_time = 0.0

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -625,9 +625,17 @@ class UPSGroupMonitor(
             )
 
         if notification:
-            self._send_notification(
-                *notification, category="power_event",
-            )
+            # Sub-typed categories for the Slice 4 brief-outage coalescer:
+            # the worker pairs on_battery + on_line by exact category match
+            # so it doesn't have to grep the user-visible body strings
+            # (which can change wording without anyone updating the
+            # coalescer). Other power events stay on the generic category.
+            event_to_category = {
+                "ON_BATTERY": "power_event_on_battery",
+                "POWER_RESTORED": "power_event_on_line",
+            }
+            category = event_to_category.get(event, "power_event")
+            self._send_notification(*notification, category=category)
 
     def _check_dependencies(self):
         """Check for required and optional dependencies."""

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -20,6 +20,17 @@ from eneru.state import MonitorState
 from eneru.logger import UPSLogger
 from eneru.notifications import NotificationWorker, APPRISE_AVAILABLE
 from eneru.stats import StatsStore, StatsWriter
+from eneru.lifecycle import (
+    REASON_FATAL,
+    REASON_SEQUENCE_COMPLETE,
+    REASON_SIGNAL,
+    classify_startup,
+    delete_shutdown_marker,
+    delete_upgrade_marker,
+    read_shutdown_marker,
+    read_upgrade_marker,
+    write_shutdown_marker,
+)
 from eneru.utils import run_command, command_exists, is_numeric, format_seconds
 from eneru.shutdown.vms import VMShutdownMixin
 from eneru.shutdown.containers import ContainerShutdownMixin
@@ -208,8 +219,21 @@ class UPSGroupMonitor(
             self._log_message(f"❌ FATAL ERROR: {e}")
             self._send_notification(
                 f"❌ **FATAL ERROR**\nError: {e}",
-                self.config.NOTIFY_FAILURE
+                self.config.NOTIFY_FAILURE,
+                category="lifecycle",
             )
+            # Slice 3: tag this exit so the next start emits
+            # "🚀 Restarted (last instance exited fatally)" rather than
+            # a generic Started.
+            try:
+                from pathlib import Path
+                write_shutdown_marker(
+                    Path(self.config.statistics.db_directory),
+                    version=__version__, reason=REASON_FATAL,
+                )
+            except Exception:
+                # Marker write must never mask the original FATAL.
+                pass
             raise
 
     def _initialize(self):
@@ -240,11 +264,12 @@ class UPSGroupMonitor(
         self._check_dependencies()
 
         self._log_message(f"🚀 Eneru v{__version__} starting - monitoring {self.config.ups.name}")
-        self._send_notification(
-            f"🚀 **Eneru v{__version__} Started**\nMonitoring {self.config.ups.name}",
-            self.config.NOTIFY_INFO,
-            category="lifecycle",
-        )
+        # Always invoke — the helper updates meta.last_seen_version for
+        # next-start upgrade detection. The actual SEND is suppressed in
+        # coordinator mode because the coordinator emits ONE classified
+        # lifecycle notification at the multi_ups level (per-monitor
+        # sends would be N copies of the same event).
+        self._emit_lifecycle_startup_notification()
 
         if self.config.behavior.dry_run:
             self._log_message("🧪 *** RUNNING IN DRY-RUN MODE - NO ACTUAL SHUTDOWN WILL OCCUR ***")
@@ -306,6 +331,65 @@ class UPSGroupMonitor(
         else:
             self._log_message("⚠️ WARNING: Failed to initialize notifications")
             self.config.notifications.enabled = False
+
+    def _emit_lifecycle_startup_notification(self):
+        """Update lifecycle meta + (single-UPS only) emit the classified
+        startup notification.
+
+        Replaces the v5.1 unconditional ``🚀 Started`` so the user sees:
+        - ``📦 Upgraded vX → vY`` after a deb/rpm upgrade
+        - ``📊 Recovered`` after a power-loss-triggered shutdown
+        - ``🔄 Restarted`` after a quick `systemctl restart`
+        - ``🚀 Started (after crash)`` if the previous instance died
+          without writing its marker
+        - ``🚀 Started`` on a fresh install
+
+        In coordinator mode the coordinator emits the single classified
+        notification at the multi_ups level (firing per monitor would be
+        N copies of the same event); we still update
+        ``meta.last_seen_version`` here so the next-start pip-path
+        upgrade detector has its data.
+        """
+        # Read the PREVIOUS last_seen_version BEFORE we overwrite it
+        # with the current run's version — the classifier needs the
+        # delta to detect a pip-path upgrade. After classification, set
+        # to current so the NEXT start sees this run's version as
+        # "previous".
+        last_seen = (self._stats_store.get_meta("last_seen_version")
+                     if self._stats_store._conn is not None else None)
+        if self._stats_store._conn is not None:
+            self._stats_store.set_meta("last_seen_version", __version__)
+
+        if self._coordinator_mode:
+            return
+
+        from pathlib import Path
+        stats_dir = Path(self.config.statistics.db_directory)
+        shutdown_marker = read_shutdown_marker(stats_dir)
+        upgrade_marker = read_upgrade_marker(stats_dir)
+
+        body, notify_type = classify_startup(
+            current_version=__version__,
+            shutdown_marker=shutdown_marker,
+            upgrade_marker=upgrade_marker,
+            last_seen_version=last_seen,
+        )
+
+        # Cancel any pending lifecycle rows from the previous instance —
+        # they're superseded by the new classification (Restarted folds
+        # the previous "Stopped", Recovered folds the previous "Stopped",
+        # etc.). Keeps the user from seeing ghost messages on the next
+        # successful delivery.
+        if self._stats_store._conn is not None:
+            for row in self._stats_store.find_pending_by_category("lifecycle"):
+                self._stats_store.cancel_notification(row[0], "superseded")
+
+        # Markers consumed — drop them now so a crash on the next line
+        # doesn't replay this classification on the start after that.
+        delete_shutdown_marker(stats_dir)
+        delete_upgrade_marker(stats_dir)
+
+        self._send_notification(body, notify_type, category="lifecycle")
 
     def _log_enabled_features(self):
         """Log which features are enabled."""
@@ -731,6 +815,17 @@ class UPSGroupMonitor(
                 if self._notification_worker:
                     self._notification_worker.flush(timeout=5)
 
+                # Slice 3: tag this shutdown as power-loss-triggered so
+                # the next start can emit "📊 Recovered" and (with Slice
+                # 4 coalescing) fold this run's "Shutdown sequence
+                # complete" notification into one richer message.
+                from pathlib import Path
+                write_shutdown_marker(
+                    Path(self.config.statistics.db_directory),
+                    version=__version__,
+                    reason=REASON_SEQUENCE_COMPLETE,
+                )
+
                 cmd_parts = self.config.local_shutdown.command.split()
                 if self.config.local_shutdown.message:
                     cmd_parts.append(self.config.local_shutdown.message)
@@ -777,6 +872,9 @@ class UPSGroupMonitor(
 
     def _cleanup_and_exit(self, signum: int, frame):
         """Handle clean exit on signals."""
+        from pathlib import Path
+        stats_dir = Path(self.config.statistics.db_directory)
+
         if self._shutdown_flag_path.exists():
             if self._notification_worker:
                 # Mid-shutdown signal: still try to drain any in-flight
@@ -807,6 +905,13 @@ class UPSGroupMonitor(
             self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
         self._stop_stats()
+
+        # Slice 3: drop the shutdown marker so the next start can
+        # classify this exit (signal → "🔄 Restarted" if it comes back
+        # within RESTART_DOWNTIME_THRESHOLD_SECS, else cold "Started").
+        write_shutdown_marker(
+            stats_dir, version=__version__, reason=REASON_SIGNAL,
+        )
 
         self._shutdown_flag_path.unlink(missing_ok=True)
         sys.exit(0)

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -322,14 +322,6 @@ class UPSGroupMonitor(
             timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             print(f"{timestamp} {tz_name} - {prefixed}")
 
-        # During shutdown, also send log messages as notifications (non-blocking)
-        if self._shutdown_flag_path.exists():
-            discord_safe_message = message.replace('`', '\\`')
-            self._send_notification(
-                f"ℹ️ **Shutdown Detail:** {discord_safe_message}",
-                self.config.NOTIFY_INFO
-            )
-
     def _send_notification(self, body: str, notify_type: str = "info",
                            blocking: bool = False):
         """Send a notification via the notification worker.
@@ -628,13 +620,14 @@ class UPSGroupMonitor(
     def _execute_shutdown_sequence(self):
         """Execute the controlled shutdown sequence."""
         self._shutdown_flag_path.touch()
+        sequence_start = time.monotonic()
 
-        self._log_message("🚨 ========== INITIATING EMERGENCY SHUTDOWN SEQUENCE ==========")
+        self._log_message("🚨 Initiating emergency shutdown sequence")
 
         if self.config.behavior.dry_run:
             self._log_message("🧪 *** DRY-RUN MODE: No actual shutdown will occur ***")
 
-        if not self.config.behavior.dry_run:
+        if self.config.local_shutdown.wall and not self.config.behavior.dry_run:
             run_command([
                 "wall",
                 "🚨 CRITICAL: Executing emergency UPS shutdown sequence NOW!"
@@ -663,27 +656,32 @@ class UPSGroupMonitor(
 
         # In coordinator mode, notify the coordinator instead of doing local shutdown
         if self._coordinator_mode:
-            self._log_message("✅ ========== GROUP SHUTDOWN SEQUENCE COMPLETE ==========")
+            self._log_message("✅ Group shutdown sequence complete")
             if self._shutdown_callback:
                 group = self.config.ups_groups[0] if self.config.ups_groups else None
                 self._shutdown_callback(group)
             return
 
+        elapsed = int(time.monotonic() - sequence_start)
         if self.config.local_shutdown.enabled:
             self._log_message("🔌 Shutting down local server NOW")
-            self._log_message("✅ ========== SHUTDOWN SEQUENCE COMPLETE ==========")
+            self._log_message("✅ Shutdown sequence complete")
 
             if self.config.behavior.dry_run:
                 self._log_message(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
                 self._log_message("🧪 [DRY-RUN] Shutdown sequence completed successfully (no actual shutdown)")
                 self._shutdown_flag_path.unlink(missing_ok=True)
             else:
-                # Send final notification (non-blocking - fire and forget)
+                # Single-shot summary notification covering the whole sequence;
+                # the per-phase chatter that used to mirror every log line is
+                # gone in v5.2 (journalctl is the forensic record).
                 self._send_notification(
-                    "🛑 **Shutdown Sequence Complete**\nShutting down local server NOW.",
+                    f"✅ **Shutdown Sequence Complete** (took {elapsed}s)\n"
+                    f"Powering down local server NOW.",
                     self.config.NOTIFY_FAILURE
                 )
-                # Give notification time to send
+                # Give notification time to send. Slice 5 replaces this with
+                # NotificationWorker.flush(timeout=5).
                 time.sleep(5)
 
                 cmd_parts = self.config.local_shutdown.command.split()
@@ -691,7 +689,12 @@ class UPSGroupMonitor(
                     cmd_parts.append(self.config.local_shutdown.message)
                 run_command(cmd_parts)
         else:
-            self._log_message("✅ ========== SHUTDOWN SEQUENCE COMPLETE (local shutdown disabled) ==========")
+            self._log_message("✅ Shutdown sequence complete (local shutdown disabled)")
+            self._send_notification(
+                f"✅ **Shutdown Sequence Complete** (took {elapsed}s)\n"
+                f"Local shutdown is disabled — system stays up.",
+                self.config.NOTIFY_INFO
+            )
             self._shutdown_flag_path.unlink(missing_ok=True)
 
             # Exit if --exit-after-shutdown was specified
@@ -715,7 +718,7 @@ class UPSGroupMonitor(
         )
 
         self._log_message(f"🚨 CRITICAL: Triggering immediate shutdown. Reason: {reason}")
-        if not self.config.behavior.dry_run:
+        if self.config.local_shutdown.wall and not self.config.behavior.dry_run:
             run_command([
                 "wall",
                 f"🚨 CRITICAL: UPS battery critical! Immediate shutdown initiated! Reason: {reason}"

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -622,7 +622,7 @@ class UPSGroupMonitor(
         self._shutdown_flag_path.touch()
         sequence_start = time.monotonic()
 
-        self._log_message("🚨 Initiating emergency shutdown sequence")
+        self._log_message("🚨 INITIATING EMERGENCY SHUTDOWN SEQUENCE")
 
         if self.config.behavior.dry_run:
             self._log_message("🧪 *** DRY-RUN MODE: No actual shutdown will occur ***")
@@ -656,7 +656,7 @@ class UPSGroupMonitor(
 
         # In coordinator mode, notify the coordinator instead of doing local shutdown
         if self._coordinator_mode:
-            self._log_message("✅ Group shutdown sequence complete")
+            self._log_message("✅ GROUP SHUTDOWN SEQUENCE COMPLETE")
             if self._shutdown_callback:
                 group = self.config.ups_groups[0] if self.config.ups_groups else None
                 self._shutdown_callback(group)
@@ -665,7 +665,7 @@ class UPSGroupMonitor(
         elapsed = int(time.monotonic() - sequence_start)
         if self.config.local_shutdown.enabled:
             self._log_message("🔌 Shutting down local server NOW")
-            self._log_message("✅ Shutdown sequence complete")
+            self._log_message("✅ SHUTDOWN SEQUENCE COMPLETE")
 
             if self.config.behavior.dry_run:
                 self._log_message(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
@@ -689,7 +689,7 @@ class UPSGroupMonitor(
                     cmd_parts.append(self.config.local_shutdown.message)
                 run_command(cmd_parts)
         else:
-            self._log_message("✅ Shutdown sequence complete (local shutdown disabled)")
+            self._log_message("✅ SHUTDOWN SEQUENCE COMPLETE (local shutdown disabled)")
             self._send_notification(
                 f"✅ **Shutdown Sequence Complete** (took {elapsed}s)\n"
                 f"Local shutdown is disabled — system stays up.",

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -25,6 +25,7 @@ from eneru.lifecycle import (
     REASON_SEQUENCE_COMPLETE,
     REASON_SIGNAL,
     classify_startup,
+    coalesce_recovered_with_prev_shutdown,
     delete_shutdown_marker,
     delete_upgrade_marker,
     read_shutdown_marker,
@@ -383,6 +384,23 @@ class UPSGroupMonitor(
         if self._stats_store._conn is not None:
             for row in self._stats_store.find_pending_by_category("lifecycle"):
                 self._stats_store.cancel_notification(row[0], "superseded")
+
+        # Slice 4 bonus: when this start is "Recovered" (reason was
+        # sequence_complete), fold the previous instance's pending
+        # shutdown headline + summary into ONE richer message. Saves the
+        # user from seeing 3 messages (headline + summary + recovered)
+        # for what's really a single power-outage round trip.
+        if (shutdown_marker
+                and shutdown_marker.get("reason") == REASON_SEQUENCE_COMPLETE
+                and self._stats_store._conn is not None):
+            import time as _time
+            downtime = max(0, int(_time.time())
+                           - int(shutdown_marker.get("shutdown_at", 0)))
+            coalesced_body = coalesce_recovered_with_prev_shutdown(
+                self._stats_store, downtime_secs=downtime,
+            )
+            if coalesced_body:
+                body = coalesced_body
 
         # Markers consumed — drop them now so a crash on the next line
         # doesn't replay this classification on the start after that.

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -129,14 +129,20 @@ class UPSGroupMonitor(
         self._stats_writer: Optional[StatsWriter] = None
 
     def _start_stats(self):
-        """Open the per-UPS stats DB and start the background writer.
+        """Open the per-UPS stats DB (if not already open) and start the
+        background writer.
 
-        SQLite errors are isolated -- a failure here logs once and the
-        daemon continues to run without stats persistence.
+        v5.2: ``_initialize_notifications`` opens the store earlier so
+        the notification worker can persist messages from the very first
+        notification. We keep the open() call here for the
+        ``notifications.enabled=False`` path where _initialize_notifications
+        skips the open. SQLite errors are isolated — a failure here
+        logs once and the daemon continues without stats persistence.
         """
         try:
-            self._stats_store._logger = self.logger
-            self._stats_store.open()
+            if self._stats_store._conn is None:
+                self._stats_store._logger = self.logger
+                self._stats_store.open()
         except Exception as e:
             self._log_message(
                 f"⚠️ WARNING: stats store open failed at {self._stats_db_path}: {e}. "
@@ -236,7 +242,8 @@ class UPSGroupMonitor(
         self._log_message(f"🚀 Eneru v{__version__} starting - monitoring {self.config.ups.name}")
         self._send_notification(
             f"🚀 **Eneru v{__version__} Started**\nMonitoring {self.config.ups.name}",
-            self.config.NOTIFY_INFO
+            self.config.NOTIFY_INFO,
+            category="lifecycle",
         )
 
         if self.config.behavior.dry_run:
@@ -248,9 +255,36 @@ class UPSGroupMonitor(
         self._start_stats()
 
     def _initialize_notifications(self):
-        """Initialize the notification worker."""
-        # In coordinator mode, the notification worker is shared and pre-initialized
+        """Initialize the notification worker.
+
+        v5.2 wires the worker to the per-UPS stats DB so notifications
+        can be persisted and replayed across restarts. The store is
+        opened early (here) — earlier than ``_start_stats()`` — because
+        the very first notification (the lifecycle "Started" / "Recovered"
+        message) fires before stats opens by the legacy ordering, and
+        we want it persisted too.
+
+        In coordinator mode the worker is created externally and shared;
+        we still open + register our store so the shared worker can pick
+        up our pending rows on the next iteration.
+        """
+        # Open the per-UPS stats store now (idempotent; _start_stats
+        # will skip the open() call if it sees us already opened it).
+        try:
+            if self._stats_store._conn is None:
+                self._stats_store._logger = self.logger
+                self._stats_store.open()
+        except Exception as e:
+            self._log_message(
+                f"⚠️ WARNING: stats store open failed at "
+                f"{self._stats_db_path}: {e}. Notifications will not "
+                "persist across restarts."
+            )
+
         if self._notification_worker is not None:
+            # Coordinator mode: register our store with the shared worker.
+            if self._stats_store._conn is not None:
+                self._notification_worker.register_store(self._stats_store)
             return
 
         if not self.config.notifications.enabled:
@@ -265,6 +299,8 @@ class UPSGroupMonitor(
 
         self._notification_worker = NotificationWorker(self.config)
         if self._notification_worker.start():
+            if self._stats_store._conn is not None:
+                self._notification_worker.register_store(self._stats_store)
             service_count = self._notification_worker.get_service_count()
             self._log_message(f"📢 Notifications: enabled ({service_count} service(s))")
         else:
@@ -323,38 +359,42 @@ class UPSGroupMonitor(
             print(f"{timestamp} {tz_name} - {prefixed}")
 
     def _send_notification(self, body: str, notify_type: str = "info",
-                           blocking: bool = False):
-        """Send a notification via the notification worker.
+                           blocking: bool = False,
+                           category: str = "general"):
+        """Queue a notification via the persistent notification worker.
 
-        IMPORTANT: During shutdown sequences, notifications are ALWAYS non-blocking.
-        This ensures that network failures (common during power outages) do not
-        delay the critical shutdown process. The blocking parameter is only
-        honored for non-shutdown scenarios like --test-notifications.
+        v5.2 change: notifications are inserted as ``pending`` rows in
+        the per-UPS stats DB before delivery is attempted. The worker
+        thread reads/writes through the DB, so messages survive process
+        death and prolonged endpoint outages — see ``notifications.py``
+        for the full architecture.
 
         Args:
-            body: Notification body text
-            notify_type: One of 'info', 'success', 'warning', 'failure'
-            blocking: If True AND not during shutdown, wait for send completion.
-                      Ignored during shutdown to prevent delays.
+            body: Notification body text.
+            notify_type: One of 'info', 'success', 'warning', 'failure'.
+            blocking: Back-compat shim. The v5.2 queue is always
+                asynchronous (delivery happens on the worker thread).
+                The flag is accepted for API stability but ignored.
+            category: Coarse classification used by Slice 4 coalescing
+                and per-category queries. Common values: ``lifecycle``,
+                ``power_event``, ``voltage``, ``shutdown``,
+                ``shutdown_summary``, ``general`` (default).
         """
+        del blocking  # see docstring
         if not self._notification_worker:
             return
 
-        # Prefix notification body with UPS name in multi-UPS mode
+        # Prefix notification body with UPS name in multi-UPS mode.
         prefixed_body = f"{self._log_prefix}{body}" if self._log_prefix else body
 
         # Escape @ symbols to prevent Discord mentions (e.g., UPS@192.168.1.1)
         escaped_body = prefixed_body.replace("@", "@\u200B")  # Zero-width space after @
 
-        # CRITICAL: During shutdown, NEVER block on notifications
-        # Network is likely unreliable during power outages
-        is_shutdown = self._shutdown_flag_path.exists()
-        actual_blocking = blocking and not is_shutdown
-
         self._notification_worker.send(
             body=escaped_body,
             notify_type=notify_type,
-            blocking=actual_blocking
+            category=category,
+            store=self._stats_store,
         )
 
     def _log_power_event(self, event: str, details: str,
@@ -483,7 +523,9 @@ class UPSGroupMonitor(
             )
 
         if notification:
-            self._send_notification(*notification)
+            self._send_notification(
+                *notification, category="power_event",
+            )
 
     def _check_dependencies(self):
         """Check for required and optional dependencies."""
@@ -678,7 +720,8 @@ class UPSGroupMonitor(
                 self._send_notification(
                     f"✅ **Shutdown Sequence Complete** (took {elapsed}s)\n"
                     f"Powering down local server NOW.",
-                    self.config.NOTIFY_FAILURE
+                    self.config.NOTIFY_FAILURE,
+                    category="shutdown_summary",
                 )
                 # Give notification time to send. Slice 5 replaces this with
                 # NotificationWorker.flush(timeout=5).
@@ -693,7 +736,8 @@ class UPSGroupMonitor(
             self._send_notification(
                 f"✅ **Shutdown Sequence Complete** (took {elapsed}s)\n"
                 f"Local shutdown is disabled — system stays up.",
-                self.config.NOTIFY_INFO
+                self.config.NOTIFY_INFO,
+                category="shutdown_summary",
             )
             self._shutdown_flag_path.unlink(missing_ok=True)
 
@@ -714,7 +758,8 @@ class UPSGroupMonitor(
             f"🚨 **EMERGENCY SHUTDOWN INITIATED!**\n"
             f"Reason: {reason}\n"
             "Executing shutdown tasks (VMs, Containers, Remote Servers).",
-            self.config.NOTIFY_FAILURE
+            self.config.NOTIFY_FAILURE,
+            category="shutdown",
         )
 
         self._log_message(f"🚨 CRITICAL: Triggering immediate shutdown. Reason: {reason}")
@@ -741,7 +786,8 @@ class UPSGroupMonitor(
         # Send notification (non-blocking - fire and forget)
         self._send_notification(
             "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
-            self.config.NOTIFY_WARNING
+            self.config.NOTIFY_WARNING,
+            category="lifecycle",
         )
 
         if self._notification_worker:

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -20,6 +20,16 @@ from eneru.logger import UPSLogger
 from eneru.notifications import APPRISE_AVAILABLE, NotificationWorker
 from eneru.monitor import UPSGroupMonitor
 from eneru.redundancy import RedundancyGroupEvaluator, RedundancyGroupExecutor
+from eneru.lifecycle import (
+    REASON_SEQUENCE_COMPLETE,
+    REASON_SIGNAL,
+    classify_startup,
+    delete_shutdown_marker,
+    delete_upgrade_marker,
+    read_shutdown_marker,
+    read_upgrade_marker,
+    write_shutdown_marker,
+)
 from eneru.utils import run_command
 
 
@@ -96,6 +106,33 @@ class MultiUPSCoordinator:
 
         if self.config.behavior.dry_run:
             self._log("🧪 *** RUNNING IN DRY-RUN MODE - NO ACTUAL SHUTDOWN WILL OCCUR ***")
+
+        # Slice 3: emit ONE classified lifecycle notification at the
+        # coordinator level (the per-monitor _emit_lifecycle_startup
+        # is suppressed in coordinator_mode so we don't get N copies).
+        # Marker file ops only need a directory; meta.last_seen_version
+        # update is deferred to the per-monitor startup which has a
+        # store handle.
+        if self._notification_worker:
+            stats_dir = Path(self.config.statistics.db_directory)
+            shutdown_marker = read_shutdown_marker(stats_dir)
+            upgrade_marker = read_upgrade_marker(stats_dir)
+            body, notify_type = classify_startup(
+                current_version=__version__,
+                shutdown_marker=shutdown_marker,
+                upgrade_marker=upgrade_marker,
+                # In coordinator mode the meta lookup defers to the
+                # per-monitor lifecycle pass, which still runs (the
+                # _coordinator_mode skip there is only for the SEND).
+                # Pass None so the classifier doesn't attempt a pip-path
+                # version comparison without the data.
+                last_seen_version=None,
+            )
+            self._notification_worker.send(
+                body=body, notify_type=notify_type, category="lifecycle",
+            )
+            delete_shutdown_marker(stats_dir)
+            delete_upgrade_marker(stats_dir)
 
     def _start_monitors(self):
         """Create and start one UPSGroupMonitor thread per group."""

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -186,9 +186,13 @@ class MultiUPSCoordinator:
             label = group.ups.label
             self._log(f"❌ Monitor thread for {label} crashed: {e}")
             if self._notification_worker:
+                # The monitor's _stats_store is opened by _initialize_notifications,
+                # so it's safe to pin the destination here.
                 self._notification_worker.send(
                     f"❌ **Monitor Crashed:** {label}\nError: {e}",
                     "failure",
+                    category="lifecycle",
+                    store=getattr(monitor, "_stats_store", None),
                 )
 
     def _on_group_shutdown(self, group):
@@ -247,6 +251,7 @@ class MultiUPSCoordinator:
                     self._notification_worker.send(
                         "🛑 **Shutdown Sequence Complete**\nShutting down local server NOW.",
                         "failure",
+                        category="shutdown_summary",
                     )
                 time.sleep(5)
                 cmd_parts = self.config.local_shutdown.command.split()
@@ -326,6 +331,7 @@ class MultiUPSCoordinator:
             self._notification_worker.send(
                 "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
                 "warning",
+                category="lifecycle",
             )
 
         self._stop_event.set()

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -265,13 +265,19 @@ class MultiUPSCoordinator:
             label = group.ups.label
             self._log(f"❌ Monitor thread for {label} crashed: {e}")
             if self._notification_worker:
-                # The monitor's _stats_store is opened by _initialize_notifications,
-                # so it's safe to pin the destination here.
+                # Pin to the monitor's store ONLY if it actually opened
+                # (the crash may have happened before _initialize_notifications
+                # got that far). Otherwise pass None so the worker can
+                # fall back to another registered store or the pre-store
+                # buffer (Cubic P2).
+                store = getattr(monitor, "_stats_store", None)
+                if store is not None and getattr(store, "_conn", None) is None:
+                    store = None
                 self._notification_worker.send(
                     f"❌ **Monitor Crashed:** {label}\nError: {e}",
                     "failure",
                     category="lifecycle",
-                    store=getattr(monitor, "_stats_store", None),
+                    store=store,
                 )
 
     def _on_group_shutdown(self, group):
@@ -447,11 +453,21 @@ class MultiUPSCoordinator:
         # if it comes back within RESTART_DOWNTIME_THRESHOLD_SECS, else
         # "🚀 Started (last seen Nh ago)". Coordinator mode was missing
         # this — caught in pre-push review.
-        write_shutdown_marker(
-            Path(self.config.statistics.db_directory),
-            version=__version__,
-            reason=REASON_SIGNAL,
-        )
+        # BUT: don't downgrade an existing sequence_complete marker
+        # (Cubic P2). If a power-loss shutdown sequence already wrote
+        # it, the SIGTERM handler that fires when systemd shuts the
+        # service down should preserve "we shut ourselves down for a
+        # reason" so the next start emits "📊 Recovered" rather than
+        # "🔄 Restarted".
+        stats_dir = Path(self.config.statistics.db_directory)
+        existing = read_shutdown_marker(stats_dir)
+        if not (existing
+                and existing.get("reason") == REASON_SEQUENCE_COMPLETE):
+            write_shutdown_marker(
+                stats_dir,
+                version=__version__,
+                reason=REASON_SIGNAL,
+            )
 
         self._global_shutdown_flag.unlink(missing_ok=True)
         sys.exit(0)

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -253,7 +253,11 @@ class MultiUPSCoordinator:
                         "failure",
                         category="shutdown_summary",
                     )
-                time.sleep(5)
+                    # Drain in flight before halt; lossless guarantee on
+                    # what doesn't make it.
+                    self._notification_worker.flush(timeout=5)
+                else:
+                    time.sleep(5)
                 cmd_parts = self.config.local_shutdown.command.split()
                 if self.config.local_shutdown.message:
                     cmd_parts.append(self.config.local_shutdown.message)
@@ -343,6 +347,10 @@ class MultiUPSCoordinator:
             thread.join(timeout=5)
 
         if self._notification_worker:
+            # Same SIGTERM-race fix as in monitor.py:_cleanup_and_exit:
+            # drain the queue before joining the worker thread so the
+            # final 'Service Stopped' notification actually ships.
+            self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
 
         self._global_shutdown_flag.unlink(missing_ok=True)

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -20,6 +20,7 @@ from eneru.logger import UPSLogger
 from eneru.notifications import APPRISE_AVAILABLE, NotificationWorker
 from eneru.monitor import UPSGroupMonitor
 from eneru.redundancy import RedundancyGroupEvaluator, RedundancyGroupExecutor
+from eneru.stats import StatsStore
 from eneru.lifecycle import (
     REASON_SEQUENCE_COMPLETE,
     REASON_SIGNAL,
@@ -110,29 +111,70 @@ class MultiUPSCoordinator:
         # Slice 3: emit ONE classified lifecycle notification at the
         # coordinator level (the per-monitor _emit_lifecycle_startup
         # is suppressed in coordinator_mode so we don't get N copies).
-        # Marker file ops only need a directory; meta.last_seen_version
-        # update is deferred to the per-monitor startup which has a
-        # store handle.
+        # Markers + classification ALWAYS run; the SEND only fires when
+        # a notification worker is configured. Otherwise the markers
+        # would leak across configurations (P2 finding from review).
+        stats_dir = Path(self.config.statistics.db_directory)
+        shutdown_marker = read_shutdown_marker(stats_dir)
+        upgrade_marker = read_upgrade_marker(stats_dir)
+
+        # Pip-path upgrade detection in coord mode: peek at the first
+        # group's stats DB for meta.last_seen_version. Without this the
+        # coordinator passes None and a pip user upgrading via
+        # `pip install -U eneru` between runs gets "Restarted" instead
+        # of "📦 Upgraded vX → vY" (caught in pre-push review).
+        last_seen = self._read_last_seen_version_from_first_group(stats_dir)
+
+        body, notify_type = classify_startup(
+            current_version=__version__,
+            shutdown_marker=shutdown_marker,
+            upgrade_marker=upgrade_marker,
+            last_seen_version=last_seen,
+        )
         if self._notification_worker:
-            stats_dir = Path(self.config.statistics.db_directory)
-            shutdown_marker = read_shutdown_marker(stats_dir)
-            upgrade_marker = read_upgrade_marker(stats_dir)
-            body, notify_type = classify_startup(
-                current_version=__version__,
-                shutdown_marker=shutdown_marker,
-                upgrade_marker=upgrade_marker,
-                # In coordinator mode the meta lookup defers to the
-                # per-monitor lifecycle pass, which still runs (the
-                # _coordinator_mode skip there is only for the SEND).
-                # Pass None so the classifier doesn't attempt a pip-path
-                # version comparison without the data.
-                last_seen_version=None,
-            )
             self._notification_worker.send(
                 body=body, notify_type=notify_type, category="lifecycle",
             )
-            delete_shutdown_marker(stats_dir)
-            delete_upgrade_marker(stats_dir)
+        # Always consume the markers so the next start doesn't replay
+        # this classification. Safe whether or not the SEND happened —
+        # the per-monitor lifecycle pass updates last_seen_version on
+        # every store from inside its _emit_lifecycle_startup_notification
+        # (which still runs in coordinator mode for the meta side).
+        delete_shutdown_marker(stats_dir)
+        delete_upgrade_marker(stats_dir)
+
+    def _read_last_seen_version_from_first_group(self, stats_dir):
+        """Read meta.last_seen_version from the first group's stats DB
+        (read-only). Returns ``None`` if the DB doesn't exist yet (first
+        ever start) or the row is missing.
+
+        Coordinator startup runs BEFORE any monitor opens its DB write
+        connection, so we use StatsStore.open_readonly to avoid stepping
+        on the writer. Any exception here is swallowed — the worst case
+        is the classifier degrades to "no pip-path upgrade detected"."""
+        if not self.config.ups_groups:
+            return None
+        first = self.config.ups_groups[0]
+        sanitized = first.ups.name.replace("@", "-").replace(":", "-").replace("/", "-")
+        db_path = stats_dir / f"{sanitized}.db"
+        try:
+            conn = StatsStore.open_readonly(db_path)
+        except Exception:
+            return None
+        if conn is None:
+            return None
+        try:
+            row = conn.execute(
+                "SELECT value FROM meta WHERE key='last_seen_version'"
+            ).fetchone()
+            return str(row[0]) if row and row[0] else None
+        except Exception:
+            return None
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
     def _start_monitors(self):
         """Create and start one UPSGroupMonitor thread per group."""
@@ -295,6 +337,17 @@ class MultiUPSCoordinator:
                     self._notification_worker.flush(timeout=5)
                 else:
                     time.sleep(5)
+                # Slice 3: tag this shutdown as power-loss-triggered so
+                # the next start can emit "📊 Recovered" and the Slice 4
+                # bonus folds the prev shutdown into a richer message.
+                # (Single-UPS path already does this in monitor.py;
+                # coordinator mode was missing it — caught in pre-push
+                # review.)
+                write_shutdown_marker(
+                    Path(self.config.statistics.db_directory),
+                    version=__version__,
+                    reason=REASON_SEQUENCE_COMPLETE,
+                )
                 cmd_parts = self.config.local_shutdown.command.split()
                 if self.config.local_shutdown.message:
                     cmd_parts.append(self.config.local_shutdown.message)
@@ -389,6 +442,16 @@ class MultiUPSCoordinator:
             # final 'Service Stopped' notification actually ships.
             self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
+
+        # Slice 3: tag this exit so the next start can emit "🔄 Restarted"
+        # if it comes back within RESTART_DOWNTIME_THRESHOLD_SECS, else
+        # "🚀 Started (last seen Nh ago)". Coordinator mode was missing
+        # this — caught in pre-push review.
+        write_shutdown_marker(
+            Path(self.config.statistics.db_directory),
+            version=__version__,
+            reason=REASON_SIGNAL,
+        )
 
         self._global_shutdown_flag.unlink(missing_ok=True)
         sys.exit(0)

--- a/src/eneru/notifications.py
+++ b/src/eneru/notifications.py
@@ -278,13 +278,25 @@ class NotificationWorker:
                 pass
 
     def _drain_once(self) -> None:
-        """One pass: look at the oldest pending across all stores, try
-        to deliver it, then continue while there's more to do.
+        """One pass: coalesce, then look at the oldest pending across all
+        stores, try to deliver it, then continue while there's more to do.
 
         Bounded by the stop event so a long backlog can't block shutdown
         indefinitely (and ``flush()`` still polls until empty up to its
         own timeout).
         """
+        # Slice 4: fold same-outage on_battery + on_line pairs into a
+        # single "Brief outage" summary BEFORE delivery so the user sees
+        # one message instead of two when the network was down for the
+        # duration of a short blip.
+        with self._stores_lock:
+            stores_snapshot = list(self._stores)
+        for store in stores_snapshot:
+            try:
+                self._coalesce_pending_outages(store)
+            except Exception:
+                pass  # coalescing must never block delivery
+
         max_iters = 1000  # Defensive — large bursts must still drain.
         for _ in range(max_iters):
             if self._stop_event.is_set():
@@ -299,6 +311,55 @@ class NotificationWorker:
                 store=store, row_id=row_id, body=body,
                 notify_type=notify_type, attempts=attempts,
             )
+
+    def _coalesce_pending_outages(self, store) -> int:
+        """Pair pending ON_BATTERY + POWER_RESTORED rows into a single
+        "Brief outage" summary. Returns count of pairs coalesced.
+
+        The match is body-substring based — both events come through
+        ``_log_power_event`` and the body always carries the event name
+        in ``"⚡ **Event:** <NAME>\\n..."`` form. Cheap to scan; runs
+        once per worker iteration.
+
+        Both rows must still be ``pending`` for coalescing to apply.
+        Once one of the pair has shipped (the network was up at one end
+        but not the other), they go out separately.
+        """
+        rows = store.find_pending_by_category("power_event") or []
+        coalesced = 0
+        from datetime import datetime
+        from eneru.utils import format_seconds
+
+        on_battery = None
+        for row_id, ts, body, notify_type in rows:
+            body_str = str(body)
+            if "ON_BATTERY" in body_str:
+                # If we'd already seen one without finding its restore,
+                # keep the latest (the most recent outage start).
+                on_battery = (row_id, ts, body_str, notify_type)
+                continue
+            if on_battery and "POWER_RESTORED" in body_str:
+                ob_id, ob_ts, _, _ = on_battery
+                duration = max(0, ts - ob_ts)
+                start_str = datetime.fromtimestamp(ob_ts).strftime("%H:%M:%S")
+                end_str = datetime.fromtimestamp(ts).strftime("%H:%M:%S")
+                summary_body = (
+                    f"📊 **Brief Power Outage**\n"
+                    f"On battery for {format_seconds(duration)} "
+                    f"({start_str} → {end_str})."
+                )
+                # Use the end timestamp so the summary sorts AFTER any
+                # other unrelated pending power events from before the
+                # outage.
+                store.enqueue_notification(
+                    body=summary_body, notify_type="info",
+                    category="power_event", ts=ts,
+                )
+                store.cancel_notification(ob_id, "coalesced")
+                store.cancel_notification(row_id, "coalesced")
+                coalesced += 1
+                on_battery = None
+        return coalesced
 
     def _next_due_candidate(self) -> Optional[Tuple]:
         """Return the oldest pending row across all registered stores

--- a/src/eneru/notifications.py
+++ b/src/eneru/notifications.py
@@ -313,52 +313,65 @@ class NotificationWorker:
             )
 
     def _coalesce_pending_outages(self, store) -> int:
-        """Pair pending ON_BATTERY + POWER_RESTORED rows into a single
+        """Pair pending on_battery + on_line rows into a single
         "Brief outage" summary. Returns count of pairs coalesced.
 
-        The match is body-substring based — both events come through
-        ``_log_power_event`` and the body always carries the event name
-        in ``"⚡ **Event:** <NAME>\\n..."`` form. Cheap to scan; runs
-        once per worker iteration.
+        Pairs are identified by sub-typed category (set in
+        ``UPSGroupMonitor._log_power_event``):
+        ``power_event_on_battery`` and ``power_event_on_line``. Exact
+        category match keeps the coalescer from depending on the
+        user-visible body wording, which changes more often than the
+        category enum.
 
         Both rows must still be ``pending`` for coalescing to apply.
         Once one of the pair has shipped (the network was up at one end
         but not the other), they go out separately.
         """
-        rows = store.find_pending_by_category("power_event") or []
-        coalesced = 0
+        on_batt_rows = store.find_pending_by_category(
+            "power_event_on_battery"
+        ) or []
+        on_line_rows = store.find_pending_by_category(
+            "power_event_on_line"
+        ) or []
+        if not on_batt_rows or not on_line_rows:
+            return 0
+
         from datetime import datetime
         from eneru.utils import format_seconds
 
-        on_battery = None
-        for row_id, ts, body, notify_type in rows:
-            body_str = str(body)
-            if "ON_BATTERY" in body_str:
-                # If we'd already seen one without finding its restore,
-                # keep the latest (the most recent outage start).
-                on_battery = (row_id, ts, body_str, notify_type)
-                continue
-            if on_battery and "POWER_RESTORED" in body_str:
-                ob_id, ob_ts, _, _ = on_battery
-                duration = max(0, ts - ob_ts)
-                start_str = datetime.fromtimestamp(ob_ts).strftime("%H:%M:%S")
-                end_str = datetime.fromtimestamp(ts).strftime("%H:%M:%S")
-                summary_body = (
-                    f"📊 **Brief Power Outage**\n"
-                    f"On battery for {format_seconds(duration)} "
-                    f"({start_str} → {end_str})."
-                )
-                # Use the end timestamp so the summary sorts AFTER any
-                # other unrelated pending power events from before the
-                # outage.
-                store.enqueue_notification(
-                    body=summary_body, notify_type="info",
-                    category="power_event", ts=ts,
-                )
-                store.cancel_notification(ob_id, "coalesced")
-                store.cancel_notification(row_id, "coalesced")
-                coalesced += 1
-                on_battery = None
+        # Pair each on_battery with the next on_line whose ts is later.
+        # Both lists are sorted by ts ASC from the store query.
+        coalesced = 0
+        line_idx = 0
+        for ob_id, ob_ts, _, _ in on_batt_rows:
+            # Advance the on_line cursor past anything older than this
+            # on_battery (those come from a previous outage and either
+            # already shipped or will pair with an older on_battery).
+            while line_idx < len(on_line_rows) and on_line_rows[line_idx][1] <= ob_ts:
+                line_idx += 1
+            if line_idx >= len(on_line_rows):
+                break
+            ol_id, ol_ts, _, _ = on_line_rows[line_idx]
+            duration = max(0, ol_ts - ob_ts)
+            start_str = datetime.fromtimestamp(ob_ts).strftime("%H:%M:%S")
+            end_str = datetime.fromtimestamp(ol_ts).strftime("%H:%M:%S")
+            summary_body = (
+                f"📊 **Brief Power Outage**\n"
+                f"On battery for {format_seconds(duration)} "
+                f"({start_str} → {end_str})."
+            )
+            # Use the end timestamp so the summary sorts AFTER any
+            # other unrelated pending power events from before the
+            # outage. Keep the generic category so a downstream "where
+            # are my power events?" query still finds it.
+            store.enqueue_notification(
+                body=summary_body, notify_type="info",
+                category="power_event", ts=ol_ts,
+            )
+            store.cancel_notification(ob_id, "coalesced")
+            store.cancel_notification(ol_id, "coalesced")
+            line_idx += 1
+            coalesced += 1
         return coalesced
 
     def _next_due_candidate(self) -> Optional[Tuple]:

--- a/src/eneru/notifications.py
+++ b/src/eneru/notifications.py
@@ -160,6 +160,13 @@ class NotificationWorker:
         becomes the default for sends that don't pin a store (e.g. the
         coordinator-level lifecycle notifications fired before any
         per-UPS thread comes up).
+
+        The in-memory buffer is drained AFTER the store is appended.
+        Each ``enqueue_notification`` is checked for success; rows that
+        fail to persist (transient SQLite error) get re-buffered so the
+        next ``register_store`` call (or a worker retry) can try again.
+        Without this, a transient sqlite failure during the drain would
+        permanently drop coordinator-startup notifications (CR P1).
         """
         if store is None:
             return
@@ -167,21 +174,34 @@ class NotificationWorker:
             if store in self._stores:
                 return
             self._stores.append(store)
-            # Drain the memory buffer to this store. Nothing in the
-            # buffer means single-UPS or coordinator+monitors raced
-            # in our favour; either way it's a no-op.
-            buffered = self._memory_buffer
+            # Snapshot the buffer; do NOT clear it yet — we only clear
+            # entries that successfully persist below.
+            buffered = list(self._memory_buffer)
             self._memory_buffer = []
-        if buffered:
-            for body, notify_type, category, ts in buffered:
-                store.enqueue_notification(body, notify_type, category, ts=ts)
-            # Apply backlog cap after the drain too (P2 follow-up to the
-            # in-memory cap): if the buffer grew large before the store
-            # registered, the persisted side now needs the same trim.
-            cap = self.config.notifications.max_pending
-            if cap > 0:
-                store.cap_pending_notifications(cap)
-            self._wakeup_event.set()
+        if not buffered:
+            return
+        leftovers: List[Tuple[str, str, str, int]] = []
+        for body, notify_type, category, ts in buffered:
+            row_id = store.enqueue_notification(
+                body, notify_type, category, ts=ts,
+            )
+            if row_id is None:
+                # enqueue returned None → store wasn't open or SQLite
+                # raised; keep the row buffered so a future register
+                # gets a chance.
+                leftovers.append((body, notify_type, category, ts))
+        if leftovers:
+            with self._stores_lock:
+                # Prepend so age order is preserved against any new
+                # sends that arrived while we were draining.
+                self._memory_buffer = leftovers + self._memory_buffer
+        # Apply backlog cap after the drain (P2 follow-up to the
+        # in-memory cap): if the buffer grew large before the store
+        # registered, the persisted side now needs the same trim.
+        cap = self.config.notifications.max_pending
+        if cap > 0:
+            store.cap_pending_notifications(cap)
+        self._wakeup_event.set()
 
     # ----- producer side -----
 
@@ -263,14 +283,20 @@ class NotificationWorker:
     # ----- consumer side -----
 
     def flush(self, timeout: float) -> bool:
-        """Block until every registered store's pending count reaches 0,
-        or until ``timeout`` seconds elapse.
+        """Block until every registered store's pending count reaches 0
+        AND the in-memory pre-store buffer is empty, or until ``timeout``
+        seconds elapse.
 
         Returns ``True`` if drained cleanly, ``False`` on timeout. Used
         from the shutdown path (Slice 5) to give in-flight notifications
         their best chance of being sent before the process exits.
         Whatever doesn't drain stays as ``pending`` rows in SQLite and
         flushes on the next start.
+
+        The drain check includes ``_memory_buffer`` (CR P1): if shutdown
+        fires before any store registers, the final lifecycle / shutdown
+        message can still be sitting in memory, and ``flush`` would
+        otherwise return ``True`` immediately and ``stop`` would drop it.
         """
         deadline = time.monotonic() + max(0.0, float(timeout))
         # Wake the worker so it doesn't sit on its 1 s poll if there's
@@ -278,10 +304,11 @@ class NotificationWorker:
         self._wakeup_event.set()
         while True:
             with self._stores_lock:
+                buffered = len(self._memory_buffer)
                 pending = sum(
                     s.pending_notification_count() for s in self._stores
                 )
-            if pending == 0:
+            if pending == 0 and buffered == 0:
                 return True
             if time.monotonic() >= deadline:
                 return False
@@ -306,29 +333,31 @@ class NotificationWorker:
                 pass
 
     def _drain_once(self) -> None:
-        """One pass: coalesce, then look at the oldest pending across all
-        stores, try to deliver it, then continue while there's more to do.
+        """Drain pending rows: coalesce on every iteration, then deliver
+        the oldest due candidate. Repeats until nothing is due (or the
+        stop event fires).
 
-        Bounded by the stop event so a long backlog can't block shutdown
-        indefinitely (and ``flush()`` still polls until empty up to its
-        own timeout).
+        The coalesce pass runs INSIDE the inner loop because a single
+        Apprise call can block for seconds on an unreachable endpoint;
+        an on_battery + on_line pair that arrives during that block must
+        still get folded into a single "Brief outage" before either
+        half is wasted on a separate send. Coalesce is cheap (one
+        SELECT + at most one INSERT/UPDATE per pair); running it per
+        iteration keeps the merge window tight.
         """
-        # Slice 4: fold same-outage on_battery + on_line pairs into a
-        # single "Brief outage" summary BEFORE delivery so the user sees
-        # one message instead of two when the network was down for the
-        # duration of a short blip.
         with self._stores_lock:
             stores_snapshot = list(self._stores)
-        for store in stores_snapshot:
-            try:
-                self._coalesce_pending_outages(store)
-            except Exception:
-                pass  # coalescing must never block delivery
 
         max_iters = 1000  # Defensive — large bursts must still drain.
         for _ in range(max_iters):
             if self._stop_event.is_set():
                 return
+
+            for store in stores_snapshot:
+                try:
+                    self._coalesce_pending_outages(store)
+                except Exception:
+                    pass  # coalescing must never block delivery
 
             candidate = self._next_due_candidate()
             if candidate is None:
@@ -396,10 +425,16 @@ class NotificationWorker:
             # other unrelated pending power events from before the
             # outage. Keep the generic category so a downstream "where
             # are my power events?" query still finds it.
-            store.enqueue_notification(
+            new_id = store.enqueue_notification(
                 body=summary_body, notify_type="info",
                 category="power_event", ts=ol_ts,
             )
+            # Only cancel the originals if the summary actually persisted
+            # (Cubic P1). Otherwise we'd silently drop the outage
+            # notifications on a transient SQLite error.
+            if new_id is None:
+                line_idx += 1
+                continue
             store.cancel_notification(ob_id, "coalesced")
             store.cancel_notification(ol_id, "coalesced")
             line_idx += 1
@@ -410,15 +445,23 @@ class NotificationWorker:
         """Return the oldest pending row across all registered stores
         whose backoff window has elapsed, or ``None`` if nothing is due.
 
+        Scans up to ``max_pending`` pending rows per store in a single
+        SELECT so a head-of-queue cluster of backed-off rows can't
+        starve newer due rows (CR P1). The previous ``limit=10`` made
+        row 11+ invisible until the head drained, which never happened
+        when the head was a poison message with ``max_attempts=0``.
+
         Returned tuple: ``(store, ts, id, body, notify_type, attempts)``.
         """
         now_mono = time.monotonic()
         best: Optional[Tuple] = None
+        scan_cap = max(50,
+                       int(self.config.notifications.max_pending or 10000))
         with self._stores_lock:
             stores_snapshot = list(self._stores)
         for store in stores_snapshot:
-            rows = store.next_pending_notifications(limit=10)
-            for ts, row_id, body, notify_type, attempts, _category in rows:
+            rows = store.next_pending_notifications(limit=scan_cap)
+            for ts, row_id, body, notify_type, attempts, _cat in rows:
                 key = (str(store.db_path), int(row_id))
                 next_attempt = self._backoff.get(key, 0.0)
                 if now_mono < next_attempt:

--- a/src/eneru/notifications.py
+++ b/src/eneru/notifications.py
@@ -1,10 +1,30 @@
-"""Notification worker for Eneru."""
+"""DB-backed notification worker for Eneru (v5.2+).
 
-import queue
+Replaces the v5.1 in-memory queue with a SQLite-persisted queue so that
+notifications survive process death, network outages, and reboots.
+Pending rows live in each registered ``StatsStore``'s ``notifications``
+table (schema v4) and only get marked ``sent`` once Apprise confirms
+delivery. The "panic-attack" guarantee: a power outage that takes the
+internet down still produces the notifications when the endpoint comes
+back, even days later.
+
+Architecture:
+- Main thread: queues notifications via ``send()`` → INSERT pending row
+  in the calling monitor's store, signal the worker.
+- Worker thread: polls all registered stores for the globally-oldest
+  pending row, attempts delivery via Apprise, marks ``sent`` on success
+  or increments ``attempts`` on failure. Per-message exponential backoff
+  prevents network hammering during prolonged outages.
+- TTL pruning runs once per minute (cheap when nothing to delete) to
+  bound DB growth.
+"""
+
 import threading
-from typing import Optional, Dict, Any
+import time
+from typing import Any, Dict, List, Optional, Tuple
 
 from eneru.config import Config
+from eneru.stats import StatsStore
 
 # Optional import for Apprise
 try:
@@ -15,216 +35,390 @@ except ImportError:
     APPRISE_AVAILABLE = False
 
 
+_PRUNE_INTERVAL_SECS = 60.0
+
+
 class NotificationWorker:
-    """Non-blocking notification worker with persistent retry using a background thread.
+    """Persistent, lossless notification worker.
 
-    This worker ensures that notifications never block the main monitoring loop
-    or shutdown sequence. The main thread queues notifications instantly and
-    continues with critical operations. The worker thread persistently retries
-    failed notifications until they succeed (or the process exits).
+    Queues live in per-store SQLite tables (the ``notifications`` table
+    on each registered :class:`StatsStore`). The worker thread merges
+    pending rows across all stores and delivers them in age order.
 
-    Architecture:
-    - Main thread: Queues notifications instantly (non-blocking)
-    - Worker thread: Processes queue in FIFO order, retrying each message
-      until successful before moving to the next one
-    - Apprise handles parallel delivery to multiple backends
+    Stores register themselves when their SQLite DB opens
+    (:meth:`register_store`); sends made before any store is registered
+    are buffered in memory and flushed to the first store as soon as it
+    appears (covers the multi-UPS coordinator startup window).
 
-    This design ensures:
-    1. Zero impact on shutdown operations (main thread never waits)
-    2. Guaranteed delivery during transient network issues
-    3. Order preservation (FIFO queue, no message skipping)
-    4. No message loss during brief outages (e.g., 30-second power blip)
+    Failure handling:
+    - Apprise success → row marked ``sent``, ``sent_at`` recorded.
+    - Apprise failure → ``attempts`` incremented; per-message
+      exponential backoff (``retry_interval`` doubling, capped at
+      ``retry_backoff_max``) determines when to retry.
+    - ``max_attempts`` (default 0 = unlimited) caps per-message retries
+      before the row is ``cancelled (max_attempts)``. Default off
+      because Apprise's bool return doesn't distinguish "bad URL" from
+      "internet down" — giving up risks dropping legitimate messages.
+    - ``max_age_days`` (default 30) cancels pending rows older than
+      that bound, so a stuck message can't sit in the queue forever.
+    - ``max_pending`` (default 10000) caps backlog; on overflow the
+      oldest pending rows get ``cancelled (backlog_overflow)``.
     """
 
     def __init__(self, config: Config):
         self.config = config
-        self._queue: queue.Queue = queue.Queue()
-        self._worker_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self._wakeup_event = threading.Event()
+        self._worker_thread: Optional[threading.Thread] = None
         self._apprise_instance: Optional[Any] = None
         self._initialized = False
-        self._retry_count = 0  # Track retries for current message (for logging)
+        # Registered stores in registration order. The first store also
+        # serves as the default destination for sends that don't pin a
+        # specific store (notably the coordinator-level lifecycle
+        # notifications in multi-UPS mode).
+        self._stores: List[StatsStore] = []
+        self._stores_lock = threading.Lock()
+        # Pre-store memory buffer: tuples of
+        # (body, notify_type, category, ts) for sends that arrived
+        # before any store was registered. Drained on the first
+        # ``register_store`` call.
+        self._memory_buffer: List[Tuple[str, str, str, int]] = []
+        # Per-message backoff state: notification_id → next_attempt_monotonic.
+        # Cleared on success / cancellation. Keyed by row id, which is
+        # globally unique across stores at the worker layer because we
+        # tag each entry with its (store, id) tuple in _process_one.
+        self._backoff: Dict[Tuple[int, int], float] = {}
+        # Track last prune time so we don't run DELETE on every iteration.
+        self._last_prune_monotonic = 0.0
+        # Used during stop() to surface the pending count to a "messages
+        # left undelivered" log warning.
+        self._final_pending_count = 0
+
+    # ----- lifecycle -----
 
     def start(self) -> bool:
         """Initialize Apprise and start the background worker thread."""
         if not self.config.notifications.enabled:
             return False
-
         if not APPRISE_AVAILABLE:
             return False
-
         if not self.config.notifications.urls:
             return False
 
-        # Initialize Apprise
         self._apprise_instance = apprise.Apprise()
-
         for url in self.config.notifications.urls:
             if not self._apprise_instance.add(url):
                 print(f"Warning: Failed to add notification URL: {url}")
-
         if len(self._apprise_instance) == 0:
             print("Warning: No valid notification URLs configured")
             return False
 
-        # Start background worker thread (daemon=True ensures it won't block shutdown)
         self._stop_event.clear()
-        self._worker_thread = threading.Thread(target=self._worker_loop, daemon=True)
+        self._wakeup_event.clear()
+        self._worker_thread = threading.Thread(
+            target=self._worker_loop, daemon=True, name="notify-worker",
+        )
         self._worker_thread.start()
         self._initialized = True
-
         return True
 
-    def stop(self):
-        """Stop the background worker thread gracefully.
+    def stop(self) -> None:
+        """Stop the background worker thread.
 
-        Note: During shutdown, the worker will attempt to send any pending
-        notifications. Messages that cannot be delivered before process exit
-        will be lost, but this is acceptable since journalctl logs remain
-        for forensics.
+        Pending rows stay in the DB; the next process start will pick
+        them up and resume delivery (the lossless guarantee). The 5s
+        :meth:`flush` in the shutdown path (Slice 5) gives the worker
+        a chance to drain the in-flight queue first; whatever's left
+        survives in SQLite.
         """
         if self._worker_thread and self._worker_thread.is_alive():
-            # Log pending notifications
-            pending = self._queue.qsize()
-            in_progress = 1 if self._retry_count > 0 else 0
-            total_pending = pending + in_progress
-            if total_pending > 0:
-                retry_info = f" (current message: retry #{self._retry_count})" if in_progress else ""
-                print(f"⚠️ Stopping notification worker with {total_pending} message(s) pending{retry_info}")
-
+            with self._stores_lock:
+                pending = sum(
+                    s.pending_notification_count() for s in self._stores
+                )
+            self._final_pending_count = pending
+            if pending > 0:
+                # Informational, not an error: the rows aren't lost,
+                # they just go out on the next start.
+                print(
+                    f"ℹ️ Notification worker stopping with {pending} "
+                    f"message(s) still pending in the persistent queue "
+                    f"— they will deliver on the next start."
+                )
             self._stop_event.set()
-            # Add sentinel to unblock the queue
-            self._queue.put(None)
-            # Don't wait too long - we might be shutting down
+            self._wakeup_event.set()
             self._worker_thread.join(timeout=2)
 
-    def send(self, body: str, notify_type: str = "info", blocking: bool = False):
+    # ----- store registration -----
+
+    def register_store(self, store: StatsStore) -> None:
+        """Register a per-UPS stats store as a notification destination.
+
+        Each :class:`UPSGroupMonitor` calls this once its
+        :class:`StatsStore` is open. The first registered store also
+        becomes the default for sends that don't pin a store (e.g. the
+        coordinator-level lifecycle notifications fired before any
+        per-UPS thread comes up).
         """
-        Queue a notification for sending.
+        if store is None:
+            return
+        with self._stores_lock:
+            if store in self._stores:
+                return
+            self._stores.append(store)
+            # Drain the memory buffer to this store. Nothing in the
+            # buffer means single-UPS or coordinator+monitors raced
+            # in our favour; either way it's a no-op.
+            buffered = self._memory_buffer
+            self._memory_buffer = []
+        if buffered:
+            for body, notify_type, category, ts in buffered:
+                store.enqueue_notification(body, notify_type, category, ts=ts)
+            self._wakeup_event.set()
+
+    # ----- producer side -----
+
+    def send(self, body: str, notify_type: str = "info",
+             category: str = "general",
+             store: Optional[StatsStore] = None,
+             blocking: bool = False) -> Optional[int]:
+        """Queue a notification for persistent, retried delivery.
 
         Args:
-            body: Notification body
-            notify_type: One of 'info', 'success', 'warning', 'failure'
-            blocking: If True, wait for notification to be sent.
-                      NOTE: This should only be used for test notifications,
-                      never during shutdown sequences where network may be down.
+            body: Notification body.
+            notify_type: One of 'info', 'success', 'warning', 'failure'.
+            category: Coarse classification for coalescing (Slice 4)
+                and per-category queries. Common values: ``lifecycle``,
+                ``power_event``, ``voltage``, ``shutdown``,
+                ``shutdown_summary``, ``general``.
+            store: Destination StatsStore. Defaults to the first
+                registered store; falls back to in-memory buffer if no
+                store is registered yet (multi-UPS coordinator startup).
+            blocking: Reserved for future use. The v5.1 worker honoured
+                this for the ``--test-notifications`` CLI; v5.2's DB
+                queue means delivery is asynchronous by design. Kept in
+                the signature for back-compat; ignored.
+
+        Returns the new notification id, or ``None`` if the send was
+        buffered (no store yet) or the worker isn't initialized.
         """
+        del blocking  # back-compat shim; the v5.2 queue is always async
         if not self._initialized:
-            return
+            return None
 
-        notification = {
-            'title': self.config.notifications.title,  # Can be None
-            'body': body,
-            'notify_type': notify_type,
-            'blocking_event': threading.Event() if blocking else None,
-        }
+        ts = int(time.time())
+        target_store = store
+        with self._stores_lock:
+            if target_store is None and self._stores:
+                target_store = self._stores[0]
+            if target_store is None:
+                # Pre-store buffer: replayed verbatim (with original ts)
+                # once register_store fires.
+                self._memory_buffer.append(
+                    (body, notify_type, category, ts)
+                )
+                self._wakeup_event.set()
+                return None
 
-        self._queue.put(notification)
+        notification_id = target_store.enqueue_notification(
+            body=body, notify_type=notify_type, category=category, ts=ts,
+        )
+        # Enforce backlog cap right after insert so the just-added row
+        # stays (it's the newest by definition; cap_pending cancels
+        # oldest first).
+        max_pending = self.config.notifications.max_pending
+        if max_pending > 0:
+            target_store.cap_pending_notifications(max_pending)
+        self._wakeup_event.set()
+        return notification_id
 
-        # If blocking, wait for the notification to be processed
-        # This should ONLY be used for --test-notifications, never during shutdown
-        if blocking and notification['blocking_event']:
-            # For blocking calls, use a generous timeout that allows for retries
-            max_wait = self.config.notifications.timeout * 3 + 10
-            notification['blocking_event'].wait(timeout=max_wait)
+    # ----- consumer side -----
 
-    def _worker_loop(self):
-        """Background worker that processes the notification queue with persistent retry."""
+    def flush(self, timeout: float) -> bool:
+        """Block until every registered store's pending count reaches 0,
+        or until ``timeout`` seconds elapse.
+
+        Returns ``True`` if drained cleanly, ``False`` on timeout. Used
+        from the shutdown path (Slice 5) to give in-flight notifications
+        their best chance of being sent before the process exits.
+        Whatever doesn't drain stays as ``pending`` rows in SQLite and
+        flushes on the next start.
+        """
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        # Wake the worker so it doesn't sit on its 1 s poll if there's
+        # something to do.
+        self._wakeup_event.set()
+        while True:
+            with self._stores_lock:
+                pending = sum(
+                    s.pending_notification_count() for s in self._stores
+                )
+            if pending == 0:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.1)
+            self._wakeup_event.set()
+
+    def _worker_loop(self) -> None:
+        """Background worker: drain pending rows from all stores."""
         while not self._stop_event.is_set():
+            # Wait for a wakeup signal or a 1 s tick. Short tick so a
+            # message that just hit its backoff window gets retried
+            # promptly without needing an external poke.
+            self._wakeup_event.wait(timeout=1.0)
+            self._wakeup_event.clear()
+
             try:
-                notification = self._queue.get(timeout=1)
-
-                if notification is None:
-                    # Sentinel value, exit loop
-                    break
-
-                self._send_with_retry(notification)
-
-            except queue.Empty:
-                continue
+                self._drain_once()
+                self._maybe_prune()
             except Exception:
-                # Silently ignore errors - notifications should never crash the monitor
+                # Defensive — the worker thread must NEVER crash, since
+                # losing it would silently disable all future notifications.
                 pass
 
-    def _send_with_retry(self, notification: Dict[str, Any]):
-        """Send notification with persistent retry until success or stop signal."""
-        self._retry_count = 0
-        retry_interval = self.config.notifications.retry_interval
+    def _drain_once(self) -> None:
+        """One pass: look at the oldest pending across all stores, try
+        to deliver it, then continue while there's more to do.
 
-        while not self._stop_event.is_set():
-            success = self._send_notification(notification)
-
-            if success:
-                self._retry_count = 0
+        Bounded by the stop event so a long backlog can't block shutdown
+        indefinitely (and ``flush()`` still polls until empty up to its
+        own timeout).
+        """
+        max_iters = 1000  # Defensive — large bursts must still drain.
+        for _ in range(max_iters):
+            if self._stop_event.is_set():
                 return
 
-            # Failed - wait and retry
-            self._retry_count += 1
+            candidate = self._next_due_candidate()
+            if candidate is None:
+                return
 
-            # Use stop_event.wait() instead of time.sleep() so we can interrupt quickly
-            if self._stop_event.wait(timeout=retry_interval):
-                # Stop was requested during wait
-                break
+            store, ts, row_id, body, notify_type, attempts = candidate
+            self._process_one(
+                store=store, row_id=row_id, body=body,
+                notify_type=notify_type, attempts=attempts,
+            )
 
-        # If we exit the loop without success (stop requested), reset counter
-        self._retry_count = 0
-        # Signal completion even on failure (for blocking calls)
-        if notification.get('blocking_event'):
-            notification['blocking_event'].set()
+    def _next_due_candidate(self) -> Optional[Tuple]:
+        """Return the oldest pending row across all registered stores
+        whose backoff window has elapsed, or ``None`` if nothing is due.
 
-    def _send_notification(self, notification: Dict[str, Any]) -> bool:
-        """Actually send the notification via Apprise.
-
-        Returns:
-            True if notification was sent successfully, False otherwise.
+        Returned tuple: ``(store, ts, id, body, notify_type, attempts)``.
         """
+        now_mono = time.monotonic()
+        best: Optional[Tuple] = None
+        with self._stores_lock:
+            stores_snapshot = list(self._stores)
+        for store in stores_snapshot:
+            rows = store.next_pending_notifications(limit=10)
+            for ts, row_id, body, notify_type, attempts, _category in rows:
+                key = (id(store), int(row_id))
+                next_attempt = self._backoff.get(key, 0.0)
+                if now_mono < next_attempt:
+                    continue
+                cand = (store, int(ts), int(row_id), str(body),
+                        str(notify_type), int(attempts))
+                if best is None or cand[1] < best[1] or (
+                    cand[1] == best[1] and cand[2] < best[2]
+                ):
+                    best = cand
+        return best
+
+    def _process_one(self, *, store: StatsStore, row_id: int,
+                     body: str, notify_type: str,
+                     attempts: int) -> None:
+        """Attempt delivery of a single row. Marks sent on success;
+        increments attempts and applies exponential backoff on failure.
+        Cancels on max_attempts overrun (when configured)."""
+        success = self._send_via_apprise(body, notify_type)
+        key = (id(store), row_id)
+
+        if success:
+            store.mark_notification_sent(row_id)
+            self._backoff.pop(key, None)
+            return
+
+        store.mark_notification_attempt(row_id)
+        new_attempts = attempts + 1
+
+        max_attempts = self.config.notifications.max_attempts
+        if max_attempts > 0 and new_attempts >= max_attempts:
+            store.cancel_notification(row_id, "max_attempts")
+            self._backoff.pop(key, None)
+            return
+
+        # Exponential backoff: retry_interval * 2^(attempts-1), capped.
+        # Treat retry_interval=0 as "every tick" (the 1 s poll loop).
+        base = max(0, int(self.config.notifications.retry_interval))
+        cap = max(base, int(self.config.notifications.retry_backoff_max))
+        # Bound the shift to avoid pathological 2**N for huge attempts.
+        shift = min(new_attempts - 1, 20)
+        wait_secs = min(base * (2 ** shift) if base > 0 else 0, cap)
+        self._backoff[key] = time.monotonic() + max(0, wait_secs)
+
+    def _send_via_apprise(self, body: str, notify_type: str) -> bool:
+        """Call Apprise. Returns True iff at least one backend
+        accepted the message. Network/DNS errors → False (worker
+        retries via the backoff schedule)."""
         if not self._apprise_instance:
             return False
-
         try:
-            # Map notify_type string to Apprise NotifyType
             type_map = {
                 "info": apprise.NotifyType.INFO,
                 "success": apprise.NotifyType.SUCCESS,
                 "warning": apprise.NotifyType.WARNING,
                 "failure": apprise.NotifyType.FAILURE,
             }
-            notify_type = type_map.get(notification['notify_type'], apprise.NotifyType.INFO)
+            apprise_type = type_map.get(notify_type, apprise.NotifyType.INFO)
 
-            # Build notification parameters
-            notify_kwargs = {
-                'body': notification['body'],
-                'notify_type': notify_type,
+            notify_kwargs: Dict[str, Any] = {
+                "body": body,
+                "notify_type": apprise_type,
             }
+            # Only include the title if explicitly configured (the v5.1
+            # behaviour — None / empty title means body-only).
+            title = self.config.notifications.title
+            if title:
+                notify_kwargs["title"] = title
 
-            # Only add title if configured (not None/empty)
-            if notification.get('title'):
-                notify_kwargs['title'] = notification['title']
-
-            # Apprise.notify() returns True if at least one notification succeeded
-            success = self._apprise_instance.notify(**notify_kwargs)
-
-            if success:
-                # Signal completion for blocking calls
-                if notification.get('blocking_event'):
-                    notification['blocking_event'].set()
-
-            return success
-
+            return bool(self._apprise_instance.notify(**notify_kwargs))
         except Exception:
-            # Network error, DNS failure, etc. - will retry
             return False
 
+    def _maybe_prune(self) -> None:
+        """Run TTL prune at most once per ``_PRUNE_INTERVAL_SECS``.
+
+        Two-step:
+          1. ``DELETE`` ``sent`` / ``cancelled`` rows older than
+             ``retention_days``.
+          2. ``UPDATE`` pending rows older than ``max_age_days`` to
+             ``cancelled (too_old)``. Skipped when ``max_age_days <= 0``
+             (panic-attack guarantee — pending lives forever).
+        """
+        now_mono = time.monotonic()
+        if now_mono - self._last_prune_monotonic < _PRUNE_INTERVAL_SECS:
+            return
+        self._last_prune_monotonic = now_mono
+
+        retention = max(1, int(self.config.notifications.retention_days))
+        max_age = max(0, int(self.config.notifications.max_age_days))
+        with self._stores_lock:
+            stores_snapshot = list(self._stores)
+        for store in stores_snapshot:
+            store.prune_old_notifications(retention, max_age)
+
+    # ----- accessors (mostly for tests + status displays) -----
+
     def get_service_count(self) -> int:
-        """Return the number of configured notification services."""
+        """Return the number of configured Apprise backends."""
         if self._apprise_instance:
             return len(self._apprise_instance)
         return 0
 
-    def get_queue_size(self) -> int:
-        """Return the number of pending notifications in the queue."""
-        return self._queue.qsize()
-
-    def get_retry_count(self) -> int:
-        """Return the current retry count for the message being processed."""
-        return self._retry_count
+    def get_pending_count(self) -> int:
+        """Sum of pending rows across all registered stores. 0 when no
+        store is registered yet (memory buffer is opaque to callers —
+        it flushes on first registration)."""
+        with self._stores_lock:
+            return sum(s.pending_notification_count() for s in self._stores)

--- a/src/eneru/notifications.py
+++ b/src/eneru/notifications.py
@@ -83,11 +83,12 @@ class NotificationWorker:
         # before any store was registered. Drained on the first
         # ``register_store`` call.
         self._memory_buffer: List[Tuple[str, str, str, int]] = []
-        # Per-message backoff state: notification_id → next_attempt_monotonic.
-        # Cleared on success / cancellation. Keyed by row id, which is
-        # globally unique across stores at the worker layer because we
-        # tag each entry with its (store, id) tuple in _process_one.
-        self._backoff: Dict[Tuple[int, int], float] = {}
+        # Per-message backoff state: (str(store.db_path), row_id) →
+        # next_attempt_monotonic. Cleared on success / cancellation. We
+        # key on the db_path STRING (not id(store)) so re-creation of a
+        # StatsStore object at the same memory address can't bleed
+        # backoff state across instances.
+        self._backoff: Dict[Tuple[str, int], float] = {}
         # Track last prune time so we don't run DELETE on every iteration.
         self._last_prune_monotonic = 0.0
         # Used during stop() to surface the pending count to a "messages
@@ -174,6 +175,12 @@ class NotificationWorker:
         if buffered:
             for body, notify_type, category, ts in buffered:
                 store.enqueue_notification(body, notify_type, category, ts=ts)
+            # Apply backlog cap after the drain too (P2 follow-up to the
+            # in-memory cap): if the buffer grew large before the store
+            # registered, the persisted side now needs the same trim.
+            cap = self.config.notifications.max_pending
+            if cap > 0:
+                store.cap_pending_notifications(cap)
             self._wakeup_event.set()
 
     # ----- producer side -----
@@ -217,6 +224,7 @@ class NotificationWorker:
                 self._memory_buffer.append(
                     (body, notify_type, category, ts)
                 )
+                self._trim_memory_buffer()
                 self._wakeup_event.set()
                 return None
 
@@ -231,6 +239,26 @@ class NotificationWorker:
             target_store.cap_pending_notifications(max_pending)
         self._wakeup_event.set()
         return notification_id
+
+    def _trim_memory_buffer(self) -> None:
+        """Drop oldest in-memory pending notifications when the buffer
+        overflows ``max_pending``. Without this, a misconfigured daemon
+        (notifications.enabled=true but every store fails to open) would
+        accumulate every send forever and OOM. Called from inside
+        ``send()`` after appending, so the just-added row stays."""
+        cap = self.config.notifications.max_pending
+        if cap <= 0 or len(self._memory_buffer) <= cap:
+            return
+        excess = len(self._memory_buffer) - cap
+        del self._memory_buffer[:excess]
+        if not getattr(self, "_buffer_overflow_warned", False):
+            print(
+                f"⚠️ Notification memory buffer exceeded {cap} entries — "
+                "oldest dropped. Stats DB unreachable? Check "
+                f"{self.config.statistics.db_directory if hasattr(self.config, 'statistics') else '/var/lib/eneru'} "
+                "is writable."
+            )
+            self._buffer_overflow_warned = True
 
     # ----- consumer side -----
 
@@ -339,15 +367,19 @@ class NotificationWorker:
         from datetime import datetime
         from eneru.utils import format_seconds
 
-        # Pair each on_battery with the next on_line whose ts is later.
-        # Both lists are sorted by ts ASC from the store query.
+        # Pair each on_battery with the next on_line whose ts is >= this
+        # on_battery's ts. Both lists are sorted by ts ASC from the
+        # store query. Equal-ts pairs ARE valid (NUT polls at 1s
+        # granularity; a same-second cycle is reachable in tests and
+        # high-poll-rate setups), so this is strict-less-than.
         coalesced = 0
         line_idx = 0
         for ob_id, ob_ts, _, _ in on_batt_rows:
-            # Advance the on_line cursor past anything older than this
-            # on_battery (those come from a previous outage and either
-            # already shipped or will pair with an older on_battery).
-            while line_idx < len(on_line_rows) and on_line_rows[line_idx][1] <= ob_ts:
+            # Advance the on_line cursor past anything strictly older
+            # than this on_battery (those come from a previous outage
+            # and either already shipped or will pair with an older
+            # on_battery).
+            while line_idx < len(on_line_rows) and on_line_rows[line_idx][1] < ob_ts:
                 line_idx += 1
             if line_idx >= len(on_line_rows):
                 break
@@ -387,7 +419,7 @@ class NotificationWorker:
         for store in stores_snapshot:
             rows = store.next_pending_notifications(limit=10)
             for ts, row_id, body, notify_type, attempts, _category in rows:
-                key = (id(store), int(row_id))
+                key = (str(store.db_path), int(row_id))
                 next_attempt = self._backoff.get(key, 0.0)
                 if now_mono < next_attempt:
                     continue
@@ -406,7 +438,7 @@ class NotificationWorker:
         increments attempts and applies exponential backoff on failure.
         Cancels on max_attempts overrun (when configured)."""
         success = self._send_via_apprise(body, notify_type)
-        key = (id(store), row_id)
+        key = (str(store.db_path), row_id)
 
         if success:
             store.mark_notification_sent(row_id)

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -142,7 +142,13 @@ class RedundancyGroupExecutor(
             print(prefixed)
 
     def _send_notification(self, body: str, notify_type: str = "info",
-                           blocking: bool = False):
+                           blocking: bool = False,
+                           category: str = "general"):
+        # ``category`` is a v5.2 addition (Slice 4 coalescer hook + per-
+        # category queries); not pinned to a specific store here because
+        # the redundancy executor doesn't own one — the worker falls
+        # back to the first registered store, which in coordinator mode
+        # is the first per-UPS monitor's DB.
         if not self._notification_worker:
             return
         prefixed = f"{self._log_prefix}{body}" if self._log_prefix else body
@@ -152,7 +158,8 @@ class RedundancyGroupExecutor(
         # Redundancy-group shutdowns are always "during shutdown" by definition,
         # so notifications are non-blocking to avoid network-stall delays.
         self._notification_worker.send(
-            body=escaped, notify_type=notify_type, blocking=False,
+            body=escaped, notify_type=notify_type, category=category,
+            blocking=False,
         )
 
     def _log_power_event(self, event: str, details: str):
@@ -186,6 +193,7 @@ class RedundancyGroupExecutor(
             f"Reason: {reason}\n"
             f"Sources: {', '.join(self._group.ups_sources) or '(none)'}",
             "failure",
+            category="shutdown",
         )
 
         if self.config.behavior.dry_run:

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -178,7 +178,7 @@ class RedundancyGroupExecutor(
             self._shutdown_flag_path.touch()
 
         self._log_message(
-            f"🚨 ========== REDUNDANCY GROUP SHUTDOWN: {self._group.name} =========="
+            f"🚨 Redundancy group shutdown: {self._group.name}"
         )
         self._log_message(f"   Reason: {reason}")
         self._send_notification(
@@ -199,8 +199,7 @@ class RedundancyGroupExecutor(
                 self._unmount_filesystems()
             self._shutdown_remote_servers()
             self._log_message(
-                f"✅ ========== REDUNDANCY GROUP SHUTDOWN COMPLETE: "
-                f"{self._group.name} =========="
+                f"✅ Redundancy group shutdown complete: {self._group.name}"
             )
             # is_local quorum-loss must also fire the local poweroff.
             # Without this, the executor stops local services and remote

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -178,7 +178,7 @@ class RedundancyGroupExecutor(
             self._shutdown_flag_path.touch()
 
         self._log_message(
-            f"🚨 Redundancy group shutdown: {self._group.name}"
+            f"🚨 REDUNDANCY GROUP SHUTDOWN: {self._group.name}"
         )
         self._log_message(f"   Reason: {reason}")
         self._send_notification(
@@ -199,7 +199,7 @@ class RedundancyGroupExecutor(
                 self._unmount_filesystems()
             self._shutdown_remote_servers()
             self._log_message(
-                f"✅ Redundancy group shutdown complete: {self._group.name}"
+                f"✅ REDUNDANCY GROUP SHUTDOWN COMPLETE: {self._group.name}"
             )
             # is_local quorum-loss must also fire the local poweroff.
             # Without this, the executor stops local services and remote

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -304,7 +304,8 @@ class RemoteShutdownMixin:
         self._send_notification(
             f"🌐 **Remote Shutdown Starting:** {display_name}\n"
             f"Host: {server.host}",
-            self.config.NOTIFY_INFO
+            self.config.NOTIFY_INFO,
+            category="shutdown",
         )
 
         # Execute pre-shutdown commands first
@@ -343,5 +344,6 @@ class RemoteShutdownMixin:
             self._send_notification(
                 f"❌ **Remote Shutdown Failed:** {display_name}\n"
                 f"Error: {error_msg}",
-                self.config.NOTIFY_FAILURE
+                self.config.NOTIFY_FAILURE,
+                category="shutdown",
             )

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -330,11 +330,12 @@ class RemoteShutdownMixin:
 
         if success:
             self._log_message(f"  ✅ {display_name} shutdown command sent successfully")
-            self._send_notification(
-                f"✅ **Remote Shutdown Sent:** {display_name}\n"
-                f"Server is shutting down.",
-                self.config.NOTIFY_SUCCESS
-            )
+            # Per-server success used to fire a notification too; dropped in
+            # v5.2 — the "Starting" notification is the per-server signal,
+            # the aggregate "Sequence Complete" rolls up the result, and
+            # journalctl carries the full trace. Failures still notify
+            # because they're the only thing the user actually needs to act
+            # on individually.
         else:
             self._log_message(
                 f"  ❌ WARNING: Failed to execute shutdown command on {display_name}: {error_msg}"

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -125,13 +125,17 @@ class StatsStore:
         self._buffer: deque = deque(maxlen=buffer_maxlen)
         self._buffer_lock = threading.Lock()
         self._conn: Optional[sqlite3.Connection] = None
-        # v5.2: serialize ALL _conn access. The notification worker
-        # thread polls pending rows while the main thread inserts +
-        # caps the queue from inside _send_notification — Python 3.13's
-        # stricter sqlite3 binding raises "SystemError: error return
-        # without exception set" when both happen on the same connection
-        # without external mutex. The WAL underneath already serializes
-        # writes; this lock just keeps the Python wrapper happy.
+        # v5.2: serialize ALL _conn access across threads — the
+        # notification-worker thread polls pending rows while the main
+        # thread inserts + caps the queue, while the StatsWriter thread
+        # runs flush/aggregate/purge every 10 s / 5 min, while the TUI
+        # may call query_events / query_range concurrently. Python
+        # 3.13's stricter sqlite3 binding raises "SystemError: error
+        # return without exception set" when concurrent execute()s
+        # share a connection (CPython issue #118172). WAL underneath
+        # already serializes writes; this lock keeps the Python
+        # wrapper consistent. The lock is acquired by every public
+        # method that touches self._conn AFTER open() returns.
         self._db_lock = threading.Lock()
         self._logger = logger
         # Rate-limit error logging (per error message text).
@@ -408,7 +412,7 @@ class StatsStore:
             batch: List[Tuple] = list(self._buffer)
             self._buffer.clear()
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 placeholders = ", ".join("?" for _ in SAMPLE_FIELDS)
                 self._conn.executemany(
                     f"INSERT INTO samples ({', '.join(SAMPLE_FIELDS)}) "
@@ -428,7 +432,7 @@ class StatsStore:
         if self._conn is None:
             return (0, 0)
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 inserted_5 = self._conn.execute(f"""
                     INSERT OR REPLACE INTO agg_5min (
                         ts,
@@ -496,7 +500,7 @@ class StatsStore:
         cutoff_5min = now - self.retention_5min_days * 86400
         cutoff_hourly = now - self.retention_hourly_days * 86400
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 deleted_raw = self._conn.execute(
                     "DELETE FROM samples WHERE ts < ?", (cutoff_raw,),
                 ).rowcount
@@ -553,12 +557,13 @@ class StatsStore:
         if self._conn is None:
             return []
         try:
-            cur = self._conn.execute(
-                "SELECT ts, event_type, detail FROM events "
-                "WHERE ts BETWEEN ? AND ? ORDER BY ts ASC",
-                (int(start_ts), int(end_ts)),
-            )
-            return cur.fetchall()
+            with self._db_lock:
+                cur = self._conn.execute(
+                    "SELECT ts, event_type, detail FROM events "
+                    "WHERE ts BETWEEN ? AND ? ORDER BY ts ASC",
+                    (int(start_ts), int(end_ts)),
+                )
+                return cur.fetchall()
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(f"stats: query_events failed: {e}")
             return []
@@ -590,10 +595,16 @@ class StatsStore:
             return None
 
     def next_pending_notifications(self,
-                                   limit: int = 10) -> List[Tuple]:
-        """Return up to ``limit`` oldest pending rows as
-        ``(ts, id, body, notify_type, attempts, category)`` tuples.
-        Order: ts ASC then id ASC for deterministic FIFO across same-ts ties.
+                                   limit: int = 10,
+                                   offset: int = 0) -> List[Tuple]:
+        """Return up to ``limit`` oldest pending rows starting at
+        ``offset``, as ``(ts, id, body, notify_type, attempts, category)``
+        tuples. Order: ts ASC then id ASC for deterministic FIFO across
+        same-ts ties.
+
+        ``offset`` lets the worker paginate when the head of the queue
+        is occupied by backoff-delayed rows, so newer due rows aren't
+        starved (CR P1).
         """
         if self._conn is None:
             return []
@@ -602,8 +613,8 @@ class StatsStore:
                 cur = self._conn.execute(
                     "SELECT ts, id, body, notify_type, attempts, category "
                     "FROM notifications WHERE status='pending' "
-                    "ORDER BY ts ASC, id ASC LIMIT ?",
-                    (int(limit),),
+                    "ORDER BY ts ASC, id ASC LIMIT ? OFFSET ?",
+                    (int(limit), int(offset)),
                 )
                 return cur.fetchall()
         except (sqlite3.Error, OSError) as e:
@@ -853,24 +864,25 @@ class StatsStore:
 
         tier = prefer_tier or self._pick_tier(start_ts, end_ts)
         try:
-            if tier == "samples":
-                column = metric
-                cur = self._conn.execute(
-                    f"SELECT ts, {column} FROM samples "
-                    f"WHERE ts BETWEEN ? AND ? AND {column} IS NOT NULL "
-                    "ORDER BY ts ASC",
-                    (int(start_ts), int(end_ts)),
-                )
-            else:
-                table = "agg_5min" if tier == "agg_5min" else "agg_hourly"
-                column = self._agg_column_for(metric)
-                cur = self._conn.execute(
-                    f"SELECT ts, {column} FROM {table} "
-                    f"WHERE ts BETWEEN ? AND ? AND {column} IS NOT NULL "
-                    "ORDER BY ts ASC",
-                    (int(start_ts), int(end_ts)),
-                )
-            return [(int(r[0]), float(r[1])) for r in cur.fetchall()]
+            with self._db_lock:
+                if tier == "samples":
+                    column = metric
+                    cur = self._conn.execute(
+                        f"SELECT ts, {column} FROM samples "
+                        f"WHERE ts BETWEEN ? AND ? AND {column} IS NOT NULL "
+                        "ORDER BY ts ASC",
+                        (int(start_ts), int(end_ts)),
+                    )
+                else:
+                    table = "agg_5min" if tier == "agg_5min" else "agg_hourly"
+                    column = self._agg_column_for(metric)
+                    cur = self._conn.execute(
+                        f"SELECT ts, {column} FROM {table} "
+                        f"WHERE ts BETWEEN ? AND ? AND {column} IS NOT NULL "
+                        "ORDER BY ts ASC",
+                        (int(start_ts), int(end_ts)),
+                    )
+                return [(int(r[0]), float(r[1])) for r in cur.fetchall()]
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(f"stats: query_range failed: {e}")
             return []

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -125,6 +125,14 @@ class StatsStore:
         self._buffer: deque = deque(maxlen=buffer_maxlen)
         self._buffer_lock = threading.Lock()
         self._conn: Optional[sqlite3.Connection] = None
+        # v5.2: serialize ALL _conn access. The notification worker
+        # thread polls pending rows while the main thread inserts +
+        # caps the queue from inside _send_notification — Python 3.13's
+        # stricter sqlite3 binding raises "SystemError: error return
+        # without exception set" when both happen on the same connection
+        # without external mutex. The WAL underneath already serializes
+        # writes; this lock just keeps the Python wrapper happy.
+        self._db_lock = threading.Lock()
         self._logger = logger
         # Rate-limit error logging (per error message text).
         self._last_error_log: Dict[str, float] = {}
@@ -530,7 +538,7 @@ class StatsStore:
             return
         ts = int(ts if ts is not None else time.time())
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 self._conn.execute(
                     "INSERT INTO events (ts, event_type, detail, "
                     "notification_sent) VALUES (?, ?, ?, ?)",
@@ -563,13 +571,13 @@ class StatsStore:
         """Persist a pending notification. Returns the new row id, or
         ``None`` if the store isn't open (caller should fall back).
 
-        Safe to call from any thread.
+        Safe to call from any thread (serialized via ``_db_lock``).
         """
         if self._conn is None:
             return None
         ts = int(ts if ts is not None else time.time())
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 cur = self._conn.execute(
                     "INSERT INTO notifications "
                     "(ts, body, notify_type, category) "
@@ -590,13 +598,14 @@ class StatsStore:
         if self._conn is None:
             return []
         try:
-            cur = self._conn.execute(
-                "SELECT ts, id, body, notify_type, attempts, category "
-                "FROM notifications WHERE status='pending' "
-                "ORDER BY ts ASC, id ASC LIMIT ?",
-                (int(limit),),
-            )
-            return cur.fetchall()
+            with self._db_lock:
+                cur = self._conn.execute(
+                    "SELECT ts, id, body, notify_type, attempts, category "
+                    "FROM notifications WHERE status='pending' "
+                    "ORDER BY ts ASC, id ASC LIMIT ?",
+                    (int(limit),),
+                )
+                return cur.fetchall()
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(
                 f"stats: next_pending_notifications failed: {e}"
@@ -613,21 +622,22 @@ class StatsStore:
         if self._conn is None:
             return []
         try:
-            if since_ts is None:
-                cur = self._conn.execute(
-                    "SELECT id, ts, body, notify_type FROM notifications "
-                    "WHERE status='pending' AND category=? "
-                    "ORDER BY ts ASC",
-                    (str(category),),
-                )
-            else:
-                cur = self._conn.execute(
-                    "SELECT id, ts, body, notify_type FROM notifications "
-                    "WHERE status='pending' AND category=? AND ts>=? "
-                    "ORDER BY ts ASC",
-                    (str(category), int(since_ts)),
-                )
-            return cur.fetchall()
+            with self._db_lock:
+                if since_ts is None:
+                    cur = self._conn.execute(
+                        "SELECT id, ts, body, notify_type FROM notifications "
+                        "WHERE status='pending' AND category=? "
+                        "ORDER BY ts ASC",
+                        (str(category),),
+                    )
+                else:
+                    cur = self._conn.execute(
+                        "SELECT id, ts, body, notify_type FROM notifications "
+                        "WHERE status='pending' AND category=? AND ts>=? "
+                        "ORDER BY ts ASC",
+                        (str(category), int(since_ts)),
+                    )
+                return cur.fetchall()
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(
                 f"stats: find_pending_by_category failed: {e}"
@@ -641,7 +651,7 @@ class StatsStore:
             return
         sent_at = int(sent_at if sent_at is not None else time.time())
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 self._conn.execute(
                     "UPDATE notifications SET status='sent', sent_at=? "
                     "WHERE id=?",
@@ -658,7 +668,7 @@ class StatsStore:
         if self._conn is None:
             return
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 self._conn.execute(
                     "UPDATE notifications SET attempts=attempts+1 "
                     "WHERE id=?",
@@ -677,7 +687,7 @@ class StatsStore:
         if self._conn is None:
             return
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 self._conn.execute(
                     "UPDATE notifications SET status='cancelled', "
                     "cancel_reason=? WHERE id=?",
@@ -694,11 +704,12 @@ class StatsStore:
         if self._conn is None:
             return 0
         try:
-            cur = self._conn.execute(
-                "SELECT COUNT(*) FROM notifications WHERE status='pending'"
-            )
-            row = cur.fetchone()
-            return int(row[0]) if row else 0
+            with self._db_lock:
+                cur = self._conn.execute(
+                    "SELECT COUNT(*) FROM notifications WHERE status='pending'"
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row else 0
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(
                 f"stats: pending_notification_count failed: {e}"
@@ -714,7 +725,7 @@ class StatsStore:
         if self._conn is None or max_pending <= 0:
             return 0
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 cur = self._conn.execute(
                     "SELECT COUNT(*) FROM notifications "
                     "WHERE status='pending'"
@@ -762,7 +773,7 @@ class StatsStore:
         deleted = 0
         expired = 0
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 cur = self._conn.execute(
                     "DELETE FROM notifications "
                     "WHERE status IN ('sent','cancelled') AND ts < ?",
@@ -794,11 +805,12 @@ class StatsStore:
         if self._conn is None:
             return None
         try:
-            cur = self._conn.execute(
-                "SELECT value FROM meta WHERE key=?", (str(key),),
-            )
-            row = cur.fetchone()
-            return str(row[0]) if row else None
+            with self._db_lock:
+                cur = self._conn.execute(
+                    "SELECT value FROM meta WHERE key=?", (str(key),),
+                )
+                row = cur.fetchone()
+                return str(row[0]) if row else None
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(f"stats: get_meta failed: {e}")
             return None
@@ -808,7 +820,7 @@ class StatsStore:
         if self._conn is None:
             return
         try:
-            with self._conn:
+            with self._db_lock, self._conn:
                 self._conn.execute(
                     "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
                     (str(key), str(value)),

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -43,9 +43,9 @@ SAMPLE_FIELDS: Tuple[str, ...] = (
 )
 
 # Bump and add a migration block in StatsStore._init_schema whenever the
-# samples / agg_5min / agg_hourly / events / meta schema gains a column
-# or table. See src/eneru/CLAUDE.md "Stats schema evolution".
-SCHEMA_VERSION = 3
+# samples / agg_5min / agg_hourly / events / meta / notifications schema
+# gains a column or table. See src/eneru/CLAUDE.md "Stats schema evolution".
+SCHEMA_VERSION = 4
 
 # Bucket sizes for aggregation tiers.
 BUCKET_5MIN = 5 * 60
@@ -248,6 +248,24 @@ class StatsStore:
                     key TEXT PRIMARY KEY,
                     value TEXT
                 );
+
+                -- v4: persistent notification queue. The worker reads/writes
+                -- through this table so messages survive process death and
+                -- prolonged endpoint outages. Pending rows are NEVER pruned
+                -- by retention TTL — only sent/cancelled rows are.
+                CREATE TABLE IF NOT EXISTS notifications (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts INTEGER NOT NULL,
+                    body TEXT NOT NULL,
+                    notify_type TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    sent_at INTEGER,
+                    cancel_reason TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_notifications_status_ts
+                    ON notifications(status, ts);
             """)
             self._migrate_schema()
             self._conn.execute(
@@ -315,6 +333,26 @@ class StatsStore:
             #   WHERE notification_sent = 0 GROUP BY event_type;
             self._safe_alter("events",
                              "notification_sent INTEGER DEFAULT 1")
+
+        if current < 4:
+            # v3 -> v4: persistent notification queue. New table + index;
+            # no ALTERs to existing tables. Idempotent via CREATE IF NOT
+            # EXISTS so a partially-migrated DB heals on next open.
+            self._conn.executescript("""
+                CREATE TABLE IF NOT EXISTS notifications (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts INTEGER NOT NULL,
+                    body TEXT NOT NULL,
+                    notify_type TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    sent_at INTEGER,
+                    cancel_reason TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_notifications_status_ts
+                    ON notifications(status, ts);
+            """)
 
     def _safe_alter(self, table: str, column_def: str) -> None:
         """Idempotent ``ALTER TABLE ... ADD COLUMN``; ignores duplicates."""
@@ -516,6 +554,267 @@ class StatsStore:
         except (sqlite3.Error, OSError) as e:
             self._log_error_once(f"stats: query_events failed: {e}")
             return []
+
+    # ----- notification queue (v4+) -----
+
+    def enqueue_notification(self, body: str, notify_type: str,
+                             category: str,
+                             ts: Optional[int] = None) -> Optional[int]:
+        """Persist a pending notification. Returns the new row id, or
+        ``None`` if the store isn't open (caller should fall back).
+
+        Safe to call from any thread.
+        """
+        if self._conn is None:
+            return None
+        ts = int(ts if ts is not None else time.time())
+        try:
+            with self._conn:
+                cur = self._conn.execute(
+                    "INSERT INTO notifications "
+                    "(ts, body, notify_type, category) "
+                    "VALUES (?, ?, ?, ?)",
+                    (ts, str(body), str(notify_type), str(category)),
+                )
+                return int(cur.lastrowid)
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(f"stats: enqueue_notification failed: {e}")
+            return None
+
+    def next_pending_notifications(self,
+                                   limit: int = 10) -> List[Tuple]:
+        """Return up to ``limit`` oldest pending rows as
+        ``(ts, id, body, notify_type, attempts, category)`` tuples.
+        Order: ts ASC then id ASC for deterministic FIFO across same-ts ties.
+        """
+        if self._conn is None:
+            return []
+        try:
+            cur = self._conn.execute(
+                "SELECT ts, id, body, notify_type, attempts, category "
+                "FROM notifications WHERE status='pending' "
+                "ORDER BY ts ASC, id ASC LIMIT ?",
+                (int(limit),),
+            )
+            return cur.fetchall()
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: next_pending_notifications failed: {e}"
+            )
+            return []
+
+    def find_pending_by_category(self, category: str,
+                                 since_ts: Optional[int] = None
+                                 ) -> List[Tuple]:
+        """Return pending rows with the given category as
+        ``(id, ts, body, notify_type)`` tuples. Used by the worker's
+        coalescing pass (Slice 4): scan for an open on-battery / on-line
+        pair to fold into one summary."""
+        if self._conn is None:
+            return []
+        try:
+            if since_ts is None:
+                cur = self._conn.execute(
+                    "SELECT id, ts, body, notify_type FROM notifications "
+                    "WHERE status='pending' AND category=? "
+                    "ORDER BY ts ASC",
+                    (str(category),),
+                )
+            else:
+                cur = self._conn.execute(
+                    "SELECT id, ts, body, notify_type FROM notifications "
+                    "WHERE status='pending' AND category=? AND ts>=? "
+                    "ORDER BY ts ASC",
+                    (str(category), int(since_ts)),
+                )
+            return cur.fetchall()
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: find_pending_by_category failed: {e}"
+            )
+            return []
+
+    def mark_notification_sent(self, notification_id: int,
+                               sent_at: Optional[int] = None) -> None:
+        """Mark a notification as delivered."""
+        if self._conn is None:
+            return
+        sent_at = int(sent_at if sent_at is not None else time.time())
+        try:
+            with self._conn:
+                self._conn.execute(
+                    "UPDATE notifications SET status='sent', sent_at=? "
+                    "WHERE id=?",
+                    (sent_at, int(notification_id)),
+                )
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: mark_notification_sent failed: {e}"
+            )
+
+    def mark_notification_attempt(self, notification_id: int) -> None:
+        """Increment a notification's attempt counter (it stays pending
+        — the worker will retry on the next loop iteration)."""
+        if self._conn is None:
+            return
+        try:
+            with self._conn:
+                self._conn.execute(
+                    "UPDATE notifications SET attempts=attempts+1 "
+                    "WHERE id=?",
+                    (int(notification_id),),
+                )
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: mark_notification_attempt failed: {e}"
+            )
+
+    def cancel_notification(self, notification_id: int,
+                            reason: str) -> None:
+        """Mark a notification as cancelled (won't retry, eligible for
+        TTL pruning). Reason is one of ``max_attempts``, ``too_old``,
+        ``backlog_overflow``, ``coalesced``, ``superseded``."""
+        if self._conn is None:
+            return
+        try:
+            with self._conn:
+                self._conn.execute(
+                    "UPDATE notifications SET status='cancelled', "
+                    "cancel_reason=? WHERE id=?",
+                    (str(reason), int(notification_id)),
+                )
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: cancel_notification failed: {e}"
+            )
+
+    def pending_notification_count(self) -> int:
+        """Return the number of pending rows in this store. Used by
+        ``flush()`` to know when the queue has drained."""
+        if self._conn is None:
+            return 0
+        try:
+            cur = self._conn.execute(
+                "SELECT COUNT(*) FROM notifications WHERE status='pending'"
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: pending_notification_count failed: {e}"
+            )
+            return 0
+
+    def cap_pending_notifications(self, max_pending: int) -> int:
+        """Enforce the backlog cap. If pending count exceeds
+        ``max_pending``, cancel the oldest rows down to the cap with
+        ``cancel_reason='backlog_overflow'``. Returns number cancelled.
+
+        Pass 0 / negative to disable (no cap)."""
+        if self._conn is None or max_pending <= 0:
+            return 0
+        try:
+            with self._conn:
+                cur = self._conn.execute(
+                    "SELECT COUNT(*) FROM notifications "
+                    "WHERE status='pending'"
+                )
+                row = cur.fetchone()
+                pending = int(row[0]) if row else 0
+                excess = pending - int(max_pending)
+                if excess <= 0:
+                    return 0
+                # Cancel the `excess` oldest pending rows.
+                self._conn.execute(
+                    "UPDATE notifications SET status='cancelled', "
+                    "cancel_reason='backlog_overflow' "
+                    "WHERE id IN ("
+                    "  SELECT id FROM notifications WHERE status='pending' "
+                    "  ORDER BY ts ASC, id ASC LIMIT ?"
+                    ")",
+                    (int(excess),),
+                )
+                return excess
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: cap_pending_notifications failed: {e}"
+            )
+            return 0
+
+    def prune_old_notifications(self, retention_days: int,
+                                max_age_days: int = 0) -> Tuple[int, int]:
+        """Two-step cleanup:
+
+        1. ``DELETE`` rows in (``sent``, ``cancelled``) older than
+           ``retention_days``. The sent log isn't an audit log; that's
+           ``events``. Default 7d keeps the recent flush history for
+           debugging without unbounded growth.
+        2. ``UPDATE`` pending rows older than ``max_age_days`` to
+           ``cancelled`` with ``cancel_reason='too_old'``. Skipped when
+           ``max_age_days <= 0`` (pending lives forever — the panic-attack
+           guarantee). Default 30d means a month-long sabbatical still
+           delivers; longer than that is probably stale anyway.
+
+        Returns ``(deleted, expired)`` for logging."""
+        if self._conn is None:
+            return (0, 0)
+        cutoff_sent = int(time.time()) - max(1, int(retention_days)) * 86400
+        deleted = 0
+        expired = 0
+        try:
+            with self._conn:
+                cur = self._conn.execute(
+                    "DELETE FROM notifications "
+                    "WHERE status IN ('sent','cancelled') AND ts < ?",
+                    (cutoff_sent,),
+                )
+                deleted = cur.rowcount or 0
+                if max_age_days > 0:
+                    cutoff_pending = (
+                        int(time.time()) - int(max_age_days) * 86400
+                    )
+                    cur = self._conn.execute(
+                        "UPDATE notifications SET status='cancelled', "
+                        "cancel_reason='too_old' "
+                        "WHERE status='pending' AND ts < ?",
+                        (cutoff_pending,),
+                    )
+                    expired = cur.rowcount or 0
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: prune_old_notifications failed: {e}"
+            )
+        return (deleted, expired)
+
+    # ----- generic meta key/value store -----
+
+    def get_meta(self, key: str) -> Optional[str]:
+        """Read a value from the ``meta`` table. Used by Slice 3 to
+        track ``last_seen_version`` for the pip-path lifecycle classifier."""
+        if self._conn is None:
+            return None
+        try:
+            cur = self._conn.execute(
+                "SELECT value FROM meta WHERE key=?", (str(key),),
+            )
+            row = cur.fetchone()
+            return str(row[0]) if row else None
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(f"stats: get_meta failed: {e}")
+            return None
+
+    def set_meta(self, key: str, value: str) -> None:
+        """Write a value to the ``meta`` table (insert-or-replace)."""
+        if self._conn is None:
+            return
+        try:
+            with self._conn:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                    (str(key), str(value)),
+                )
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(f"stats: set_meta failed: {e}")
 
     # ----- metric query API -----
 

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -300,9 +300,9 @@ def _format_event_line(ts: int, label: str, event_type: str,
                        detail: str, multi_ups: bool) -> str:
     """Format one event row from the SQLite events table for display."""
     try:
-        time_str = datetime.fromtimestamp(int(ts)).strftime("%H:%M:%S")
+        time_str = datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M:%S")
     except (TypeError, ValueError, OSError):
-        time_str = "??:??:??"
+        time_str = "????-??-?? ??:??:??"
     prefix = f"[{label}] " if multi_ups else ""
     if detail:
         return f"{time_str}  {prefix}{event_type}: {detail}"

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -1,5 +1,5 @@
 """Version information for Eneru."""
 
 # Version is set at build time via git describe --tags
-# Format: "5.1.0" for tagged releases, "5.1.0-5-gabcdef1" for dev builds
-__version__ = "5.1.2"
+# Format: "5.2.0" for tagged releases, "5.2.0-5-gabcdef1" for dev builds
+__version__ = "5.2.0"

--- a/tests/e2e/config-e2e-coalesce.yaml
+++ b/tests/e2e/config-e2e-coalesce.yaml
@@ -49,6 +49,11 @@ notifications:
     # guaranteed-unreachable per RFC 5737 — every call fails, every
     # row stays pending, the coalescer gets to do its job.
     - "json://192.0.2.1/notify"
+  # 1 s Apprise timeout so the worker doesn't sit blocked on the
+  # unreachable TEST-NET-1 host for 10 s × N pending; we need it to
+  # cycle back to the coalesce pass quickly (the on_line arrives ~4 s
+  # after on_battery in the scenario).
+  timeout: 1
   retry_interval: 1
   retry_backoff_max: 5
   max_attempts: 0

--- a/tests/e2e/config-e2e-coalesce.yaml
+++ b/tests/e2e/config-e2e-coalesce.yaml
@@ -1,0 +1,57 @@
+# Eneru E2E test config — Slice 4 panic-attack coalescing.
+#
+# Notifications are enabled but pointed at an unreachable Apprise URL,
+# so every Apprise call returns False and the rows stay 'pending'. Once
+# eneru cycles ON_BATTERY → POWER_RESTORED, the worker's coalescer
+# folds the pair into a single "Brief Power Outage" summary row. The
+# test then inspects the SQLite notifications table directly to assert
+# the contract.
+#
+# The key reason the URL never resolves successfully is that
+# 192.0.2.0/24 is RFC 5737 TEST-NET-1 — guaranteed not to point at any
+# real host. Apprise gives up quickly and returns False.
+
+ups:
+  name: "TestUPS@localhost:3493"
+  display_name: "E2E Coalesce UPS"
+  check_interval: 1
+
+triggers:
+  low_battery_threshold: 5      # high enough that ON_BATTERY fires but
+  critical_runtime_threshold: 1 # neither low_battery nor critical_runtime
+  depletion:                    # trigger an emergency shutdown — we just
+    window: 300                 # want the on-battery / on-line cycle.
+    critical_rate: 1000.0
+    grace_period: 300
+  extended_time:
+    enabled: false
+
+statistics:
+  db_directory: "/tmp/eneru-e2e-coalesce"
+  retention:
+    raw_hours: 24
+    agg_5min_days: 30
+    agg_hourly_days: 1825
+
+behavior:
+  dry_run: true
+
+logging:
+  file: null
+  state_file: "/tmp/eneru-e2e-coalesce-state"
+  battery_history_file: "/tmp/eneru-e2e-coalesce-history"
+  shutdown_flag_file: "/tmp/eneru-e2e-coalesce-shutdown-flag"
+
+notifications:
+  enabled: true
+  urls:
+    # json:// scheme posts to a generic webhook URL. 192.0.2.x is
+    # guaranteed-unreachable per RFC 5737 — every call fails, every
+    # row stays pending, the coalescer gets to do its job.
+    - "json://192.0.2.1/notify"
+  retry_interval: 1
+  retry_backoff_max: 5
+  max_attempts: 0
+
+local_shutdown:
+  enabled: false

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -338,5 +338,84 @@ echo ""
 echo "=== Test 32 PASSED: voltage auto-detect verified ==="
 )
 
+# ======================================================================
+# Test 34: v5.2 panic-attack coalescing (Slice 4)
+#
+# Cycle ON_BATTERY → POWER_RESTORED with notifications pointed at an
+# unreachable Apprise endpoint (RFC 5737 TEST-NET-1). Both rows stay
+# 'pending' in SQLite, the worker's coalescer folds them into one
+# "Brief Power Outage" summary, and the originals get cancel_reason=
+# 'coalesced'. This is the only direct E2E coverage of the slice 4
+# coalescer; per-rule unit tests carry the rest.
+# ======================================================================
+(
+echo ""
+echo ">>> Running: Test 34: panic-attack coalescing"
+
+echo "=== Test 34: panic-attack notification coalescing ==="
+
+# Clean slate.
+rm -rf /tmp/eneru-e2e-coalesce /tmp/eneru-e2e-coalesce-*
+mkdir -p /tmp/eneru-e2e-coalesce
+rm -f /tmp/eneru-e2e-coalesce-shutdown-flag
+
+# Start from on-line.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+sleep 3
+
+# Run eneru in the background — we drive the NUT scenario from the
+# foreground while the worker thread cycles through events.
+eneru run --config $E2E_DIR/config-e2e-coalesce.yaml > /tmp/test34.log 2>&1 &
+ENERU_PID=$!
+sleep 5  # let _initialize finish + register store + reach steady state
+
+# Trigger the outage.
+cp $E2E_DIR/scenarios/on-battery.dev $E2E_DIR/scenarios/apply.dev
+sleep 5  # ON_BATTERY event fires + lands in DB pending
+# Restore power.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+sleep 5  # POWER_RESTORED fires + worker iteration runs the coalescer
+
+# Stop eneru cleanly (SIGTERM → _cleanup_and_exit → flush(5)).
+kill -TERM $ENERU_PID 2>/dev/null || true
+wait $ENERU_PID 2>/dev/null || true
+
+DB=$(ls /tmp/eneru-e2e-coalesce/*.db 2>/dev/null | head -1)
+if [ -z "$DB" ]; then
+  echo "FAIL: no SQLite stats DB created at /tmp/eneru-e2e-coalesce/"
+  cat /tmp/test34.log
+  exit 1
+fi
+
+# Originals: 2 rows cancelled with reason='coalesced'.
+coalesced=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM notifications \
+   WHERE category='power_event' AND status='cancelled' \
+     AND cancel_reason='coalesced';")
+if [ "$coalesced" -ne 2 ]; then
+  echo "FAIL: expected 2 cancelled (coalesced) power_event rows, got $coalesced"
+  sqlite3 "$DB" "SELECT id, ts, status, cancel_reason, body FROM notifications WHERE category='power_event' ORDER BY id;"
+  cat /tmp/test34.log
+  exit 1
+fi
+echo "PASS (34a): 2 power_event rows cancelled with reason='coalesced'"
+
+# Summary: 1 pending row whose body says "Brief Power Outage".
+summary=$(sqlite3 "$DB" \
+  "SELECT body FROM notifications \
+   WHERE category='power_event' AND status='pending' \
+     AND body LIKE '%Brief Power Outage%';")
+if [ -z "$summary" ]; then
+  echo "FAIL: no pending 'Brief Power Outage' summary row found"
+  sqlite3 "$DB" "SELECT id, ts, status, cancel_reason, body FROM notifications WHERE category='power_event' ORDER BY id;"
+  cat /tmp/test34.log
+  exit 1
+fi
+echo "PASS (34b): coalesced summary row present and pending"
+
+echo ""
+echo "=== Test 34 PASSED: panic-attack coalescing verified ==="
+)
+
 echo ""
 echo "=== Group 'stats' completed successfully ==="

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -387,10 +387,14 @@ if [ -z "$DB" ]; then
   exit 1
 fi
 
-# Originals: 2 rows cancelled with reason='coalesced'.
+# Originals: 2 rows cancelled with reason='coalesced'. Production tags
+# the originals with sub-typed categories (power_event_on_battery /
+# power_event_on_line) so the coalescer can pair them by exact match
+# instead of grepping body text — see the ddbd886 hotfix.
 coalesced=$(sqlite3 "$DB" \
   "SELECT COUNT(*) FROM notifications \
-   WHERE category='power_event' AND status='cancelled' \
+   WHERE category IN ('power_event_on_battery','power_event_on_line') \
+     AND status='cancelled' \
      AND cancel_reason='coalesced';")
 if [ "$coalesced" -ne 2 ]; then
   echo "FAIL: expected 2 cancelled (coalesced) power_event rows, got $coalesced"

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -318,13 +318,17 @@ if ! echo "$rows" | grep -q "VOLTAGE_AUTODETECT_MISMATCH|0"; then
 fi
 echo "PASS (32c): events table records mismatch with notification_sent=0"
 
-# Schema version must be 3 after rc7-class daemon's first start.
+# Schema version must match SCHEMA_VERSION in src/eneru/stats.py — the
+# value bumps on each migration (3 in v5.1.x, 4 in v5.2.0). Read the
+# expected value from the package itself rather than hard-coding so this
+# assertion doesn't keep breaking on every schema change.
+expected_ver=$(python3 -c "from eneru.stats import SCHEMA_VERSION; print(SCHEMA_VERSION)")
 ver=$(sqlite3 "$DB" "SELECT value FROM meta WHERE key='schema_version';")
-if [ "$ver" != "3" ]; then
-  echo "FAIL: expected schema_version=3, got '$ver'"
+if [ "$ver" != "$expected_ver" ]; then
+  echo "FAIL: expected schema_version=$expected_ver, got '$ver'"
   exit 1
 fi
-echo "PASS (32d): meta.schema_version=3"
+echo "PASS (32d): meta.schema_version=$ver"
 
 # Restore for downstream tests
 cp $E2E_DIR/scenarios/online-charging.dev \

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -370,19 +370,38 @@ ENERU_PID=$!
 sleep 5  # let _initialize finish + register store + reach steady state
 
 # Trigger the outage.
-cp $E2E_DIR/scenarios/on-battery.dev $E2E_DIR/scenarios/apply.dev
+cp "$E2E_DIR/scenarios/on-battery.dev" "$E2E_DIR/scenarios/apply.dev"
 sleep 5  # ON_BATTERY event fires + lands in DB pending
 # Restore power.
-cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
-sleep 5  # POWER_RESTORED fires + worker iteration runs the coalescer
+cp "$E2E_DIR/scenarios/online-charging.dev" "$E2E_DIR/scenarios/apply.dev"
+sleep 2  # POWER_RESTORED fires + lands in DB
+
+# Poll for the coalesced state instead of a fixed sleep — we don't
+# want to race the worker thread's iteration cadence (it's blocked
+# attempting Apprise calls to TEST-NET-1, but with timeout=1 in the
+# config it cycles every second). 20 s ceiling; well below the SIGTERM
+# kill path's flush(timeout=5) so we never starve that.
+DB_DIR=/tmp/eneru-e2e-coalesce
+for i in $(seq 1 20); do
+  DB_PROBE=$(find "$DB_DIR" -maxdepth 1 -name '*.db' 2>/dev/null | head -1)
+  if [ -n "$DB_PROBE" ]; then
+    c=$(sqlite3 "$DB_PROBE" \
+      "SELECT COUNT(*) FROM notifications \
+       WHERE category IN ('power_event_on_battery','power_event_on_line') \
+         AND status='cancelled' AND cancel_reason='coalesced';" \
+      2>/dev/null || echo 0)
+    [ "$c" = "2" ] && break
+  fi
+  sleep 1
+done
 
 # Stop eneru cleanly (SIGTERM → _cleanup_and_exit → flush(5)).
 kill -TERM $ENERU_PID 2>/dev/null || true
 wait $ENERU_PID 2>/dev/null || true
 
-DB=$(ls /tmp/eneru-e2e-coalesce/*.db 2>/dev/null | head -1)
+DB=$(find "$DB_DIR" -maxdepth 1 -name '*.db' 2>/dev/null | head -1)
 if [ -z "$DB" ]; then
-  echo "FAIL: no SQLite stats DB created at /tmp/eneru-e2e-coalesce/"
+  echo "FAIL: no SQLite stats DB created at $DB_DIR/"
   cat /tmp/test34.log
   exit 1
 fi
@@ -398,7 +417,12 @@ coalesced=$(sqlite3 "$DB" \
      AND cancel_reason='coalesced';")
 if [ "$coalesced" -ne 2 ]; then
   echo "FAIL: expected 2 cancelled (coalesced) power_event rows, got $coalesced"
-  sqlite3 "$DB" "SELECT id, ts, status, cancel_reason, body FROM notifications WHERE category='power_event' ORDER BY id;"
+  # Dump ALL notification rows so a category-naming regression is visible
+  # (was hiding a real issue earlier when the filter was still scoped to
+  # category='power_event').
+  echo "--- ALL notifications rows: ---"
+  sqlite3 "$DB" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  echo "--- /tmp/test34.log: ---"
   cat /tmp/test34.log
   exit 1
 fi
@@ -411,7 +435,7 @@ summary=$(sqlite3 "$DB" \
      AND body LIKE '%Brief Power Outage%';")
 if [ -z "$summary" ]; then
   echo "FAIL: no pending 'Brief Power Outage' summary row found"
-  sqlite3 "$DB" "SELECT id, ts, status, cancel_reason, body FROM notifications WHERE category='power_event' ORDER BY id;"
+  sqlite3 "$DB" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
   cat /tmp/test34.log
   exit 1
 fi

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,271 @@
+"""Tests for the v5.2 lifecycle classifier (Slice 3).
+
+Covers the marker-file CRUD helpers and the pure
+:func:`classify_startup` function across every branch:
+- upgrade marker → 📦 Upgraded
+- pip-path upgrade (last_seen vs current) → 📦 Upgraded
+- shutdown marker reason=sequence_complete → 📊 Recovered
+- shutdown marker reason=fatal → 🚀 Restarted (fatal)
+- shutdown marker reason=signal + recent downtime → 🔄 Restarted
+- shutdown marker reason=signal + old downtime → 🚀 Started (last seen)
+- no marker, last_seen present → 🚀 Started (after crash)
+- no marker, no last_seen → 🚀 Started (first install)
+"""
+
+import json
+import time
+
+import pytest
+
+from eneru.lifecycle import (
+    REASON_FATAL,
+    REASON_SEQUENCE_COMPLETE,
+    REASON_SIGNAL,
+    RESTART_DOWNTIME_THRESHOLD_SECS,
+    SHUTDOWN_MARKER_NAME,
+    UPGRADE_MARKER_NAME,
+    classify_startup,
+    delete_shutdown_marker,
+    delete_upgrade_marker,
+    read_shutdown_marker,
+    read_upgrade_marker,
+    write_shutdown_marker,
+)
+
+
+# ==============================================================================
+# Marker file CRUD
+# ==============================================================================
+
+class TestShutdownMarker:
+
+    @pytest.mark.unit
+    def test_write_then_read_round_trip(self, tmp_path):
+        write_shutdown_marker(
+            tmp_path, version="5.2.0", reason=REASON_SIGNAL,
+            shutdown_at=1700000000,
+        )
+        marker = read_shutdown_marker(tmp_path)
+        assert marker == {
+            "shutdown_at": 1700000000,
+            "version": "5.2.0",
+            "reason": "signal",
+        }
+
+    @pytest.mark.unit
+    def test_read_returns_none_when_absent(self, tmp_path):
+        assert read_shutdown_marker(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_read_returns_none_on_invalid_json(self, tmp_path):
+        (tmp_path / SHUTDOWN_MARKER_NAME).write_text("{not valid json")
+        assert read_shutdown_marker(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_delete_idempotent_when_absent(self, tmp_path):
+        # Must not raise even when the marker isn't there.
+        delete_shutdown_marker(tmp_path)
+        delete_shutdown_marker(tmp_path)
+
+    @pytest.mark.unit
+    def test_delete_removes_existing_marker(self, tmp_path):
+        write_shutdown_marker(tmp_path, version="5.2.0")
+        assert (tmp_path / SHUTDOWN_MARKER_NAME).exists()
+        delete_shutdown_marker(tmp_path)
+        assert not (tmp_path / SHUTDOWN_MARKER_NAME).exists()
+
+    @pytest.mark.unit
+    def test_write_creates_directory_if_missing(self, tmp_path):
+        target = tmp_path / "nested" / "stats"
+        write_shutdown_marker(target, version="5.2.0")
+        assert (target / SHUTDOWN_MARKER_NAME).exists()
+
+    @pytest.mark.unit
+    def test_write_uses_now_when_shutdown_at_omitted(self, tmp_path):
+        before = int(time.time())
+        write_shutdown_marker(tmp_path, version="5.2.0")
+        after = int(time.time())
+        marker = read_shutdown_marker(tmp_path)
+        assert before <= marker["shutdown_at"] <= after
+
+
+class TestUpgradeMarker:
+
+    @pytest.mark.unit
+    def test_read_returns_dict_when_present(self, tmp_path):
+        (tmp_path / UPGRADE_MARKER_NAME).write_text(
+            json.dumps({"old_version": "5.1.2", "new_version": "5.2.0"})
+        )
+        assert read_upgrade_marker(tmp_path) == {
+            "old_version": "5.1.2", "new_version": "5.2.0",
+        }
+
+    @pytest.mark.unit
+    def test_read_returns_none_when_absent(self, tmp_path):
+        assert read_upgrade_marker(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_read_returns_none_on_invalid_json(self, tmp_path):
+        (tmp_path / UPGRADE_MARKER_NAME).write_text("garbage")
+        assert read_upgrade_marker(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_delete_idempotent(self, tmp_path):
+        delete_upgrade_marker(tmp_path)
+
+
+# ==============================================================================
+# classify_startup — each branch
+# ==============================================================================
+
+class TestClassifyStartup:
+
+    @pytest.mark.unit
+    def test_upgrade_marker_takes_priority(self):
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker={"shutdown_at": 1, "version": "5.1.2",
+                             "reason": "signal"},
+            upgrade_marker={"old_version": "5.1.2",
+                            "new_version": "5.2.0"},
+            last_seen_version="5.1.2",
+            now_ts=100,
+        )
+        assert "📦" in body and "Upgraded" in body
+        assert "5.1.2" in body and "5.2.0" in body
+        assert ntype == "success"
+
+    @pytest.mark.unit
+    def test_upgrade_marker_falls_back_to_current_when_new_version_missing(self):
+        body, _ = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker=None,
+            upgrade_marker={"old_version": "5.1.2"},  # no new_version
+            last_seen_version=None,
+            now_ts=100,
+        )
+        assert "5.1.2" in body and "5.2.0" in body
+
+    @pytest.mark.unit
+    def test_pip_path_upgrade_via_last_seen_version_diff(self):
+        """No on-disk markers but last_seen_version differs from
+        current_version (pip user upgraded between runs)."""
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker=None,
+            upgrade_marker=None,
+            last_seen_version="5.1.2",
+            now_ts=100,
+        )
+        assert "📦" in body and "Upgraded" in body
+        assert "5.1.2" in body and "5.2.0" in body
+        assert ntype == "success"
+
+    @pytest.mark.unit
+    def test_shutdown_sequence_complete_emits_recovered(self):
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker={"shutdown_at": 1000,
+                             "version": "5.2.0",
+                             "reason": REASON_SEQUENCE_COMPLETE},
+            upgrade_marker=None,
+            last_seen_version="5.2.0",
+            now_ts=23000,  # 22000s downtime
+        )
+        assert "📊" in body and "Recovered" in body
+        assert "power-loss" in body
+        assert "5.2.0" in body
+        assert ntype == "success"
+
+    @pytest.mark.unit
+    def test_shutdown_fatal_emits_restarted_after_fatal(self):
+        # Same version on both sides — otherwise the pip-path upgrade
+        # branch wins (covered separately in
+        # test_pip_upgrade_during_shutdown_marker_combines_both).
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker={"shutdown_at": 100,
+                             "version": "5.2.0",
+                             "reason": REASON_FATAL},
+            upgrade_marker=None,
+            last_seen_version="5.2.0",
+            now_ts=200,
+        )
+        assert "🚀" in body and "Restarted" in body
+        assert "fatally" in body
+        assert "5.2.0" in body
+        assert ntype == "warning"
+
+    @pytest.mark.unit
+    def test_shutdown_signal_recent_downtime_emits_restarted(self):
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker={"shutdown_at": 100,
+                             "version": "5.2.0",
+                             "reason": REASON_SIGNAL},
+            upgrade_marker=None,
+            last_seen_version="5.2.0",
+            now_ts=100 + RESTART_DOWNTIME_THRESHOLD_SECS - 1,
+        )
+        assert "🔄" in body and "Restarted" in body
+        assert ntype == "info"
+
+    @pytest.mark.unit
+    def test_shutdown_signal_old_downtime_emits_started_with_last_seen(self):
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker={"shutdown_at": 100,
+                             "version": "5.2.0",
+                             "reason": REASON_SIGNAL},
+            upgrade_marker=None,
+            last_seen_version="5.2.0",
+            now_ts=100 + RESTART_DOWNTIME_THRESHOLD_SECS + 60,
+        )
+        assert "🚀" in body and "Started" in body and "last seen" in body
+        assert "🔄" not in body
+        assert ntype == "info"
+
+    @pytest.mark.unit
+    def test_no_marker_with_last_seen_emits_after_crash(self):
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker=None,
+            upgrade_marker=None,
+            last_seen_version="5.2.0",
+            now_ts=100,
+        )
+        assert "🚀" in body and "after crash" in body
+        assert ntype == "warning"
+
+    @pytest.mark.unit
+    def test_no_marker_no_last_seen_emits_first_start(self):
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker=None,
+            upgrade_marker=None,
+            last_seen_version=None,
+            now_ts=100,
+        )
+        assert "🚀" in body and "Started" in body
+        assert "after crash" not in body
+        assert "last seen" not in body
+        assert ntype == "info"
+
+    @pytest.mark.unit
+    def test_pip_upgrade_during_shutdown_marker_combines_both(self):
+        """Edge case: pip user upgraded mid-cycle. Both shutdown marker
+        AND a different last_seen_version are present. Should explain
+        both via the upgrade phrasing, since the version change is the
+        bigger story."""
+        body, ntype = classify_startup(
+            current_version="5.2.0",
+            shutdown_marker={"shutdown_at": 100,
+                             "version": "5.1.2",
+                             "reason": REASON_SIGNAL},
+            upgrade_marker=None,
+            last_seen_version="5.1.2",
+            now_ts=200,
+        )
+        assert "📦" in body and "Upgraded" in body
+        assert "5.1.2" in body and "5.2.0" in body
+        assert ntype == "success"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -25,12 +25,14 @@ from eneru.lifecycle import (
     SHUTDOWN_MARKER_NAME,
     UPGRADE_MARKER_NAME,
     classify_startup,
+    coalesce_recovered_with_prev_shutdown,
     delete_shutdown_marker,
     delete_upgrade_marker,
     read_shutdown_marker,
     read_upgrade_marker,
     write_shutdown_marker,
 )
+from eneru.stats import StatsStore
 
 
 # ==============================================================================
@@ -269,3 +271,111 @@ class TestClassifyStartup:
         assert "📦" in body and "Upgraded" in body
         assert "5.1.2" in body and "5.2.0" in body
         assert ntype == "success"
+
+
+# ==============================================================================
+# Slice 4: coalesce Recovered with previous shutdown headline
+# ==============================================================================
+
+class TestCoalesceRecoveredWithPrevShutdown:
+
+    def _store(self, tmp_path):
+        s = StatsStore(tmp_path / "n.db")
+        s.open()
+        return s
+
+    @pytest.mark.unit
+    def test_no_pending_returns_none(self, tmp_path):
+        s = self._store(tmp_path)
+        try:
+            assert coalesce_recovered_with_prev_shutdown(
+                s, downtime_secs=60, now_ts=2000,
+            ) is None
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_with_headline_includes_reason_and_times(self, tmp_path):
+        """When the previous instance's pending shutdown headline carries
+        a Reason: line, the coalesced body lifts that reason verbatim."""
+        s = self._store(tmp_path)
+        try:
+            head_id = s.enqueue_notification(
+                body=("🚨 **EMERGENCY SHUTDOWN INITIATED!**\n"
+                      "Reason: Battery charge 14% below threshold 20%\n"
+                      "Executing shutdown tasks."),
+                notify_type="failure",
+                category="shutdown",
+                ts=1000,
+            )
+            body = coalesce_recovered_with_prev_shutdown(
+                s, downtime_secs=3600, now_ts=4600,
+            )
+            assert body is not None
+            assert "📊" in body and "Recovered" in body
+            assert "Battery charge 14% below threshold 20%" in body
+            # The headline row should now be cancelled with reason coalesced.
+            row = s._conn.execute(
+                "SELECT status, cancel_reason FROM notifications "
+                "WHERE id=?", (head_id,),
+            ).fetchone()
+            assert row == ("cancelled", "coalesced")
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_with_summary_only_includes_times(self, tmp_path):
+        """When only the shutdown_summary is pending (the headline
+        already shipped), coalesce on the summary alone — no Reason
+        line available, but still folds into one Recovered message."""
+        s = self._store(tmp_path)
+        try:
+            sum_id = s.enqueue_notification(
+                body="✅ **Shutdown Sequence Complete** (took 12s)\nPowering down.",
+                notify_type="failure",
+                category="shutdown_summary",
+                ts=1000,
+            )
+            body = coalesce_recovered_with_prev_shutdown(
+                s, downtime_secs=120, now_ts=1120,
+            )
+            assert body is not None
+            assert "Recovered" in body
+            row = s._conn.execute(
+                "SELECT status, cancel_reason FROM notifications "
+                "WHERE id=?", (sum_id,),
+            ).fetchone()
+            assert row == ("cancelled", "coalesced")
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_headline_takes_priority_over_summary_when_both_pending(self, tmp_path):
+        """If both the shutdown headline AND its summary are pending,
+        the coalesced body is built from the headline (which carries
+        the Reason) and the summary is also cancelled."""
+        s = self._store(tmp_path)
+        try:
+            head_id = s.enqueue_notification(
+                body=("🚨 **EMERGENCY SHUTDOWN INITIATED!**\n"
+                      "Reason: Runtime 30s below threshold 60s\n"
+                      "Executing."),
+                notify_type="failure", category="shutdown", ts=1000,
+            )
+            sum_id = s.enqueue_notification(
+                body="✅ **Shutdown Sequence Complete** (took 8s)",
+                notify_type="failure", category="shutdown_summary", ts=1010,
+            )
+            body = coalesce_recovered_with_prev_shutdown(
+                s, downtime_secs=300, now_ts=1310,
+            )
+            assert body is not None
+            assert "Runtime 30s below threshold 60s" in body
+            for nid in (head_id, sum_id):
+                row = s._conn.execute(
+                    "SELECT status, cancel_reason FROM notifications "
+                    "WHERE id=?", (nid,),
+                ).fetchone()
+                assert row == ("cancelled", "coalesced")
+        finally:
+            s.close()

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -489,9 +489,14 @@ class TestNotifications:
         with patch.object(monitor, "_execute_shutdown_sequence"):
             monitor._trigger_immediate_shutdown("Battery critical")
 
-        # Notification worker should have been called (possibly multiple times
-        # for the shutdown notification + log forwarding)
-        assert monitor._notification_worker.send.call_count >= 1
+        # Exactly one notification: the headline. Log lines are NOT mirrored
+        # as notifications anymore (v5.2 — see TestNotificationPolicyV52).
+        assert monitor._notification_worker.send.call_count == 1
+        body = monitor._notification_worker.send.call_args.kwargs.get(
+            "body"
+        ) or monitor._notification_worker.send.call_args.args[0]
+        assert "EMERGENCY SHUTDOWN INITIATED" in body
+        assert "Battery critical" in body
 
     @pytest.mark.unit
     def test_power_restored_logs_event(self, tmp_path):
@@ -525,6 +530,109 @@ class TestNotifications:
 
         log_calls = [str(c) for c in monitor.logger.log.call_args_list]
         assert not any("POWER_RESTORED" in c for c in log_calls)
+
+
+# ==============================================================================
+# v5.2 NOTIFICATION POLICY (Slice 1: noise cleanup + wall opt-in)
+# ==============================================================================
+
+class TestNotificationPolicyV52:
+    """v5.2 changes: log lines no longer mirror to notifications during
+    shutdown, wall(1) is opt-in instead of always-on, and the sequence
+    completion notification fires in both the local-shutdown-enabled
+    and the local-shutdown-disabled paths."""
+
+    @pytest.mark.unit
+    def test_log_message_during_shutdown_does_not_mirror_to_notification(self, tmp_path):
+        """The "ℹ️ Shutdown Detail:" auto-mirror that wrapped every
+        _log_message during shutdown is gone. journalctl is the forensic
+        record now."""
+        monitor = make_monitor(tmp_path)
+        monitor._shutdown_flag_path.touch()
+
+        monitor._log_message("VMs: stopping libvirt-qemu-1234")
+        monitor._log_message("Containers: docker stop nginx")
+
+        # No notifications should have been queued solely because shutdown
+        # was in progress.
+        assert monitor._notification_worker.send.call_count == 0
+
+    @pytest.mark.unit
+    def test_wall_disabled_by_default(self, tmp_path):
+        """LocalShutdownConfig.wall defaults False; neither wall call
+        site fires the shell broadcast."""
+        monitor = make_monitor(tmp_path)
+        # Stub out the phases so the sequence runs without I/O.
+        monitor._shutdown_vms = lambda: None
+        monitor._shutdown_containers = lambda: None
+        monitor._sync_filesystems = lambda: None
+        monitor._unmount_filesystems = lambda: None
+        monitor._shutdown_remote_servers = lambda: None
+        # dry_run is False for this test — we want the wall path to be
+        # otherwise reachable so the *only* thing suppressing it is the
+        # config flag.
+        monitor.config.behavior.dry_run = False
+        monitor.config.local_shutdown.enabled = False  # don't actually halt
+
+        with patch("eneru.monitor.run_command") as run_cmd:
+            monitor._execute_shutdown_sequence()
+
+        wall_calls = [c for c in run_cmd.call_args_list
+                      if c.args and c.args[0] and c.args[0][0] == "wall"]
+        assert wall_calls == [], (
+            f"wall(1) should not be invoked when local_shutdown.wall=False; "
+            f"got {wall_calls}"
+        )
+
+    @pytest.mark.unit
+    def test_wall_enabled_invokes_wall_command(self, tmp_path):
+        """When the user opts in via local_shutdown.wall=True, the
+        shell broadcast fires from the sequence entry point."""
+        monitor = make_monitor(tmp_path)
+        monitor._shutdown_vms = lambda: None
+        monitor._shutdown_containers = lambda: None
+        monitor._sync_filesystems = lambda: None
+        monitor._unmount_filesystems = lambda: None
+        monitor._shutdown_remote_servers = lambda: None
+        monitor.config.behavior.dry_run = False
+        monitor.config.local_shutdown.enabled = False
+        monitor.config.local_shutdown.wall = True
+
+        with patch("eneru.monitor.run_command") as run_cmd:
+            monitor._execute_shutdown_sequence()
+
+        wall_calls = [c for c in run_cmd.call_args_list
+                      if c.args and c.args[0] and c.args[0][0] == "wall"]
+        assert len(wall_calls) == 1, (
+            f"expected one wall(1) broadcast at sequence start, got "
+            f"{len(wall_calls)}: {wall_calls}"
+        )
+
+    @pytest.mark.unit
+    def test_summary_notification_fires_when_local_shutdown_disabled(self, tmp_path):
+        """The "✅ Shutdown Sequence Complete" summary used to fire only
+        when local_shutdown.enabled=true (because the system was about
+        to halt and the user needed a goodbye). The disabled path
+        finished silently. v5.2 always summarises so users running Eneru
+        as a remote-resource orchestrator get the same closure."""
+        monitor = make_monitor(tmp_path)
+        monitor._shutdown_vms = lambda: None
+        monitor._shutdown_containers = lambda: None
+        monitor._sync_filesystems = lambda: None
+        monitor._unmount_filesystems = lambda: None
+        monitor._shutdown_remote_servers = lambda: None
+        monitor.config.local_shutdown.enabled = False
+
+        monitor._execute_shutdown_sequence()
+
+        bodies = []
+        for c in monitor._notification_worker.send.call_args_list:
+            body = c.kwargs.get("body") or (c.args[0] if c.args else "")
+            bodies.append(body)
+        summaries = [b for b in bodies if "Shutdown Sequence Complete" in b]
+        assert len(summaries) == 1, (
+            f"expected exactly one summary notification, got bodies={bodies}"
+        )
 
 
 # ==============================================================================

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -543,18 +543,28 @@ class TestNotificationPolicyV52:
     and the local-shutdown-disabled paths."""
 
     @pytest.mark.unit
-    def test_log_message_during_shutdown_does_not_mirror_to_notification(self, tmp_path):
-        """The "ℹ️ Shutdown Detail:" auto-mirror that wrapped every
-        _log_message during shutdown is gone. journalctl is the forensic
-        record now."""
+    def test_log_message_during_shutdown_does_not_auto_mirror(self, tmp_path):
+        """Regression guard for the v5.1 ``_log_message`` auto-mirror
+        block (lines 325-331 before its v5.2 removal): every log line
+        emitted during shutdown got wrapped as
+        ``ℹ️ **Shutdown Detail:** <line>`` and pushed through
+        ``_send_notification``, which produced ~22 notifications per
+        shutdown sequence. v5.2 deletes the block; this test fires
+        ``_log_message`` with the shutdown flag set and asserts the
+        notification worker was never called.
+
+        If a future change re-introduces any path from ``_log_message``
+        to ``_notification_worker.send``, this test fails — which is
+        exactly what we want.
+        """
         monitor = make_monitor(tmp_path)
         monitor._shutdown_flag_path.touch()
 
         monitor._log_message("VMs: stopping libvirt-qemu-1234")
         monitor._log_message("Containers: docker stop nginx")
 
-        # No notifications should have been queued solely because shutdown
-        # was in progress.
+        # journalctl carries the per-step trace; the notification
+        # channel must stay silent for these.
         assert monitor._notification_worker.send.call_count == 0
 
     @pytest.mark.unit

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -581,14 +581,19 @@ class TestPowerEventCoalescing:
         # the cap test had on Python 3.13.
         worker.stop()
 
-        # Simulate the on_battery → on_line pair with realistic bodies.
+        # Simulate the on_battery → on_line pair using the sub-typed
+        # categories that _log_power_event sets in production. The
+        # body wording is irrelevant to the coalescer (intentionally —
+        # it doesn't grep user-visible strings).
         registered_store.enqueue_notification(
-            body="⚡ **Event:** ON_BATTERY\nDetails: Battery 80%, Runtime 600s",
-            notify_type="failure", category="power_event", ts=1000,
+            body="⚠️ **POWER FAILURE DETECTED!**\nDetails: Battery 80%",
+            notify_type="warning",
+            category="power_event_on_battery", ts=1000,
         )
         registered_store.enqueue_notification(
-            body="⚡ **Event:** POWER_RESTORED\nDetails: outage 60s",
-            notify_type="success", category="power_event", ts=1060,
+            body="✅ **POWER RESTORED**\nDetails: Outage 60s",
+            notify_type="success",
+            category="power_event_on_line", ts=1060,
         )
         coalesced = worker._coalesce_pending_outages(registered_store)
         assert coalesced == 1
@@ -626,8 +631,9 @@ class TestPowerEventCoalescing:
         worker.stop()
 
         registered_store.enqueue_notification(
-            body="⚡ **Event:** ON_BATTERY\nDetails: Battery 80%",
-            notify_type="failure", category="power_event", ts=1000,
+            body="⚠️ **POWER FAILURE DETECTED!**\nDetails: Battery 80%",
+            notify_type="warning",
+            category="power_event_on_battery", ts=1000,
         )
         coalesced = worker._coalesce_pending_outages(registered_store)
         assert coalesced == 0

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -555,6 +555,86 @@ class TestBacklogCap:
 
 
 # ==============================================================================
+# Slice 4: brief-outage coalescing (panic-attack)
+# ==============================================================================
+
+class TestPowerEventCoalescing:
+
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_pair_collapses_into_brief_outage_summary(
+        self, mock_apprise, notification_config, registered_store,
+    ):
+        """When ON_BATTERY + POWER_RESTORED are both pending in the
+        store (network down for the duration of a short outage), the
+        coalescer replaces them with a single 'Brief Power Outage'
+        summary BEFORE the worker tries delivery."""
+        # Apprise unreachable so nothing ships and we can observe the
+        # final pending state.
+        _patch_apprise(mock_apprise, succeed=False)
+        worker = NotificationWorker(notification_config)
+        worker.start()
+        worker.register_store(registered_store)
+        # Stop the worker thread before mutating; we'll exercise
+        # _coalesce_pending_outages directly to avoid the same race
+        # the cap test had on Python 3.13.
+        worker.stop()
+
+        # Simulate the on_battery → on_line pair with realistic bodies.
+        registered_store.enqueue_notification(
+            body="⚡ **Event:** ON_BATTERY\nDetails: Battery 80%, Runtime 600s",
+            notify_type="failure", category="power_event", ts=1000,
+        )
+        registered_store.enqueue_notification(
+            body="⚡ **Event:** POWER_RESTORED\nDetails: outage 60s",
+            notify_type="success", category="power_event", ts=1060,
+        )
+        coalesced = worker._coalesce_pending_outages(registered_store)
+        assert coalesced == 1
+
+        # Originals cancelled; one new summary remains pending.
+        cancelled = registered_store._conn.execute(
+            "SELECT body, cancel_reason FROM notifications "
+            "WHERE status='cancelled' ORDER BY id ASC"
+        ).fetchall()
+        assert len(cancelled) == 2
+        assert all(c[1] == "coalesced" for c in cancelled)
+
+        pending = registered_store._conn.execute(
+            "SELECT body FROM notifications WHERE status='pending'"
+        ).fetchall()
+        assert len(pending) == 1
+        body = pending[0][0]
+        assert "Brief Power Outage" in body
+        # Includes duration + the time-of-day window.
+        assert "1m" in body or "60s" in body
+
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_unpaired_on_battery_alone_is_left_alone(
+        self, mock_apprise, notification_config, registered_store,
+    ):
+        """Without a matching POWER_RESTORED, the lone ON_BATTERY stays
+        pending — coalescing only kicks in for matched pairs (otherwise
+        we'd hide an in-progress outage from the user)."""
+        _patch_apprise(mock_apprise, succeed=False)
+        worker = NotificationWorker(notification_config)
+        worker.start()
+        worker.register_store(registered_store)
+        worker.stop()
+
+        registered_store.enqueue_notification(
+            body="⚡ **Event:** ON_BATTERY\nDetails: Battery 80%",
+            notify_type="failure", category="power_event", ts=1000,
+        )
+        coalesced = worker._coalesce_pending_outages(registered_store)
+        assert coalesced == 0
+        assert registered_store.pending_notification_count() == 1
+
+
+# ==============================================================================
 # Config defaults (regression-style)
 # ==============================================================================
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -74,6 +74,22 @@ def _wait_until(predicate, timeout=2.0, poll=0.02):
     return False
 
 
+def _peek(store, sql, params=()):
+    """Test helper: read from the store under its ``_db_lock`` to avoid
+    racing the worker thread on Python 3.13 sqlite3 (which raises
+    ``SystemError: error return without exception set`` when concurrent
+    execute()s share a connection without external mutex). Cubic P1.
+    """
+    with store._db_lock:
+        return store._conn.execute(sql, params).fetchone()
+
+
+def _peek_all(store, sql, params=()):
+    """Test helper: like ``_peek`` but returns ``fetchall()``."""
+    with store._db_lock:
+        return store._conn.execute(sql, params).fetchall()
+
+
 # ==============================================================================
 # Worker lifecycle
 # ==============================================================================
@@ -187,10 +203,11 @@ class TestSendPersistence:
             worker.stop()
             row_id = worker.send("persisted", "info", "lifecycle")
             assert row_id is not None
-            row = registered_store._conn.execute(
+            row = _peek(
+                registered_store,
                 "SELECT body, notify_type, category, status FROM notifications "
-                "WHERE id=?", (row_id,)
-            ).fetchone()
+                "WHERE id=?", (row_id,),
+            )
             assert row == ("persisted", "info", "lifecycle", "pending")
         finally:
             worker.stop()
@@ -265,15 +282,17 @@ class TestRetryAndBackoff:
             worker.send("retry-me", "info", "lifecycle")
             # Wait long enough for at least one attempt.
             assert _wait_until(
-                lambda: registered_store._conn.execute(
+                lambda: _peek(
+                    registered_store,
                     "SELECT attempts FROM notifications "
-                    "WHERE body='retry-me'"
-                ).fetchone()[0] >= 1
+                    "WHERE body='retry-me'",
+                )[0] >= 1
             )
-            row = registered_store._conn.execute(
+            row = _peek(
+                registered_store,
                 "SELECT status, attempts FROM notifications "
-                "WHERE body='retry-me'"
-            ).fetchone()
+                "WHERE body='retry-me'",
+            )
             assert row[0] == "pending"
             assert row[1] >= 1
         finally:
@@ -303,14 +322,16 @@ class TestRetryAndBackoff:
             worker.register_store(registered_store)
             worker.send("poison", "info", "lifecycle")
             assert _wait_until(
-                lambda: registered_store._conn.execute(
-                    "SELECT status FROM notifications WHERE body='poison'"
-                ).fetchone()[0] == "cancelled"
+                lambda: _peek(
+                    registered_store,
+                    "SELECT status FROM notifications WHERE body='poison'",
+                )[0] == "cancelled"
             )
-            row = registered_store._conn.execute(
+            row = _peek(
+                registered_store,
                 "SELECT status, attempts, cancel_reason "
-                "FROM notifications WHERE body='poison'"
-            ).fetchone()
+                "FROM notifications WHERE body='poison'",
+            )
             assert row[0] == "cancelled"
             assert row[1] == 3
             assert row[2] == "max_attempts"
@@ -342,15 +363,17 @@ class TestRetryAndBackoff:
             worker.register_store(registered_store)
             worker.send("forever", "info", "lifecycle")
             assert _wait_until(
-                lambda: registered_store._conn.execute(
+                lambda: _peek(
+                    registered_store,
                     "SELECT attempts FROM notifications "
-                    "WHERE body='forever'"
-                ).fetchone()[0] >= 5
+                    "WHERE body='forever'",
+                )[0] >= 5
             )
-            row = registered_store._conn.execute(
+            row = _peek(
+                registered_store,
                 "SELECT status, cancel_reason FROM notifications "
-                "WHERE body='forever'"
-            ).fetchone()
+                "WHERE body='forever'",
+            )
             assert row[0] == "pending"
             assert row[1] is None
         finally:
@@ -386,10 +409,11 @@ class TestRetryAndBackoff:
             assert _wait_until(
                 lambda: registered_store.pending_notification_count() == 0
             )
-            row = registered_store._conn.execute(
+            row = _peek(
+                registered_store,
                 "SELECT status, attempts FROM notifications "
-                "WHERE body='eventually'"
-            ).fetchone()
+                "WHERE body='eventually'",
+            )
             assert row[0] == "sent"
             assert row[1] >= 3
 
@@ -423,10 +447,12 @@ class TestRetryAndBackoff:
         worker.stop()
         elapsed = time.monotonic() - t0
         assert elapsed < 3.0
-        # Row stayed pending for the next start.
-        row = registered_store._conn.execute(
-            "SELECT status FROM notifications WHERE body='stays-pending'"
-        ).fetchone()
+        # Row stayed pending for the next start. Worker is stopped now,
+        # but use the lock helper anyway for consistency.
+        row = _peek(
+            registered_store,
+            "SELECT status FROM notifications WHERE body='stays-pending'",
+        )
         assert row[0] == "pending"
 
 
@@ -543,10 +569,11 @@ class TestBacklogCap:
             worker.send(f"msg-{i}", "info", "lifecycle")
         # Cap kicks in synchronously inside send().
         assert registered_store.pending_notification_count() <= 2
-        cancelled = registered_store._conn.execute(
+        cancelled = _peek_all(
+            registered_store,
             "SELECT body, cancel_reason FROM notifications "
-            "WHERE status='cancelled' ORDER BY id ASC"
-        ).fetchall()
+            "WHERE status='cancelled' ORDER BY id ASC",
+        )
         cancel_bodies = [c[0] for c in cancelled]
         cancel_reasons = {c[1] for c in cancelled}
         # Older messages cancelled, newest kept.
@@ -599,16 +626,18 @@ class TestPowerEventCoalescing:
         assert coalesced == 1
 
         # Originals cancelled; one new summary remains pending.
-        cancelled = registered_store._conn.execute(
+        cancelled = _peek_all(
+            registered_store,
             "SELECT body, cancel_reason FROM notifications "
-            "WHERE status='cancelled' ORDER BY id ASC"
-        ).fetchall()
+            "WHERE status='cancelled' ORDER BY id ASC",
+        )
         assert len(cancelled) == 2
         assert all(c[1] == "coalesced" for c in cancelled)
 
-        pending = registered_store._conn.execute(
-            "SELECT body FROM notifications WHERE status='pending'"
-        ).fetchall()
+        pending = _peek_all(
+            registered_store,
+            "SELECT body FROM notifications WHERE status='pending'",
+        )
         assert len(pending) == 1
         body = pending[0][0]
         assert "Brief Power Outage" in body

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,8 +1,15 @@
-"""Tests for notification system."""
+"""Tests for the v5.2 DB-backed notification worker.
+
+The worker is persistent: ``send()`` writes a ``pending`` row to a
+registered :class:`StatsStore`'s notifications table, and the worker
+thread drains those rows via Apprise. Tests assert the new contract:
+persistence, exponential backoff, attempt cap, age expiry, backlog cap,
+flush(), and the memory-buffer drain on first ``register_store``.
+"""
 
 import pytest
 import time
-import threading
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from eneru import (
@@ -10,421 +17,557 @@ from eneru import (
     Config,
     NotificationsConfig,
 )
+from eneru.stats import StatsStore
 
 
-# Module-level fixture for notification config
 @pytest.fixture
 def notification_config():
-    """Create a config with notifications enabled."""
+    """Config with notifications enabled. Short retry_interval so the
+    backoff schedule lands inside test budgets."""
     config = Config()
     config.notifications = NotificationsConfig(
         enabled=True,
         urls=["discord://test/token"],
         title="Test UPS",
         timeout=5,
+        retry_interval=1,
     )
     return config
 
 
-class TestNotificationWorker:
-    """Test the notification worker."""
+@pytest.fixture
+def registered_store(tmp_path):
+    """Open a StatsStore for tests that need real persistent delivery."""
+    store = StatsStore(tmp_path / "notifications.db")
+    store.open()
+    yield store
+    store.close()
+
+
+def _patch_apprise(mock_apprise, *, succeed=True,
+                   side_effect=None, service_count=1):
+    """Wire the apprise mock so the worker can construct & call it.
+    Returns the inner Apprise() mock so tests can interrogate notify."""
+    mock_instance = MagicMock()
+    mock_apprise.Apprise.return_value = mock_instance
+    mock_instance.add.return_value = True
+    mock_instance.__len__ = lambda self: service_count
+    if side_effect is not None:
+        mock_instance.notify.side_effect = side_effect
+    else:
+        mock_instance.notify.return_value = bool(succeed)
+    mock_apprise.NotifyType = MagicMock()
+    mock_apprise.NotifyType.INFO = "info"
+    mock_apprise.NotifyType.SUCCESS = "success"
+    mock_apprise.NotifyType.WARNING = "warning"
+    mock_apprise.NotifyType.FAILURE = "failure"
+    return mock_instance
+
+
+def _wait_until(predicate, timeout=2.0, poll=0.02):
+    """Block until predicate() is truthy or the timeout elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll)
+    return False
+
+
+# ==============================================================================
+# Worker lifecycle
+# ==============================================================================
+
+class TestWorkerLifecycle:
 
     @pytest.mark.unit
     def test_worker_not_initialized_when_disabled(self):
-        """Test that worker doesn't start when notifications disabled."""
         config = Config()
         config.notifications.enabled = False
-
         worker = NotificationWorker(config)
-        result = worker.start()
-
-        assert result is False
+        assert worker.start() is False
         assert worker._initialized is False
 
     @pytest.mark.unit
     def test_worker_not_initialized_without_urls(self):
-        """Test that worker doesn't start without URLs."""
         config = Config()
         config.notifications.enabled = True
         config.notifications.urls = []
-
         worker = NotificationWorker(config)
-        result = worker.start()
-
-        assert result is False
+        assert worker.start() is False
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_worker_starts_with_valid_config(self, mock_apprise, notification_config):
-        """Test that worker starts with valid configuration."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-
+    def test_worker_starts_with_valid_config(self, mock_apprise,
+                                             notification_config):
+        _patch_apprise(mock_apprise)
         worker = NotificationWorker(notification_config)
-        result = worker.start()
-
-        assert result is True
-        assert worker._initialized is True
-        assert worker._worker_thread is not None
-        assert worker._worker_thread.daemon is True
-
-        worker.stop()
+        try:
+            assert worker.start() is True
+            assert worker._initialized is True
+            assert worker._worker_thread is not None
+            assert worker._worker_thread.daemon is True
+        finally:
+            worker.stop()
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_send_queues_notification(self, mock_apprise, notification_config):
-        """Test that send() queues notification without blocking."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-
+    def test_stop_terminates_thread(self, mock_apprise, notification_config):
+        _patch_apprise(mock_apprise)
         worker = NotificationWorker(notification_config)
         worker.start()
-
-        start_time = time.time()
-        worker.send("Test message", "info", blocking=False)
-        elapsed = time.time() - start_time
-
-        # Should return almost immediately (non-blocking)
-        assert elapsed < 0.1
-
-        worker.stop()
-
-    @pytest.mark.unit
-    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
-    @patch("eneru.notifications.apprise")
-    def test_send_with_blocking(self, mock_apprise, notification_config):
-        """Test that blocking send waits for completion."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-        mock_instance.notify.return_value = True
-
-        # Need to mock NotifyType as well
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
-        mock_apprise.NotifyType.SUCCESS = "success"
-        mock_apprise.NotifyType.WARNING = "warning"
-        mock_apprise.NotifyType.FAILURE = "failure"
-
-        worker = NotificationWorker(notification_config)
-        worker.start()
-
-        # Give worker time to start
-        time.sleep(0.1)
-
-        worker.send("Test message", "info", blocking=True)
-
-        # Verify notification was processed
-        mock_instance.notify.assert_called()
-
-        worker.stop()
-
-    @pytest.mark.unit
-    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
-    @patch("eneru.notifications.apprise")
-    def test_worker_stop_graceful(self, mock_apprise, notification_config):
-        """Test that worker stops gracefully."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-
-        worker = NotificationWorker(notification_config)
-        worker.start()
-
         assert worker._worker_thread.is_alive()
-
         worker.stop()
-
-        # Thread should be stopped
-        time.sleep(0.1)
-        assert not worker._worker_thread.is_alive()
+        # Stop joins with a 2s budget; the thread should be down well
+        # before that on a non-stuck loop.
+        assert _wait_until(lambda: not worker._worker_thread.is_alive(),
+                           timeout=2.5)
 
     @pytest.mark.unit
-    def test_send_does_nothing_when_not_initialized(self):
-        """Test that send() is a no-op when not initialized."""
+    def test_send_is_noop_when_uninitialized(self):
         config = Config()
         config.notifications.enabled = False
-
         worker = NotificationWorker(config)
-        # Don't call start()
-
-        # Should not raise any errors
-        worker.send("Test message", "info")
+        # No start() — must not raise.
+        assert worker.send("anything", "info", "general") is None
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
     def test_get_service_count(self, mock_apprise, notification_config):
-        """Test getting service count."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 3
-
+        _patch_apprise(mock_apprise, service_count=3)
         worker = NotificationWorker(notification_config)
-        worker.start()
+        try:
+            worker.start()
+            assert worker.get_service_count() == 3
+        finally:
+            worker.stop()
 
-        assert worker.get_service_count() == 3
 
-        worker.stop()
+# ==============================================================================
+# Send + persistence
+# ==============================================================================
 
-
-class TestNotificationRetry:
-    """Test notification retry behavior."""
+class TestSendPersistence:
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_retry_on_failure(self, mock_apprise):
-        """Test that notifications are retried on failure."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
+    def test_send_returns_quickly(self, mock_apprise, notification_config,
+                                  registered_store):
+        _patch_apprise(mock_apprise)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            t0 = time.monotonic()
+            worker.send("Test message", "info", "general")
+            elapsed = time.monotonic() - t0
+            # Send is INSERT + signal — should return well under 100ms
+            # even on slow sqlite.
+            assert elapsed < 0.1
+        finally:
+            worker.stop()
 
-        # Fail twice, then succeed
-        mock_instance.notify.side_effect = [False, False, True]
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_send_persists_pending_row(self, mock_apprise,
+                                       notification_config,
+                                       registered_store):
+        # Worker not started → no delivery, but the row must persist.
+        _patch_apprise(mock_apprise)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            # Stop immediately so the worker can't drain.
+            worker.stop()
+            row_id = worker.send("persisted", "info", "lifecycle")
+            assert row_id is not None
+            row = registered_store._conn.execute(
+                "SELECT body, notify_type, category, status FROM notifications "
+                "WHERE id=?", (row_id,)
+            ).fetchone()
+            assert row == ("persisted", "info", "lifecycle", "pending")
+        finally:
+            worker.stop()
 
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_successful_delivery_marks_sent(self, mock_apprise,
+                                            notification_config,
+                                            registered_store):
+        mock_instance = _patch_apprise(mock_apprise, succeed=True)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("hello", "info", "lifecycle")
+            assert _wait_until(
+                lambda: registered_store.pending_notification_count() == 0
+            )
+            mock_instance.notify.assert_called()
+        finally:
+            worker.stop()
 
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_memory_buffer_flushed_on_first_register(self, mock_apprise,
+                                                    notification_config,
+                                                    registered_store):
+        """Sends made before any store is registered (multi-UPS coordinator
+        startup window) buffer in memory and replay verbatim — including
+        the original ts — once the first store appears."""
+        mock_instance = _patch_apprise(mock_apprise, succeed=True)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            # No register yet → buffered.
+            assert worker.send("buffered-1", "info", "lifecycle") is None
+            assert worker.send("buffered-2", "info", "lifecycle") is None
+            assert registered_store.pending_notification_count() == 0
+            # Register triggers the drain.
+            worker.register_store(registered_store)
+            assert _wait_until(
+                lambda: registered_store.pending_notification_count() == 0
+                        and mock_instance.notify.call_count >= 2
+            )
+            bodies = [c.kwargs.get("body") for c
+                      in mock_instance.notify.call_args_list]
+            assert "buffered-1" in bodies and "buffered-2" in bodies
+        finally:
+            worker.stop()
+
+
+# ==============================================================================
+# Retry / backoff / max_attempts
+# ==============================================================================
+
+class TestRetryAndBackoff:
+
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_failure_increments_attempts_keeps_pending(
+        self, mock_apprise, notification_config, registered_store,
+    ):
+        # All deliveries fail.
+        _patch_apprise(mock_apprise, succeed=False)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("retry-me", "info", "lifecycle")
+            # Wait long enough for at least one attempt.
+            assert _wait_until(
+                lambda: registered_store._conn.execute(
+                    "SELECT attempts FROM notifications "
+                    "WHERE body='retry-me'"
+                ).fetchone()[0] >= 1
+            )
+            row = registered_store._conn.execute(
+                "SELECT status, attempts FROM notifications "
+                "WHERE body='retry-me'"
+            ).fetchone()
+            assert row[0] == "pending"
+            assert row[1] >= 1
+        finally:
+            worker.stop()
+
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_max_attempts_cancels_with_reason(self, mock_apprise,
+                                              registered_store):
+        """When the per-message cap is set, a poison message hits its
+        limit and the row gets cancel_reason='max_attempts'."""
+        _patch_apprise(mock_apprise, succeed=False)
         config = Config()
         config.notifications = NotificationsConfig(
             enabled=True,
-            urls=["discord://test/token"],
-            title="Test",
+            urls=["discord://x"],
+            title="t",
             timeout=5,
-            retry_interval=0.1,  # Short interval for testing
+            retry_interval=0,        # no backoff wait
+            retry_backoff_max=0,
+            max_attempts=3,
         )
+        worker = NotificationWorker(config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("poison", "info", "lifecycle")
+            assert _wait_until(
+                lambda: registered_store._conn.execute(
+                    "SELECT status FROM notifications WHERE body='poison'"
+                ).fetchone()[0] == "cancelled"
+            )
+            row = registered_store._conn.execute(
+                "SELECT status, attempts, cancel_reason "
+                "FROM notifications WHERE body='poison'"
+            ).fetchone()
+            assert row[0] == "cancelled"
+            assert row[1] == 3
+            assert row[2] == "max_attempts"
+        finally:
+            worker.stop()
 
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_max_attempts_zero_means_unlimited(self, mock_apprise,
+                                               registered_store):
+        """Default max_attempts=0 must NOT cancel the row no matter how
+        many failures pile up. This is the panic-attack guarantee:
+        Apprise's bool can't tell network down from bad URL."""
+        _patch_apprise(mock_apprise, succeed=False)
+        config = Config()
+        config.notifications = NotificationsConfig(
+            enabled=True,
+            urls=["discord://x"],
+            title="t",
+            timeout=5,
+            retry_interval=0,
+            retry_backoff_max=0,
+            max_attempts=0,
+        )
+        worker = NotificationWorker(config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("forever", "info", "lifecycle")
+            assert _wait_until(
+                lambda: registered_store._conn.execute(
+                    "SELECT attempts FROM notifications "
+                    "WHERE body='forever'"
+                ).fetchone()[0] >= 5
+            )
+            row = registered_store._conn.execute(
+                "SELECT status, cancel_reason FROM notifications "
+                "WHERE body='forever'"
+            ).fetchone()
+            assert row[0] == "pending"
+            assert row[1] is None
+        finally:
+            worker.stop()
+
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_recovery_after_failures_marks_sent(self, mock_apprise,
+                                                registered_store):
+        """First N attempts fail, then succeed — the row should
+        eventually be marked sent and removed from pending."""
+        # Fail 3 times then succeed.
+        _patch_apprise(
+            mock_apprise,
+            side_effect=[False, False, False, True],
+        )
+        config = Config()
+        config.notifications = NotificationsConfig(
+            enabled=True,
+            urls=["discord://x"],
+            title="t",
+            timeout=5,
+            retry_interval=0,
+            retry_backoff_max=0,
+            max_attempts=0,
+        )
+        worker = NotificationWorker(config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("eventually", "info", "lifecycle")
+            assert _wait_until(
+                lambda: registered_store.pending_notification_count() == 0
+            )
+            row = registered_store._conn.execute(
+                "SELECT status, attempts FROM notifications "
+                "WHERE body='eventually'"
+            ).fetchone()
+            assert row[0] == "sent"
+            assert row[1] >= 3
+
+        finally:
+            worker.stop()
+
+    @pytest.mark.unit
+    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
+    @patch("eneru.notifications.apprise")
+    def test_stop_returns_quickly_with_pending_failures(self, mock_apprise,
+                                                       registered_store):
+        """stop() must return promptly (under ~3s join budget) even
+        with pending rows that keep failing — the rows persist for the
+        next process start."""
+        _patch_apprise(mock_apprise, succeed=False)
+        config = Config()
+        config.notifications = NotificationsConfig(
+            enabled=True,
+            urls=["discord://x"],
+            title="t",
+            timeout=5,
+            retry_interval=10,  # would block forever in v5.1
+            retry_backoff_max=300,
+        )
         worker = NotificationWorker(config)
         worker.start()
+        worker.register_store(registered_store)
+        worker.send("stays-pending", "info", "lifecycle")
         time.sleep(0.1)
-
-        worker.send("Test message", "info", blocking=True)
-
-        # Should have been called 3 times (2 failures + 1 success)
-        assert mock_instance.notify.call_count == 3
-
+        t0 = time.monotonic()
         worker.stop()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 3.0
+        # Row stayed pending for the next start.
+        row = registered_store._conn.execute(
+            "SELECT status FROM notifications WHERE body='stays-pending'"
+        ).fetchone()
+        assert row[0] == "pending"
+
+
+# ==============================================================================
+# Ordering across stores + flush()
+# ==============================================================================
+
+class TestOrderingAndFlush:
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_retry_count_tracked(self, mock_apprise):
-        """Test that retry count is tracked during retries."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-
-        # Keep failing
-        mock_instance.notify.return_value = False
-
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
-
-        config = Config()
-        config.notifications = NotificationsConfig(
-            enabled=True,
-            urls=["discord://test/token"],
-            title="Test",
-            timeout=5,
-            retry_interval=0.1,
-        )
-
-        worker = NotificationWorker(config)
-        worker.start()
-        time.sleep(0.05)
-
-        worker.send("Test message", "info", blocking=False)
-
-        # Wait for some retries
-        time.sleep(0.35)
-
-        # Should have non-zero retry count
-        assert worker.get_retry_count() > 0
-
-        worker.stop()
+    def test_oldest_pending_delivered_first(self, mock_apprise,
+                                            notification_config,
+                                            registered_store):
+        mock_instance = _patch_apprise(mock_apprise, succeed=True)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            for body in ("first", "second", "third"):
+                worker.send(body, "info", "lifecycle")
+            assert _wait_until(
+                lambda: registered_store.pending_notification_count() == 0
+                        and mock_instance.notify.call_count >= 3,
+            )
+            bodies = [c.kwargs.get("body")
+                      for c in mock_instance.notify.call_args_list]
+            assert bodies[:3] == ["first", "second", "third"]
+        finally:
+            worker.stop()
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_retry_respects_stop_signal(self, mock_apprise):
-        """Test that retry loop exits when stop is requested."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-        mock_instance.notify.return_value = False  # Always fail
-
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
-
-        config = Config()
-        config.notifications = NotificationsConfig(
-            enabled=True,
-            urls=["discord://test/token"],
-            title="Test",
-            timeout=5,
-            retry_interval=0.5,
-        )
-
-        worker = NotificationWorker(config)
-        worker.start()
-        time.sleep(0.05)
-
-        worker.send("Test message", "info", blocking=False)
-
-        # Wait a bit then stop
-        time.sleep(0.1)
-        start_time = time.time()
-        worker.stop()
-        elapsed = time.time() - start_time
-
-        # Stop should be quick (not waiting for retry interval)
-        assert elapsed < 0.5
+    def test_flush_returns_true_when_drained(self, mock_apprise,
+                                             notification_config,
+                                             registered_store):
+        _patch_apprise(mock_apprise, succeed=True)
+        worker = NotificationWorker(notification_config)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("a", "info", "lifecycle")
+            worker.send("b", "info", "lifecycle")
+            assert worker.flush(timeout=2.0) is True
+            assert registered_store.pending_notification_count() == 0
+        finally:
+            worker.stop()
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_queue_size_tracked(self, mock_apprise):
-        """Test that queue size is tracked."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-        mock_instance.notify.return_value = False  # Always fail to block processing
-
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
-
+    def test_flush_returns_false_on_timeout_with_failures(
+        self, mock_apprise, registered_store,
+    ):
+        _patch_apprise(mock_apprise, succeed=False)
         config = Config()
         config.notifications = NotificationsConfig(
-            enabled=True,
-            urls=["discord://test/token"],
-            title="Test",
-            timeout=5,
-            retry_interval=10,  # Long interval so messages queue up
+            enabled=True, urls=["discord://x"], title="t", timeout=5,
+            retry_interval=10, retry_backoff_max=300,
+            max_attempts=0,
         )
-
         worker = NotificationWorker(config)
-        worker.start()
-        time.sleep(0.05)
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            worker.send("undeliverable", "info", "lifecycle")
+            t0 = time.monotonic()
+            ok = worker.flush(timeout=0.3)
+            elapsed = time.monotonic() - t0
+            assert ok is False
+            # flush honours the timeout (with small slack for poll grain).
+            assert elapsed < 0.6
+            assert registered_store.pending_notification_count() == 1
+        finally:
+            worker.stop()
 
-        # Queue several messages
-        for i in range(3):
-            worker.send(f"Message {i}", "info", blocking=False)
 
-        time.sleep(0.1)
+# ==============================================================================
+# Backlog cap (max_pending)
+# ==============================================================================
 
-        # Should have messages in queue (one being processed, rest waiting)
-        # The first one is being retried, so 2 should be in queue
-        assert worker.get_queue_size() >= 2
-
-        worker.stop()
+class TestBacklogCap:
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)
     @patch("eneru.notifications.apprise")
-    def test_fifo_order_preserved(self, mock_apprise):
-        """Test that notifications are processed in FIFO order."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-        mock_instance.notify.return_value = True
-
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
-
+    def test_send_enforces_max_pending_cancelling_oldest(
+        self, mock_apprise, registered_store,
+    ):
+        """When pending exceeds max_pending, the OLDEST get cancelled
+        with reason 'backlog_overflow'. Newest survive."""
+        _patch_apprise(mock_apprise, succeed=False)  # all stay pending
         config = Config()
         config.notifications = NotificationsConfig(
-            enabled=True,
-            urls=["discord://test/token"],
-            title="Test",
-            timeout=5,
-            retry_interval=0.1,
+            enabled=True, urls=["discord://x"], title="t", timeout=5,
+            retry_interval=10,  # never actually retries within test
+            retry_backoff_max=300,
+            max_pending=2,
+            max_attempts=0,
         )
-
         worker = NotificationWorker(config)
-        worker.start()
-        time.sleep(0.05)
-
-        messages = ["First", "Second", "Third"]
-        for msg in messages:
-            worker.send(msg, "info", blocking=False)
-
-        # Wait for all to be processed
-        time.sleep(0.5)
-
-        # Check that messages were sent in order
-        calls = mock_instance.notify.call_args_list
-        bodies = [call[1]['body'] for call in calls]
-
-        assert bodies == messages
-
-        worker.stop()
-
-    @pytest.mark.unit
-    def test_retry_interval_config_default(self):
-        """Test that retry_interval has correct default."""
-        config = NotificationsConfig()
-        assert config.retry_interval == 5
-
-    @pytest.mark.unit
-    def test_retry_interval_config_custom(self):
-        """Test that retry_interval can be configured."""
-        config = NotificationsConfig(retry_interval=10)
-        assert config.retry_interval == 10
+        try:
+            worker.start()
+            worker.register_store(registered_store)
+            for i in range(5):
+                worker.send(f"msg-{i}", "info", "lifecycle")
+            # Cap kicks in synchronously inside send().
+            assert registered_store.pending_notification_count() <= 2
+            cancelled = registered_store._conn.execute(
+                "SELECT body, cancel_reason FROM notifications "
+                "WHERE status='cancelled' ORDER BY id ASC"
+            ).fetchall()
+            cancel_bodies = [c[0] for c in cancelled]
+            cancel_reasons = {c[1] for c in cancelled}
+            # Older messages cancelled, newest kept.
+            assert "msg-0" in cancel_bodies
+            assert "backlog_overflow" in cancel_reasons
+        finally:
+            worker.stop()
 
 
-class TestNotificationTypes:
-    """Test notification type mapping."""
+# ==============================================================================
+# Config defaults (regression-style)
+# ==============================================================================
+
+class TestConfigDefaults:
 
     @pytest.mark.unit
-    @patch("eneru.notifications.APPRISE_AVAILABLE", True)
-    @patch("eneru.notifications.apprise")
-    def test_notify_type_mapping(self, mock_apprise):
-        """Test that notify types are correctly mapped."""
-        mock_instance = MagicMock()
-        mock_apprise.Apprise.return_value = mock_instance
-        mock_instance.add.return_value = True
-        mock_instance.__len__ = lambda self: 1
-        mock_instance.notify.return_value = True
+    def test_retry_interval_default(self):
+        assert NotificationsConfig().retry_interval == 5
 
-        mock_apprise.NotifyType = MagicMock()
-        mock_apprise.NotifyType.INFO = "info"
-        mock_apprise.NotifyType.SUCCESS = "success"
-        mock_apprise.NotifyType.WARNING = "warning"
-        mock_apprise.NotifyType.FAILURE = "failure"
-
-        # Create config inline instead of using fixture
-        config = Config()
-        config.notifications = NotificationsConfig(
-            enabled=True,
-            urls=["discord://test/token"],
-            title="Test",
-            timeout=5,
-        )
-
-        worker = NotificationWorker(config)
-        worker.start()
-        time.sleep(0.1)
-
-        # Test each type
-        for notify_type in ["info", "success", "warning", "failure"]:
-            worker.send(f"Test {notify_type}", notify_type, blocking=True)
-
-        worker.stop()
-
-        # Verify notify was called for each type
-        assert mock_instance.notify.call_count >= 4
+    @pytest.mark.unit
+    def test_v52_outage_survival_defaults(self):
+        """The defaults must survive a multi-day weekend outage. See
+        the analysis in the v5.2.0 plan: max_attempts=0 (unlimited),
+        max_age_days=30, max_pending=10000, retry_backoff_max=300."""
+        c = NotificationsConfig()
+        assert c.retention_days == 7
+        assert c.max_attempts == 0
+        assert c.max_age_days == 30
+        assert c.max_pending == 10000
+        assert c.retry_backoff_max == 300

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -530,24 +530,28 @@ class TestBacklogCap:
             max_attempts=0,
         )
         worker = NotificationWorker(config)
-        try:
-            worker.start()
-            worker.register_store(registered_store)
-            for i in range(5):
-                worker.send(f"msg-{i}", "info", "lifecycle")
-            # Cap kicks in synchronously inside send().
-            assert registered_store.pending_notification_count() <= 2
-            cancelled = registered_store._conn.execute(
-                "SELECT body, cancel_reason FROM notifications "
-                "WHERE status='cancelled' ORDER BY id ASC"
-            ).fetchall()
-            cancel_bodies = [c[0] for c in cancelled]
-            cancel_reasons = {c[1] for c in cancelled}
-            # Older messages cancelled, newest kept.
-            assert "msg-0" in cancel_bodies
-            assert "backlog_overflow" in cancel_reasons
-        finally:
-            worker.stop()
+        worker.start()
+        worker.register_store(registered_store)
+        # Stop the worker thread BEFORE issuing the sends — otherwise the
+        # worker thread races send()'s cap_pending UPDATE on the same
+        # SQLite connection and Python 3.13 raises SystemError. send()
+        # remains usable after stop() (it still INSERTs pending rows and
+        # cap_pending runs synchronously inside send()) — there's just
+        # no thread reading them. That's exactly what this test wants.
+        worker.stop()
+        for i in range(5):
+            worker.send(f"msg-{i}", "info", "lifecycle")
+        # Cap kicks in synchronously inside send().
+        assert registered_store.pending_notification_count() <= 2
+        cancelled = registered_store._conn.execute(
+            "SELECT body, cancel_reason FROM notifications "
+            "WHERE status='cancelled' ORDER BY id ASC"
+        ).fetchall()
+        cancel_bodies = [c[0] for c in cancelled]
+        cancel_reasons = {c[1] for c in cancelled}
+        # Older messages cancelled, newest kept.
+        assert "msg-0" in cancel_bodies
+        assert "backlog_overflow" in cancel_reasons
 
 
 # ==============================================================================

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -364,6 +364,372 @@ class TestSchemaMigration:
         finally:
             s.close()
 
+    @staticmethod
+    def _build_v3_db(path: Path) -> None:
+        """Synthesize a v3-shaped DB (v5.1.x) — no notifications table."""
+        c = sqlite3.connect(str(path), isolation_level=None)
+        c.execute("PRAGMA journal_mode = WAL")
+        c.execute(
+            "CREATE TABLE samples (ts INTEGER NOT NULL, status TEXT, "
+            "battery_charge REAL, battery_runtime REAL, ups_load REAL, "
+            "input_voltage REAL, output_voltage REAL, depletion_rate REAL, "
+            "time_on_battery INTEGER, connection_state TEXT, "
+            "battery_voltage REAL, ups_temperature REAL, "
+            "input_frequency REAL, output_frequency REAL)"
+        )
+        for table in ("agg_5min", "agg_hourly"):
+            c.execute(
+                f"CREATE TABLE {table} (ts INTEGER PRIMARY KEY, "
+                "battery_charge_avg REAL, samples_count INTEGER)"
+            )
+        c.execute(
+            "CREATE TABLE events (ts INTEGER NOT NULL, "
+            "event_type TEXT NOT NULL, detail TEXT, "
+            "notification_sent INTEGER DEFAULT 1)"
+        )
+        c.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        c.execute(
+            "INSERT INTO meta(key,value) VALUES (?, ?)",
+            ("schema_version", "3"),
+        )
+        # Seed an event row to prove preservation across migration.
+        c.execute(
+            "INSERT INTO events(ts, event_type, detail) "
+            "VALUES (?, ?, ?)", (2000, "ON_BATTERY", "v3 row"),
+        )
+        c.close()
+
+    @pytest.mark.unit
+    def test_v3_db_migrates_to_v4_creates_notifications_table(self, tmp_path):
+        # v4: new notifications table for the persistent queue.
+        path = tmp_path / "v3.db"
+        self._build_v3_db(path)
+        s = StatsStore(path)
+        s.open()
+        try:
+            tables = {
+                r[0] for r in s._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            assert "notifications" in tables
+            cols = {
+                r[1] for r in s._conn.execute(
+                    "PRAGMA table_info(notifications)"
+                )
+            }
+            assert {"id", "ts", "body", "notify_type", "category",
+                    "status", "attempts", "sent_at", "cancel_reason"} <= cols
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_v3_to_v4_migration_bumps_meta_to_4(self, tmp_path):
+        path = tmp_path / "v3.db"
+        self._build_v3_db(path)
+        s = StatsStore(path)
+        s.open()
+        try:
+            sv = s._conn.execute(
+                "SELECT value FROM meta WHERE key='schema_version'"
+            ).fetchone()
+            assert int(sv[0]) == SCHEMA_VERSION  # currently 4
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_v3_events_preserved_after_v4_migration(self, tmp_path):
+        path = tmp_path / "v3.db"
+        self._build_v3_db(path)
+        s = StatsStore(path)
+        s.open()
+        try:
+            row = s._conn.execute(
+                "SELECT ts, event_type, detail FROM events"
+            ).fetchone()
+            assert row == (2000, "ON_BATTERY", "v3 row")
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_v4_migration_idempotent(self, tmp_path):
+        path = tmp_path / "v3.db"
+        self._build_v3_db(path)
+        # Open + close + reopen + reopen must all succeed; a partially-
+        # migrated DB heals via CREATE TABLE IF NOT EXISTS.
+        StatsStore(path).open()
+        StatsStore(path).open()
+        s = StatsStore(path)
+        s.open()
+        try:
+            tables = {
+                r[0] for r in s._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            assert "notifications" in tables
+        finally:
+            s.close()
+
+
+class TestNotificationQueue:
+    """v4: persistent notification queue CRUD + TTL/cap/age rules."""
+
+    def _open(self, tmp_path):
+        s = StatsStore(tmp_path / "n.db")
+        s.open()
+        return s
+
+    @pytest.mark.unit
+    def test_enqueue_returns_monotonic_id(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            id1 = s.enqueue_notification("first", "info", "lifecycle")
+            id2 = s.enqueue_notification("second", "info", "lifecycle")
+            assert id1 is not None and id2 is not None
+            assert id2 > id1
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_next_pending_returns_oldest_first(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            s.enqueue_notification("older", "info", "lifecycle", ts=1000)
+            s.enqueue_notification("newer", "info", "lifecycle", ts=2000)
+            rows = s.next_pending_notifications(limit=10)
+            assert [r[0] for r in rows] == [1000, 2000]
+            assert rows[0][2] == "older"
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_mark_sent_removes_row_from_pending(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            id1 = s.enqueue_notification("x", "info", "lifecycle")
+            s.mark_notification_sent(id1, sent_at=12345)
+            assert s.pending_notification_count() == 0
+            row = s._conn.execute(
+                "SELECT status, sent_at FROM notifications WHERE id=?",
+                (id1,),
+            ).fetchone()
+            assert row == ("sent", 12345)
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_mark_attempt_keeps_row_pending_and_counts(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            id1 = s.enqueue_notification("x", "info", "lifecycle")
+            s.mark_notification_attempt(id1)
+            s.mark_notification_attempt(id1)
+            row = s._conn.execute(
+                "SELECT status, attempts FROM notifications WHERE id=?",
+                (id1,),
+            ).fetchone()
+            assert row == ("pending", 2)
+            assert s.pending_notification_count() == 1
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_cancel_marks_with_reason(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            id1 = s.enqueue_notification("x", "info", "lifecycle")
+            s.cancel_notification(id1, "max_attempts")
+            row = s._conn.execute(
+                "SELECT status, cancel_reason FROM notifications WHERE id=?",
+                (id1,),
+            ).fetchone()
+            assert row == ("cancelled", "max_attempts")
+            assert s.pending_notification_count() == 0
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_pending_count_excludes_sent_and_cancelled(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            id1 = s.enqueue_notification("a", "info", "x")
+            id2 = s.enqueue_notification("b", "info", "x")
+            s.enqueue_notification("c", "info", "x")  # stays pending
+            s.mark_notification_sent(id1)
+            s.cancel_notification(id2, "too_old")
+            assert s.pending_notification_count() == 1
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_cap_pending_cancels_oldest_excess(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            for i in range(5):
+                s.enqueue_notification(f"m{i}", "info", "x", ts=1000 + i)
+            cancelled = s.cap_pending_notifications(max_pending=2)
+            assert cancelled == 3
+            assert s.pending_notification_count() == 2
+            # The remaining pending rows must be the two NEWEST.
+            rows = s.next_pending_notifications(limit=10)
+            assert [r[2] for r in rows] == ["m3", "m4"]
+            # Cancelled rows carry the overflow reason.
+            cur = s._conn.execute(
+                "SELECT body, cancel_reason FROM notifications "
+                "WHERE status='cancelled' ORDER BY ts ASC"
+            )
+            cancelled_rows = cur.fetchall()
+            assert [r[0] for r in cancelled_rows] == ["m0", "m1", "m2"]
+            assert all(r[1] == "backlog_overflow" for r in cancelled_rows)
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_cap_pending_zero_or_negative_disables_cap(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            for i in range(5):
+                s.enqueue_notification(f"m{i}", "info", "x")
+            assert s.cap_pending_notifications(max_pending=0) == 0
+            assert s.cap_pending_notifications(max_pending=-1) == 0
+            assert s.pending_notification_count() == 5
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_prune_deletes_sent_older_than_retention(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            now = int(time.time())
+            old = s.enqueue_notification("old", "info", "x",
+                                         ts=now - 10 * 86400)
+            recent = s.enqueue_notification("recent", "info", "x",
+                                            ts=now - 1 * 86400)
+            s.mark_notification_sent(old, sent_at=now - 10 * 86400)
+            s.mark_notification_sent(recent, sent_at=now - 1 * 86400)
+            deleted, expired = s.prune_old_notifications(
+                retention_days=7, max_age_days=0,
+            )
+            assert deleted == 1
+            assert expired == 0
+            ids = {r[0] for r in s._conn.execute(
+                "SELECT id FROM notifications"
+            )}
+            assert ids == {recent}
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_prune_keeps_pending_within_max_age(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            now = int(time.time())
+            id1 = s.enqueue_notification("recent", "info", "x",
+                                         ts=now - 5 * 86400)
+            deleted, expired = s.prune_old_notifications(
+                retention_days=7, max_age_days=30,
+            )
+            assert deleted == 0
+            assert expired == 0
+            assert s.pending_notification_count() == 1
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_prune_cancels_pending_beyond_max_age(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            now = int(time.time())
+            ancient = s.enqueue_notification("ancient", "info", "x",
+                                             ts=now - 60 * 86400)
+            recent = s.enqueue_notification("recent", "info", "x",
+                                            ts=now - 5 * 86400)
+            deleted, expired = s.prune_old_notifications(
+                retention_days=7, max_age_days=30,
+            )
+            assert deleted == 0
+            assert expired == 1
+            row = s._conn.execute(
+                "SELECT status, cancel_reason FROM notifications "
+                "WHERE id=?", (ancient,),
+            ).fetchone()
+            assert row == ("cancelled", "too_old")
+            # Recent pending row untouched.
+            row2 = s._conn.execute(
+                "SELECT status FROM notifications WHERE id=?",
+                (recent,),
+            ).fetchone()
+            assert row2 == ("pending",)
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_prune_max_age_zero_means_pending_lives_forever(self, tmp_path):
+        """The panic-attack guarantee — pending rows never get dropped
+        by TTL when max_age_days <= 0. Only successful delivery (or an
+        explicit cancel) removes them."""
+        s = self._open(tmp_path)
+        try:
+            now = int(time.time())
+            s.enqueue_notification("ancient", "info", "x",
+                                   ts=now - 365 * 86400)
+            deleted, expired = s.prune_old_notifications(
+                retention_days=7, max_age_days=0,
+            )
+            assert (deleted, expired) == (0, 0)
+            assert s.pending_notification_count() == 1
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_find_pending_by_category_filters(self, tmp_path):
+        s = self._open(tmp_path)
+        try:
+            s.enqueue_notification("ob", "info", "power_event", ts=1000)
+            s.enqueue_notification("ol", "info", "power_event", ts=1100)
+            s.enqueue_notification("up", "info", "lifecycle", ts=1050)
+            rows = s.find_pending_by_category("power_event")
+            assert [r[2] for r in rows] == ["ob", "ol"]
+            rows = s.find_pending_by_category("power_event", since_ts=1050)
+            assert [r[2] for r in rows] == ["ol"]
+        finally:
+            s.close()
+
+
+class TestMetaKV:
+    """Generic meta key/value store helpers (for last_seen_version etc)."""
+
+    @pytest.mark.unit
+    def test_get_meta_missing_key_returns_none(self, tmp_path):
+        s = StatsStore(tmp_path / "m.db")
+        s.open()
+        try:
+            assert s.get_meta("nonexistent") is None
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_set_get_meta_round_trip(self, tmp_path):
+        s = StatsStore(tmp_path / "m.db")
+        s.open()
+        try:
+            s.set_meta("last_seen_version", "5.1.2")
+            assert s.get_meta("last_seen_version") == "5.1.2"
+        finally:
+            s.close()
+
+    @pytest.mark.unit
+    def test_set_meta_overwrites_existing_value(self, tmp_path):
+        s = StatsStore(tmp_path / "m.db")
+        s.open()
+        try:
+            s.set_meta("last_seen_version", "5.1.2")
+            s.set_meta("last_seen_version", "5.2.0")
+            assert s.get_meta("last_seen_version") == "5.2.0"
+        finally:
+            s.close()
+
 
 class TestLogEventNotificationSent:
     """B4: log_event records the notification_sent flag (v3+)."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1126,6 +1126,38 @@ class TestQueryEventsForDisplay:
         # Most recent 3 events.
         assert len(lines) == 3
 
+    @pytest.mark.unit
+    def test_event_line_includes_full_date(self, tmp_path):
+        """Rows must include YYYY-MM-DD prefix so multi-day events are
+        distinguishable in the TUI events panel (regression: TODO #1)."""
+        from datetime import datetime
+        from eneru.tui import query_events_for_display
+        config = _events_config(tmp_path)
+        # Pin a timestamp; assert the rendered prefix matches local-time
+        # YYYY-MM-DD HH:MM:SS for the same instant.
+        ts = 1_700_000_000  # 2023-11-14 22:13:20 UTC, varies by local tz
+        expected_prefix = datetime.fromtimestamp(ts).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        _seed_events(config, config.ups_groups[0],
+                     [(ts, "ON_BATTERY", "Battery: 90%")])
+        lines = query_events_for_display(config)
+        assert len(lines) == 1
+        assert lines[0].startswith(expected_prefix), (
+            f"expected line to start with {expected_prefix!r}, got {lines[0]!r}"
+        )
+
+    @pytest.mark.unit
+    def test_event_line_uses_placeholder_for_bad_timestamp(self, tmp_path):
+        """Malformed timestamps render as a same-width placeholder so the
+        column alignment in the events panel doesn't shift."""
+        from eneru.tui import _format_event_line
+        line = _format_event_line(
+            ts="not-a-number", label="UPS@h", event_type="X",
+            detail="", multi_ups=False,
+        )
+        assert line.startswith("????-??-?? ??:??:??")
+
 
 class TestRunOnceEventsOnly:
 

--- a/tests/test_voltage.py
+++ b/tests/test_voltage.py
@@ -86,7 +86,10 @@ class _TestHost(VoltageMonitorMixin):
     def _log_power_event(self, event, details, *, suppress_notification=False):
         self.power_events.append((event, details, suppress_notification))
 
-    def _send_notification(self, body, notify_type="info", blocking=False):
+    def _send_notification(self, body, notify_type="info", blocking=False,
+                           category="general"):
+        # category is a v5.2 addition (Slice 4 coalescer hook); the
+        # voltage tests don't assert on it, but the stub must accept it.
         self.notifications.append((body, notify_type))
 
 


### PR DESCRIPTION
## Summary

Architectural rework of the notification subsystem for v5.2.0. Today's
notifications are stateless and noisy: a `systemctl restart` produces
two unrelated events, a shutdown sequence produces ~22 mid-flight
detail lines, and a power outage that takes the internet down means no
notifications ever get delivered.

This PR fixes that across 7 slices.

**Done:**
- ✅ Slice 6 — TUI date fix (events panel renders full `YYYY-MM-DD HH:MM:SS`)
- ✅ Slice 1 — Notification policy cleanup: drop the per-`_log_message`
  auto-mirror that produced the 22-line shutdown wall, gate `wall(1)`
  behind `local_shutdown.wall` (default off, opt-in), drop the
  redundant per-server "Sent" notification, fire the "Sequence
  Complete" summary in both the local-shutdown-enabled and -disabled
  paths, and sweep the v2-era `========== BANNER ==========` formatting
  across `monitor.py` and `redundancy.py`.

**Pending in this PR (will push as separate commits):**
- ⏳ Slice 2 — DB-backed notification queue (schema v3→v4, worker
  rewrite, TTL pruning, `flush()` helper)
- ⏳ Slice 5 — Drain on shutdown integration (`flush(timeout=5)` from
  both shutdown paths to close the SIGTERM race)
- ⏳ Slice 3 — Stateful lifecycle (Started / Stopped / Restarted /
  Upgraded — marker file + version compare)
- ⏳ Slice 4 — Power-event coalescing (the panic-attack scenario: short
  outage with no internet → single coalesced "Brief outage" notification
  delivered once the endpoint comes back)
- ⏳ Slice 7 — Changelog comparison table catch-up (5.1.0 / 5.1.1 /
  5.1.2 / 5.2.0 rows)

Plan: `/root/.claude/plans/last-night-we-shipped-wise-pancake.md` (local
to the working session, not in repo).

## Test plan

- [x] Slice 6: `pytest tests/test_tui.py` — 70 passing, +2 new
- [x] Slice 1: `pytest tests/test_monitor_core.py` — 4 new tests in
      `TestNotificationPolicyV52` (auto-mirror gone, wall opt-in
      default, wall opt-in fires when enabled, summary fires in disabled
      path)
- [x] Full suite locally: 819 passing
- [ ] CI: validate matrix (Python 3.9–3.14) + 5 E2E jobs
- [ ] One new E2E step (Slice 4): panic-attack scenario — block network
      → trigger on-battery/on-line cycle → unblock → assert single
      coalesced "Brief outage" notification arrives
- [ ] Manual verification before tagging:
  - Restart: `systemctl restart eneru` → ONE `🔄 Restarted` notification
  - Upgrade: install vN → install vN+1 .deb → ONE `📦 Upgraded vN→vN+1`
  - Shutdown noise: dry-run shutdown → 2 notifications (headline +
    summary), not 22
  - Wall opt-in: default off → no `wall` broadcast; flip to true →
    broadcast restored
  - Lossless: kill -9 mid-send → restart → pending notification gets
    delivered
  - TTL pruning: insert old `sent` rows → start Eneru → pruned;
    `pending` rows untouched

## Notes

- Drafted: I'll mark ready-for-review once all slices are in and CI is
  green.
- Pre-push code review (`agent-skills:code-reviewer` subagent) before
  un-drafting, then `@coderabbitai full review` + `@cubic-dev-ai review
  this pull request` per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stateful, lossless notifications for v5.2 with a DB‑backed queue and a startup lifecycle classifier. Hardened coalescing, marker handling, and SQLite concurrency; drains pre‑store buffers during shutdown for safer delivery under outages and restarts.

- **New Features**
  - Persistent queue + worker: survives restarts/outages; oldest‑first across stores; exponential backoff; caps via `max_attempts` (0=unlimited), `max_age_days`, `max_pending`; TTL (`retention_days`) prunes `sent`/`cancelled`; pre‑store memory buffer is capped and drains on first register; `flush(timeout)` wired into all shutdown paths.
  - Lifecycle classification: emits one of Upgraded/Recovered/Restarted/Started (incl. “after crash”) using on‑disk markers and `meta.last_seen_version`; package postinstall writes the upgrade marker; coordinator sends one lifecycle notification and now reads `last_seen_version` from the first group; superseded lifecycle rows are cancelled.
  - Coalescing: pending `power_event_on_battery` + `power_event_on_line` fold into one “Brief Power Outage” summary; originals cancelled as `coalesced`. On “Recovered” startup, folds the previous shutdown headline/summary into a single richer recovery message.
  - Notification policy + TUI: one shutdown headline and one “Shutdown Sequence Complete” (with elapsed time); per‑server “Remote Shutdown Sent” removed; `wall(1)` behind `local_shutdown.wall` (default false); kept ALL CAPS markers; events show `YYYY‑MM‑DD HH:MM:SS`.
  - Docs: added v5.2.0 changelog and v5.2↔v5.1 comparison tables.

- **Bug Fixes**
  - Brief‑outage coalescer: pairs by category (not body); handles same‑timestamp pairs; runs every loop to catch on‑line arrivals during network timeouts; cancels originals only after the summary persists; summary uses the generic `power_event` category.
  - Lifecycle robustness: coordinator writes markers for both signal and sequence‑complete paths and deletes markers even when notifications are disabled; startup tolerates malformed markers; never downgrades an existing `sequence_complete` to `signal`; pip‑path upgrades detected via the first group’s `last_seen_version`.
  - SQLite reliability and fairness: `StatsStore` now wraps all DB access in a single lock to avoid Python 3.13 races; head‑of‑line starvation fixed by scanning more due rows per store; backlog cap applied after draining the pre‑store buffer.
  - Queue handling: `flush()` also drains the pre‑store buffer; `register_store()` drains safely (snapshot + re‑buffer on failure); backoff keyed by store path.
  - Packaging/config: postinstall resolves the upgrade marker via the configured stats DB directory; persistent‑queue knobs are coerced to ints to survive bad YAML.
  - CI/E2E: restored `E2E_NOTIFICATION_URL` injection in matrix runs to re‑enable the delivery test.

<sup>Written for commit 78429fa38b7c5b735c8a0a553a758343e99c1dc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 5.2.0

* **New Features**
  * Notifications now persist across restarts with automatic retries and configurable expiration controls
  * Shutdown events display detailed status: Upgraded, Recovered, Restarted (replacing generic messages)
  * Brief power outages are consolidated into single summary notifications
  * TUI event log displays full date-time stamps instead of time only
  * Configurable notification retention, maximum retry attempts, and backoff timing

* **Configuration**
  * New notification queue settings for retention period, retry limits, and backlog limits
  * Broadcast-to-terminals feature now opt-in (disabled by default)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->