### PR TITLE
🐞 fix(notifications): single lifecycle notification per restart/upgrade + real RPM old version (v5.2.1)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,62 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.2.1] - 2026-04-24
 
-Bug-fix release for two regressions reported within an hour of v5.2.0
-shipping. RPM users reinstalling or upgrading saw two notifications
-(`🛑 Service Stopped` + `📦 Upgraded vunknown → v5.2.0`) where v5.2's
-design called for a single `📦 Upgraded vX → vY` message. The `vunknown`
-came from RPM not passing the previous version to postinstall; the
-duplicate fired because the synchronous `flush(timeout=5)` shipped the
-stop notification before the new daemon could supersede it. The same
-race produced two messages on every plain `systemctl restart` too. Drop-in
-upgrade. See `git log v5.2.0..v5.2.1` for per-commit detail.
+Bug-fix release for two v5.2.0 regressions. Drop-in upgrade. See
+`git log v5.2.0..v5.2.1` for per-commit detail.
 
 ### Fixed
-- **Duplicate stop+start notifications on `systemctl restart` and package
-  upgrade.** `_cleanup_and_exit` now enqueues `🛑 Service Stopped` AFTER
-  the worker is drained and stopped, so the row stays `pending` in
-  SQLite. The next daemon's lifecycle classifier cancels the pending row
-  with `cancel_reason='superseded'` before emitting `🔄 Restarted` /
-  `📦 Upgraded` / `📊 Recovered` — exactly one notification per lifecycle
-  transition. Same fix in `MultiUPSCoordinator._handle_signal`. The
-  coordinator path also gets a new `_cancel_prev_pending_lifecycle_rows`
-  sweep at startup that opens each per-UPS store briefly and cancels
-  any pending lifecycle row from the previous instance — without that
-  sweep multi-UPS users would still see two notifications because
-  coordinator startup early-returns from the per-monitor cancel block.
-- **Stop notification suppressed entirely during deb/rpm upgrade.** The
-  upgrade marker is on disk by the time SIGTERM lands (postinstall drops
-  it before `systemctl restart`), so the old daemon now reads it and
-  skips the lifecycle stop write — saves a queue write + cancel
-  round-trip on every package upgrade.
-- **`📦 Upgraded vunknown → v5.2.1` on RPM.** RPM's postinstall gets
-  nothing useful in `$2`; v5.2.0's `${2:-unknown}` default rendered as
-  `vunknown`. New `packaging/scripts/preinstall.sh` queries `rpm -q
-  eneru` (or `dpkg-query -W eneru`) BEFORE the new package files unpack
-  and stashes the outgoing version in `/run/eneru/.old-version`;
-  `postinstall.sh` reads that and drops it into the upgrade marker.
-- **Defensive fallback in the lifecycle classifier.** If the upgrade
-  marker still arrives with `unknown` / `?` / empty `old_version` (manual
-  `rpm -ivh --force`, container-build edge case, partial install),
-  `lifecycle.classify_startup` now falls back to
-  `shutdown_marker.version` (always populated on graceful exit), then to
-  `meta.last_seen_version` from the stats DB, before rendering literal
-  `?`. The user never sees `vunknown` again regardless of how the marker
-  was populated.
+- **Two notifications on every `systemctl restart` and package upgrade**
+  instead of the v5.2-promised single `🔄 Restarted` / `📦 Upgraded`. The
+  synchronous `flush(timeout=5)` shipped the `🛑 Service Stopped` before
+  the next daemon's classifier could supersede it. Stop is now enqueued
+  *after* the worker drains so the row stays `pending` in SQLite for the
+  next daemon to cancel. Mirror fix in `MultiUPSCoordinator._handle_signal`,
+  plus a new coordinator-startup sweep for the multi-UPS path.
+- **`📦 Upgraded vunknown → v5.2.0` on RPM upgrade.** New `preinstall.sh`
+  captures the outgoing version via `rpm -q eneru` (or `dpkg-query -W
+  eneru`) before the new files unpack — RPM doesn't pass it in `$2` the
+  way DEB does. Defensive fallback chain in `lifecycle.classify_startup`
+  (`shutdown_marker.version` → `meta.last_seen_version` → `?`) covers
+  manual `rpm -ivh --force` and other paths that bypass scriptlets.
 
 ### Documentation
-- **`docs/notifications.md`** caught up with v5.0 / 5.1 / 5.2: SQLite-
-  backed persistent queue (replaces the v4.7 in-memory FIFO description),
-  per-message exponential backoff, the new config knobs (`retention_days`,
-  `max_attempts`, `max_age_days`, `max_pending`, `retry_backoff_max`),
-  the v5.2 lifecycle classifier states with the markers that drive each,
-  the brief-power-outage and recovery coalescing semantics. The
-  comparison table now spans `Fire-and-Forget (v4.6)` vs `Persistent
-  Retry (v4.7+)` vs `Stateful, Lossless Notifications (v5.2+)`.
+- **`docs/notifications.md`** caught up with the v5.0 / 5.1 / 5.2
+  architecture: SQLite-backed queue, exponential backoff, new config
+  knobs, lifecycle classifier states, brief-power-outage / recovery
+  coalescing. Comparison table extended to three columns (v4.6 / v4.7+ /
+  v5.2+).
 
 ### Migration notes
-None. Drop-in upgrade. Existing `notifications.*` config continues to
-work unchanged.
+None.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.2.1] - 2026-04-24
+
+Bug-fix release for two regressions reported within an hour of v5.2.0
+shipping. RPM users reinstalling or upgrading saw two notifications
+(`🛑 Service Stopped` + `📦 Upgraded vunknown → v5.2.0`) where v5.2's
+design called for a single `📦 Upgraded vX → vY` message. The `vunknown`
+came from RPM not passing the previous version to postinstall; the
+duplicate fired because the synchronous `flush(timeout=5)` shipped the
+stop notification before the new daemon could supersede it. The same
+race produced two messages on every plain `systemctl restart` too. Drop-in
+upgrade. See `git log v5.2.0..v5.2.1` for per-commit detail.
+
+### Fixed
+- **Duplicate stop+start notifications on `systemctl restart` and package
+  upgrade.** `_cleanup_and_exit` now enqueues `🛑 Service Stopped` AFTER
+  the worker is drained and stopped, so the row stays `pending` in
+  SQLite. The next daemon's lifecycle classifier cancels the pending row
+  with `cancel_reason='superseded'` before emitting `🔄 Restarted` /
+  `📦 Upgraded` / `📊 Recovered` — exactly one notification per lifecycle
+  transition. Same fix in `MultiUPSCoordinator._handle_signal`. The
+  coordinator path also gets a new `_cancel_prev_pending_lifecycle_rows`
+  sweep at startup that opens each per-UPS store briefly and cancels
+  any pending lifecycle row from the previous instance — without that
+  sweep multi-UPS users would still see two notifications because
+  coordinator startup early-returns from the per-monitor cancel block.
+- **Stop notification suppressed entirely during deb/rpm upgrade.** The
+  upgrade marker is on disk by the time SIGTERM lands (postinstall drops
+  it before `systemctl restart`), so the old daemon now reads it and
+  skips the lifecycle stop write — saves a queue write + cancel
+  round-trip on every package upgrade.
+- **`📦 Upgraded vunknown → v5.2.1` on RPM.** RPM's postinstall gets
+  nothing useful in `$2`; v5.2.0's `${2:-unknown}` default rendered as
+  `vunknown`. New `packaging/scripts/preinstall.sh` queries `rpm -q
+  eneru` (or `dpkg-query -W eneru`) BEFORE the new package files unpack
+  and stashes the outgoing version in `/run/eneru/.old-version`;
+  `postinstall.sh` reads that and drops it into the upgrade marker.
+- **Defensive fallback in the lifecycle classifier.** If the upgrade
+  marker still arrives with `unknown` / `?` / empty `old_version` (manual
+  `rpm -ivh --force`, container-build edge case, partial install),
+  `lifecycle.classify_startup` now falls back to
+  `shutdown_marker.version` (always populated on graceful exit), then to
+  `meta.last_seen_version` from the stats DB, before rendering literal
+  `?`. The user never sees `vunknown` again regardless of how the marker
+  was populated.
+
+### Documentation
+- **`docs/notifications.md`** caught up with v5.0 / 5.1 / 5.2: SQLite-
+  backed persistent queue (replaces the v4.7 in-memory FIFO description),
+  per-message exponential backoff, the new config knobs (`retention_days`,
+  `max_attempts`, `max_age_days`, `max_pending`, `retry_backoff_max`),
+  the v5.2 lifecycle classifier states with the markers that drive each,
+  the brief-power-outage and recovery coalescing semantics. The
+  comparison table now spans `Fire-and-Forget (v4.6)` vs `Persistent
+  Retry (v4.7+)` vs `Stateful, Lossless Notifications (v5.2+)`.
+
+### Migration notes
+None. Drop-in upgrade. Existing `notifications.*` config continues to
+work unchanged.
+
+---
+
 ## [5.2.0] - 2026-04-24
 
 Notifications get a rewrite. v5.1's were stateless and noisy: a `systemctl restart` emitted two unrelated events, a shutdown sequence emitted ~22 mid-flight "Shutdown Detail" lines that mirrored the log, and a power outage that took the internet down meant nothing was ever delivered. v5.2 makes them persistent, classified, and coalesced. See `git log v5.1.2..v5.2.0` for per-commit detail.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,19 +13,17 @@ Bug-fix release for two v5.2.0 regressions. Drop-in upgrade. See
 `git log v5.2.0..v5.2.1` for per-commit detail.
 
 ### Fixed
-- **Two notifications on every `systemctl restart` and package upgrade**
-  instead of the v5.2-promised single `🔄 Restarted` / `📦 Upgraded`. The
-  synchronous `flush(timeout=5)` shipped the `🛑 Service Stopped` before
-  the next daemon's classifier could supersede it. Stop is now enqueued
-  *after* the worker drains so the row stays `pending` in SQLite for the
-  next daemon to cancel. Mirror fix in `MultiUPSCoordinator._handle_signal`,
-  plus a new coordinator-startup sweep for the multi-UPS path.
-- **`📦 Upgraded vunknown → v5.2.0` on RPM upgrade.** New `preinstall.sh`
-  captures the outgoing version via `rpm -q eneru` (or `dpkg-query -W
-  eneru`) before the new files unpack — RPM doesn't pass it in `$2` the
-  way DEB does. Defensive fallback chain in `lifecycle.classify_startup`
-  (`shutdown_marker.version` → `meta.last_seen_version` → `?`) covers
-  manual `rpm -ivh --force` and other paths that bypass scriptlets.
+- **Two notifications on every `systemctl restart` / package upgrade**
+  instead of the v5.2-promised single `🔄 Restarted` / `📦 Upgraded`.
+  Old daemon defers the `🛑 Stopped` row and schedules a transient
+  `systemd-run` timer to deliver it ~15 s later. If a new daemon comes
+  up first, its classifier cancels the row → single message; if not
+  (true stop), the timer ships it → single `🛑 Stopped`. New module
+  `deferred_delivery.py` + hidden CLI subcommand `eneru _deliver-stop`.
+- **`📦 Upgraded vunknown → v5.2.0` on RPM.** New `preinstall.sh`
+  captures the outgoing version via `rpm -q eneru` before files unpack
+  (RPM doesn't pass it in `$2` the way DEB does). Defensive fallback
+  in `lifecycle.classify_startup` covers paths that bypass scriptlets.
 
 ### Documentation
 - **`docs/notifications.md`** caught up with the v5.0 / 5.1 / 5.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,11 +15,14 @@ Bug-fix release for two v5.2.0 regressions. Drop-in upgrade. See
 ### Fixed
 - **Two notifications on every `systemctl restart` / package upgrade**
   instead of the v5.2-promised single `🔄 Restarted` / `📦 Upgraded`.
-  Old daemon defers the `🛑 Stopped` row and schedules a transient
-  `systemd-run` timer to deliver it ~15 s later. If a new daemon comes
-  up first, its classifier cancels the row → single message; if not
-  (true stop), the timer ships it → single `🛑 Stopped`. New module
-  `deferred_delivery.py` + hidden CLI subcommand `eneru _deliver-stop`.
+  At SIGTERM the old daemon now picks the cheapest correct path based
+  on systemd intent (`systemctl show -p Job eneru.service`):
+  `Job=stop` → ship eagerly (instant); `Job=restart` / unknown →
+  enqueue + schedule a transient `systemd-run` timer to deliver ~15 s
+  later, cancelled by the next daemon's classifier if a replacement
+  comes up. Containers / K8s / foreground `eneru run` (no systemd) →
+  always eager. New module `deferred_delivery.py` + hidden CLI
+  subcommand `eneru _deliver-stop`.
 - **`📦 Upgraded vunknown → v5.2.0` on RPM.** New `preinstall.sh`
   captures the outgoing version via `rpm -q eneru` before files unpack
   (RPM doesn't pass it in `$2` the way DEB does). Defensive fallback

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,7 +310,12 @@ Global (one block for the whole daemon). Notifications are dispatched via Appris
 | `title` | `null` | Optional title prefix for notifications |
 | `avatar_url` | `null` | Avatar URL for supported services (Discord, Slack, Mattermost, Guilded, Zulip) |
 | `timeout` | `10` | Notification delivery timeout in seconds |
-| `retry_interval` | `5` | Seconds between retry attempts for failed notifications |
+| `retry_interval` | `5` | Initial wait between retry attempts for a failed notification. Per-message exponential backoff doubles this on each failure up to `retry_backoff_max` |
+| `retry_backoff_max` | `300` | Ceiling on the per-message exponential backoff, in seconds (5 min). Keeps reconnection quick once the endpoint returns without hammering the network during a long outage |
+| `max_attempts` | `0` | Per-message attempt cap. `0` = unlimited (default). Apprise's success/fail signal is a bool — Eneru can't tell "bad URL" from "internet down", so capping attempts risks dropping legitimate messages during a long outage. Set this only as a poison-message kill switch |
+| `max_age_days` | `30` | Pending notifications older than this become `cancelled` with reason `too_old`. The only TTL on `pending` rows; `0` disables it. Sized for "long weekend with the internet down" |
+| `max_pending` | `10000` | Backlog cap on pending rows. When pending exceeds this, the oldest are cancelled with reason `backlog_overflow`. Bounds DB growth on runaway-event days |
+| `retention_days` | `7` | Days to keep `sent` and `cancelled` rows around for forensic inspection via `sqlite3`. `pending` rows are NEVER pruned by TTL — only `max_age_days` ages them out |
 | `voltage_hysteresis_seconds` | `30` | Defer voltage `BROWNOUT` / `OVER_VOLTAGE` notifications until the condition has held this long. State log row is always immediate; only notification dispatch is deferred. `0` = legacy immediate behaviour. Severe deviations (>±15%) bypass the dwell |
 | `suppress` | `[]` | Per-event mute. Logs always record the event; only the notification is muted. Safety-critical events (`OVER_VOLTAGE_DETECTED`, `BROWNOUT_DETECTED`, `OVERLOAD_ACTIVE`, `BYPASS_MODE_ACTIVE`, `ON_BATTERY`, `CONNECTION_LOST`, any `SHUTDOWN_*`) are validator-rejected. Suppressible: `POWER_RESTORED`, `VOLTAGE_NORMALIZED`, `AVR_BOOST_ACTIVE`, `AVR_TRIM_ACTIVE`, `AVR_INACTIVE`, `BYPASS_MODE_INACTIVE`, `OVERLOAD_RESOLVED`, `CONNECTION_RESTORED`, `VOLTAGE_AUTODETECT_MISMATCH`, `VOLTAGE_FLAP_SUPPRESSED` |
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -236,7 +236,7 @@ Timeline (brief power blip, network slow to recover):
 
 ## Lifecycle notifications
 
-v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **stateful classifier** that picks one of seven messages based on two on-disk markers and the previous-version metadata in the stats DB. The result is exactly one notification per lifecycle transition rather than one per process start.
+v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **stateful classifier** that picks one of eight messages based on two on-disk markers and the previous-version metadata in the stats DB. The result is exactly one notification per lifecycle transition rather than one per process start.
 
 | Classification | Trigger | Driven by |
 |----------------|---------|-----------|
@@ -249,7 +249,7 @@ v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **st
 | `🚀 Eneru Started (after crash)` | Daemon came back without ever writing a marker | No shutdown marker but `meta.last_seen_version` is set |
 | `🚀 Eneru vX Started` | First-ever start | No markers, no `last_seen_version` |
 
-The mechanism that delivers "exactly one message" is **cancel-on-startup**: when the new daemon comes up and classifies (e.g.) as `Restarted`, it cancels any `pending` row in the `lifecycle` category that the previous instance enqueued. The `🛑 Service Stopped` row stays `pending` (the prior daemon's worker exits before delivering it) so the new daemon can supersede it cleanly. If the daemon truly never comes back, the pending stop is delivered by whichever daemon eventually starts; if nothing starts within `max_age_days`, the row ages out as `too_old`.
+The mechanism that delivers "exactly one message" is **cancel-on-startup**: when the new daemon comes up and classifies (e.g.) as `Restarted`, it cancels any `pending` row in the `lifecycle` category that the previous instance enqueued. The `🛑 Service Stopped` row stays `pending` (the prior daemon's worker exits before delivering it) so the new daemon can supersede it cleanly. If the daemon doesn't come back immediately, the pending stop is delivered by whichever daemon eventually starts (typically systemd's `Restart=always`); if no daemon starts within `max_age_days`, the row ages out as `too_old` and is never delivered.
 
 ---
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -249,7 +249,13 @@ v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **st
 | `🚀 Eneru Started (after crash)` | Daemon came back without ever writing a marker | No shutdown marker but `meta.last_seen_version` is set |
 | `🚀 Eneru vX Started` | First-ever start | No markers, no `last_seen_version` |
 
-The mechanism that delivers "exactly one message" is **cancel-on-startup**: when the new daemon comes up and classifies (e.g.) as `Restarted`, it cancels any `pending` row in the `lifecycle` category that the previous instance enqueued. The `🛑 Service Stopped` row stays `pending` (the prior daemon's worker exits before delivering it) so the new daemon can supersede it cleanly. If the daemon doesn't come back immediately, the pending stop is delivered by whichever daemon eventually starts (typically systemd's `Restart=always`); if no daemon starts within `max_age_days`, the row ages out as `too_old` and is never delivered.
+The mechanism that delivers "exactly one message" combines **cancel-on-startup** with a **systemd-run deferred-delivery timer**:
+
+1. On `SIGTERM`, the old daemon enqueues `🛑 Service Stopped` as a `pending` row, stops its worker (so it can't deliver eagerly), and schedules a transient `systemd-run` timer that re-invokes `eneru _deliver-stop` ~15 s later. The timer lives **outside** `eneru.service`'s cgroup, so it survives our exit and doesn't gate the systemd restart cycle.
+2. If the new daemon comes up first (`systemctl restart`, package upgrade, recovery), its classifier cancels every `pending` lifecycle row with `cancel_reason='superseded'` BEFORE the deferred timer fires. Single message: `🔄 Restarted` / `📦 Upgraded` / `📊 Recovered`.
+3. If no replacement comes up (true `systemctl stop`), the timer fires, sees the row still `pending`, and ships it via Apprise. Single message: `🛑 Service Stopped`.
+
+Fallback: if `systemd-run` isn't available (non-systemd containers, sandboxed builds), the old daemon ships the stop synchronously via Apprise instead. This loses the restart-coalescing benefit on those hosts but guarantees the user always sees a notification.
 
 ---
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -17,8 +17,18 @@ notifications:
   # Timeout for notification delivery (seconds)
   timeout: 10
 
-  # Seconds between retry attempts for failed notifications (default: 5)
+  # Initial retry wait for failed sends. Doubles on each failure up to
+  # retry_backoff_max (see below). Default: 5
   retry_interval: 5
+
+  # v5.2 persistent-queue knobs. Defaults are sized for "long weekend
+  # with the internet down" — the queue survives process death and
+  # prolonged outages, then drains once the endpoint returns.
+  retention_days: 7         # keep sent/cancelled rows for forensics
+  max_attempts: 0           # 0 = unlimited (default, see below)
+  max_age_days: 30          # only TTL on pending rows
+  max_pending: 10000        # backlog overflow cap
+  retry_backoff_max: 300    # 5-min ceiling on the exponential backoff
 
   # Notification service URLs
   urls:
@@ -26,6 +36,11 @@ notifications:
     - "slack://token_a/token_b/token_c/#channel"
     - "telegram://bot_token/chat_id"
 ```
+
+`max_attempts` defaults to `0` (unlimited) on purpose: Apprise's
+success/fail signal is a single bool — Eneru cannot tell "bad URL" from
+"internet down". Capping attempts risks dropping legitimate messages
+during a long outage. Use this only as a poison-message kill switch.
 
 ---
 
@@ -117,146 +132,157 @@ eneru validate --config /etc/ups-monitor/config.yaml
 
 ## Persistent retry architecture
 
-Network connectivity is often temporarily down during power outages. Eneru uses a non-blocking persistent retry system: the main thread queues notifications instantly and continues with shutdown operations, while a worker thread retries failed sends until they succeed. A FIFO queue preserves message order.
+Network connectivity is often temporarily down during power outages, and the daemon process itself may stop and restart mid-incident (`systemctl restart`, package upgrade, host reboot). Eneru's notification queue is **SQLite-backed and lossless across process death**: the main thread inserts a `pending` row in the per-UPS stats DB and returns immediately; a worker thread reads pending rows and ships them via Apprise; failed sends stay `pending` and retry with **per-message exponential backoff** (starts at `retry_interval`, doubles up to `retry_backoff_max`).
 
-All notifications are delivered as long as the network recovers before the system shuts down.
+If the daemon dies while rows are still pending, the next start picks them up and continues delivery — nothing is lost in process memory. Only `pending` rows are subject to a TTL (`max_age_days`, default 30 days); `sent` and `cancelled` rows are kept for `retention_days` (default 7) for forensic inspection via `sqlite3`.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                ENERU NOTIFICATION ARCHITECTURE.                             │
+│                  ENERU v5.2 NOTIFICATION ARCHITECTURE                       │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
-│   MAIN THREAD (Critical Path)          WORKER THREAD (Persistent Retry)     │
-│   ═══════════════════════════          ════════════════════════════════     │
+│   MAIN THREAD (Critical Path)         WORKER THREAD (Persistent Retry)      │
+│   ═══════════════════════════         ═════════════════════════════════     │
 │                                                                             │
 │   ┌─────────────────────┐                                                   │
-│   │ Shutdown Triggered  │                                                   │
+│   │  Event happens      │                                                   │
+│   │  (power, lifecycle) │                                                   │
 │   └──────────┬──────────┘                                                   │
 │              │                                                              │
 │              ▼                                                              │
-│   ┌─────────────────────┐         ┌─────────────────────┐                   │
-│   │ Queue Notification  │────────▶│  Notification Queue │                   │
-│   │ (non-blocking)      │         │  ┌───┬───┬───┬───┐  │                   │
-│   └──────────┬──────────┘         │  │ 1 │ 2 │ 3 │...│  │  FIFO Order       │
-│              │                    │  └───┴───┴───┴───┘  │                   │
-│              │ continues          └──────────┬──────────┘                   │
-│              │ immediately                   │                              │
-│              ▼                               ▼                              │
-│   ┌─────────────────────┐         ┌─────────────────────┐                   │
-│   │ Stop VMs            │         │ Attempt Send        │                   │
-│   └──────────┬──────────┘         └──────────┬──────────┘                   │
-│              │                               │                              │
-│              ▼                               ▼                              │
-│   ┌─────────────────────┐              ┌─────────┐                          │
-│   │ Stop Containers     │              │ Success?│                          │
-│   └──────────┬──────────┘              └────┬────┘                          │
-│              │                         YES/ \NO                             │
-│              ▼                            /   \                             │
-│   ┌─────────────────────┐         ┌─────┐     ┌──────────────┐              │
-│   │ Unmount Filesystems │         │ ACK │     │ Wait & Retry │              │
-│   └──────────┬──────────┘         │ ──▶ │     │ (5s default) │              │
-│              │                    │Next │     └──────┬───────┘              │
-│              ▼                    │ Msg │            │                      │
-│   ┌─────────────────────┐         └─────┘            │                      │
-│   │ Shutdown Remote     │                            ▼                      │
-│   │ Servers             │                   ┌────────────────┐              │
-│   └──────────┬──────────┘                   │ Network back?  │──▶ Retry     │
-│              │                              └────────────────┘              │
+│   ┌─────────────────────┐         ┌──────────────────────────────┐          │
+│   │ Insert pending row  │────────▶│   Per-UPS SQLite stats DB    │          │
+│   │ (non-blocking)      │         │   notifications table:       │          │
+│   └──────────┬──────────┘         │   id │ ts │ body │ status   │          │
+│              │                    │   ──┴────┴──────┴──────────  │          │
+│              │ continues          │   pending → sent / cancelled │          │
+│              │ immediately        └──────────┬───────────────────┘          │
+│              ▼                               │                              │
+│   ┌─────────────────────┐                    ▼                              │
+│   │ Stop VMs            │         ┌──────────────────────────────┐          │
+│   └──────────┬──────────┘         │ Read oldest `pending` row    │          │
+│              ▼                    │ Try Apprise send             │          │
+│   ┌─────────────────────┐         └──────────┬───────────────────┘          │
+│   │ Stop Containers     │                    │                              │
+│   └──────────┬──────────┘               YES ┌┴┐ NO                          │
+│              ▼                              │ │                             │
+│   ┌─────────────────────┐         ┌─────────┘ └──────────┐                  │
+│   │ Unmount Filesystems │         │ Mark `sent`           │ Increment       │
+│   └──────────┬──────────┘         │ Move to next pending  │ attempts        │
+│              ▼                    │                       │ Wait `interval` │
+│   ┌─────────────────────┐         └───────────────────────┘ × 2^N           │
+│   │ Shutdown Remote     │                                  (cap = 300s)     │
+│   │ Servers             │                                                   │
+│   └──────────┬──────────┘                                                   │
 │              ▼                                                              │
-│   ┌─────────────────────┐         ┌─────────────────────┐                   │
-│   │ 5-Second Grace      │         │    KEY BENEFITS     │                   │
-│   │ (retry window)      │         ├─────────────────────┤                   │
-│   └──────────┬──────────┘         │ ✓ Zero blocking     │                   │
-│              │                    │ ✓ Persistent retry  │                   │
-│              ▼                    │ ✓ FIFO ordering     │                   │
-│   ┌─────────────────────┐         │ ✓ No message loss*  │                   │
-│   │ shutdown -h now     │         │ ✓ Graceful stop     │                   │
-│   └─────────────────────┘         └─────────────────────┘                   │
-│                                   * until process exit                      │
+│   ┌─────────────────────┐         ┌──────────────────────────────┐          │
+│   │ flush(timeout=5)    │         │       KEY GUARANTEES          │         │
+│   │ wait for pending=0  │         ├──────────────────────────────┤          │
+│   │ OR 5s, whichever    │         │ ✓ Survives process death     │          │
+│   │ comes first         │         │ ✓ Survives long outages      │          │
+│   └──────────┬──────────┘         │ ✓ FIFO within UPS            │          │
+│              ▼                    │ ✓ Per-message backoff        │          │
+│   ┌─────────────────────┐         │ ✓ No flush burns the CPU on  │          │
+│   │ shutdown -h now     │         │   an unreachable endpoint    │          │
+│   └─────────────────────┘         └──────────────────────────────┘          │
+│                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Configuration
+### Comparison with prior architectures
 
-```yaml
-notifications:
-  # ... other settings ...
+| Scenario | Fire-and-Forget (v4.6) | Persistent Retry (v4.7+) | Stateful, Lossless (v5.2+) |
+|----------|------------------------|--------------------------|-----------------------------|
+| 30-second network blip | Notifications lost | Retried and delivered | Retried and delivered |
+| Router reboot during outage | Notifications lost | Retried and delivered | Retried and delivered |
+| Transient DNS failure | Notifications lost | Retried and delivered | Retried and delivered |
+| Daemon crashes mid-outage | Messages lost at exit | Messages lost at exit | Pending rows survive in SQLite; next start resumes |
+| `systemctl restart` mid-outage | Messages lost at exit | Messages lost at exit | Resumed transparently |
+| Multi-day internet outage | All retries hammer the network | Same | Per-message exponential backoff, capped at `retry_backoff_max` (default 5 min) |
+| `systemctl restart` (no event) | Stop + Start (2 unrelated messages) | Stop + Start (2 unrelated messages) | Single `🔄 Restarted (downtime: Ns)` (classifier cancels the pending stop) |
+| Package upgrade (deb/rpm) | Stop + Start (2 messages, no version) | Stop + Start (2 messages, no version) | Single `📦 Upgraded vX → vY` (postinstall marker + classifier) |
+| Power-loss recovery | Stop + Start (2 messages, no context) | Stop + Start (2 messages, no context) | Single `📊 Recovered` (folds the prior shutdown headline + downtime + reason) |
+| Brief power blip | 2 messages (`Power Lost` + `Power Restored`) | Same | Coalesced into 1 `📊 Brief Power Outage: Ns on battery` summary |
+| Backlog growth on runaway events | Unbounded queue (OOM risk) | Unbounded queue (OOM risk) | Bounded by `max_pending` (default 10000); oldest cancelled with `backlog_overflow` |
+| Stale pending TTL | N/A (no queue) | N/A (memory-only) | `max_age_days` (default 30) ages out pending rows as `too_old` |
 
-  # Seconds between retry attempts (default: 5)
-  retry_interval: 5
-```
+### Shutdown drain: `flush(timeout=5)`
 
-### Comparison with fire-and-forget
-
-| Scenario | Fire-and-Forget (v4.6) | Persistent Retry (v4.7+) |
-|----------|------------------------|--------------------------|
-| 30-second network blip | Notifications lost | Retried and delivered |
-| Router reboot during outage | Notifications lost | Retried and delivered |
-| Transient DNS failure | Notifications lost | Retried and delivered |
-| Network down until shutdown | Messages dropped at exit | Same (logs in journalctl) |
-| Multiple services configured | All fail simultaneously | Apprise retries to all |
-
-### The 5-second grace period
-
-After all shutdown operations complete, Eneru waits 5 seconds before issuing `shutdown -h now`. This gives queued notifications a window to send if the network is available.
-
-```
-Timeline (worst case - network down):
-─────────────────────────────────────────────────────────────────
-0s     │ Shutdown triggered, notification queued (instant)
-0.1s   │ VMs stopping...
-15s    │ VMs stopped, containers stopping...
-30s    │ Containers stopped, filesystems synced...
-45s    │ Remote servers notified...
-50s    │ All critical operations complete
-50-55s │ Grace period (notifications attempted)
-55s    │ shutdown -h now executed
-─────────────────────────────────────────────────────────────────
-        Total: ~55 seconds (network issues added 0 seconds delay)
-```
+When the daemon is exiting (signal, sequence-complete, or `systemctl stop`), the worker is given up to 5 seconds to drain any pending rows before the process exits. The call returns as soon as `pending` hits 0, so a fast network adds zero latency. Whatever doesn't drain stays in SQLite — the next start replays it, so the only real failure mode is "endpoint still unreachable when the system finally powers off", which Eneru flags in `journalctl` rather than dropping silently.
 
 ### 30-second power blip
 
 During a brief power blip, power may return within seconds, well before any shutdown triggers fire. But the public Internet often stays unreachable for several minutes while local network equipment reboots (router, modem, switches, WiFi APs).
 
-Notifications queue instantly and the worker retries every `retry_interval` seconds. Once the network is back, all messages are delivered in order.
+Notifications insert as `pending` immediately and the worker retries with exponential backoff. Once the network is back, queued messages drain in age order. With v5.2, an `ON_BATTERY` + `POWER_RESTORED` pair from the same outage that's still pending when delivery resumes is **coalesced into one `📊 Brief Power Outage: Ns on battery` summary** rather than shipping as two separate messages.
 
 ```
 Timeline (brief power blip, network slow to recover):
 ─────────────────────────────────────────────────────────────────
-0s     │ Power lost, "Power Lost" notification queued
-5s     │ Retry #1 - network down
-10s    │ Retry #2 - still failing
-15s    │ Retry #3 - still failing
-20s    │ Retry #4 - still failing
-28s    │ Power restored, "Power Restored" notification queued
-35s    │ Retry #5 - still failing (switches coming up)
-40s    | Retry #6 - still failing (router booting)
-45s    │ Retry #7 - still failing (WiFi AP booting)
-50s    │ Retry #8 - still failing (ISP modem syncing)
+0s     │ Power lost, ON_BATTERY row inserted (pending)
+5s     │ Worker retry #1 — network down (attempts=1, wait=5s)
+10s    │ Worker retry #2 — still failing  (attempts=2, wait=10s)
+20s    │ Worker retry #3 — still failing  (attempts=3, wait=20s)
+28s    │ Power restored, POWER_RESTORED row inserted (pending)
+40s    │ Worker retry #4 — still failing  (attempts=4, wait=40s)
 60s    │ Network is back!
-60s    │ Retry #9 - SUCCESS! ✓ "Power Lost" delivered
-60s    │ ✓ "Power Restored" delivered (next in queue)
+60s    │ Coalescer folds ON_BATTERY + POWER_RESTORED into one row
+60s    │ ✓ "📊 Brief Power Outage: 28s on battery" delivered
 ─────────────────────────────────────────────────────────────────
-        Both notifications delivered despite 60-second network outage
+       1 message delivered (instead of 2) despite a 60-second outage
 ```
+
+---
+
+## Lifecycle notifications
+
+v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **stateful classifier** that picks one of seven messages based on two on-disk markers and the previous-version metadata in the stats DB. The result is exactly one notification per lifecycle transition rather than one per process start.
+
+| Classification | Trigger | Driven by |
+|----------------|---------|-----------|
+| `📦 Eneru Upgraded vX → vY` | deb/rpm package upgrade | `.upgrade_marker.json` written by `packaging/scripts/postinstall.sh`; old version captured by `preinstall.sh` (`rpm -q eneru` / `dpkg-query`) |
+| `📦 Eneru Upgraded vX → vY` (pip path) | `pip install --upgrade eneru` followed by restart | `meta.last_seen_version` in the stats DB differs from current `__version__` |
+| `📊 Eneru Recovered` | Daemon coming back after a power-loss-triggered shutdown | `.shutdown_state.json` with `reason: sequence_complete`; folds the prior shutdown headline + summary into one richer message |
+| `🔄 Eneru Restarted (downtime: Ns)` | `systemctl restart eneru` within 30 seconds | `.shutdown_state.json` with `reason: signal` and downtime under 30 s |
+| `🚀 Eneru Restarted` (fatal) | Daemon came back after a crash that wrote a `fatal` marker | `.shutdown_state.json` with `reason: fatal` |
+| `🚀 Eneru Started (last seen Nh ago)` | Daemon started after a long graceful gap | `.shutdown_state.json` present with downtime ≥ 30 s |
+| `🚀 Eneru Started (after crash)` | Daemon came back without ever writing a marker | No shutdown marker but `meta.last_seen_version` is set |
+| `🚀 Eneru vX Started` | First-ever start | No markers, no `last_seen_version` |
+
+The mechanism that delivers "exactly one message" is **cancel-on-startup**: when the new daemon comes up and classifies (e.g.) as `Restarted`, it cancels any `pending` row in the `lifecycle` category that the previous instance enqueued. The `🛑 Service Stopped` row stays `pending` (the prior daemon's worker exits before delivering it) so the new daemon can supersede it cleanly. If the daemon truly never comes back, the pending stop is delivered by whichever daemon eventually starts; if nothing starts within `max_age_days`, the row ages out as `too_old`.
+
+---
+
+## Coalescing
+
+Two related events that reach the queue close together get folded into one richer message before delivery, so the user sees the *story* rather than the individual signals.
+
+**Brief power outage.** When a `POWER_RESTORED` notification is being enqueued and an `ON_BATTERY` notification from the same outage is still `pending` (i.e. the network was down during the outage and only came back after recovery), both rows are cancelled with reason `coalesced` and replaced by a single `📊 Brief Power Outage: Ns on battery` summary. If either row already shipped, no fold-in happens — the user still gets two messages, which is the right behaviour because the first one already left the building.
+
+**Power-loss recovery fold-in.** When the daemon classifies a startup as `📊 Recovered` (sequence_complete shutdown marker on disk), it absorbs the prior instance's pending shutdown *headline* (the `🚨 EMERGENCY SHUTDOWN INITIATED!` line) and the pending shutdown *summary* (`✅ Shutdown Sequence Complete`) into one message that carries the trigger reason and the total downtime. The fold is bounded to the current outage (`shutdown_at - 60 s` floor) so an unrelated older pending shutdown row from a previous outage isn't accidentally cancelled.
 
 ---
 
 ## Notification events
 
-Eneru sends notifications for these events:
-
-| Event | Description |
-|-------|-------------|
-| Service Start | Eneru daemon started |
-| Service Stop | Eneru daemon stopped (graceful) |
-| Power Lost | UPS switched to battery |
-| Power Restored | UPS back on line power |
-| Shutdown Triggered | Emergency shutdown initiated |
-| Voltage Events | Brownout, over-voltage, AVR activation |
-| Battery Anomaly | Charge dropped >20% while on line power (recalibration, aging, hardware fault). Must persist across 3 polls to filter jitter from APC, CyberPower, and Ubiquiti UniFi UPS units |
-| Overload | UPS load threshold exceeded |
+| Event | `event_type` (stats DB) | Category | Notes |
+|-------|-------------------------|----------|-------|
+| Power lost | `ON_BATTERY` | `power_event` | Coalescible with `POWER_RESTORED` if both pending |
+| Power restored | `POWER_RESTORED` | `power_event` | Suppressible via `notifications.suppress` |
+| Brief power outage (coalesced) | `BRIEF_POWER_OUTAGE` | `power_event` | v5.2 — replaces an `ON_BATTERY` + `POWER_RESTORED` pair |
+| Emergency shutdown initiated | `EMERGENCY_SHUTDOWN_INITIATED` | `shutdown` | Safety-critical (cannot be suppressed) |
+| Shutdown sequence complete | `SHUTDOWN_SEQUENCE_COMPLETE` | `shutdown_summary` | One per shutdown |
+| Voltage: brownout / over-voltage | `BROWNOUT_DETECTED` / `OVER_VOLTAGE_DETECTED` | `voltage` | Hysteresis-debounced; severe deviations bypass the dwell |
+| Voltage normalized | `VOLTAGE_NORMALIZED` | `voltage` | Suppressible |
+| AVR boost / trim / inactive | `AVR_BOOST_ACTIVE` / `AVR_TRIM_ACTIVE` / `AVR_INACTIVE` | `voltage` | All three suppressible |
+| Bypass active / inactive | `BYPASS_MODE_ACTIVE` / `BYPASS_MODE_INACTIVE` | `voltage` | Active is safety-critical |
+| Overload active / resolved | `OVERLOAD_ACTIVE` / `OVERLOAD_RESOLVED` | `voltage` | Active is safety-critical |
+| Connection lost / restored | `CONNECTION_LOST` / `CONNECTION_RESTORED` | `general` | Restored is suppressible |
+| Battery anomaly | `BATTERY_ANOMALY_DETECTED` | `general` | Charge dropped > 20% while on line power; sustained-reading filter (3 polls) for APC / CyberPower / UniFi firmware jitter |
+| Lifecycle: started / restarted / recovered / upgraded | `DAEMON_START` / `DAEMON_RESTARTED` / `DAEMON_RECOVERED` / `DAEMON_UPGRADED` | `lifecycle` | One per lifecycle transition (see "Lifecycle notifications") |
+| Lifecycle: restarted after fatal | `DAEMON_RESTARTED_AFTER_FATAL` | `lifecycle` | |
+| Lifecycle: started after crash | `DAEMON_AFTER_CRASH` | `lifecycle` | Marker-less restart with prior `last_seen_version` |
+| Lifecycle: stopped | `DAEMON_STOP` | `lifecycle` | Pending row gets superseded if a new daemon comes up within the restart window |
 
 ---
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -249,13 +249,14 @@ v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **st
 | `🚀 Eneru Started (after crash)` | Daemon came back without ever writing a marker | No shutdown marker but `meta.last_seen_version` is set |
 | `🚀 Eneru vX Started` | First-ever start | No markers, no `last_seen_version` |
 
-The mechanism that delivers "exactly one message" combines **cancel-on-startup** with a **systemd-run deferred-delivery timer**:
+The mechanism that delivers "exactly one message" picks the cheapest correct path based on systemd intent:
 
-1. On `SIGTERM`, the old daemon enqueues `🛑 Service Stopped` as a `pending` row, stops its worker (so it can't deliver eagerly), and schedules a transient `systemd-run` timer that re-invokes `eneru _deliver-stop` ~15 s later. The timer lives **outside** `eneru.service`'s cgroup, so it survives our exit and doesn't gate the systemd restart cycle.
-2. If the new daemon comes up first (`systemctl restart`, package upgrade, recovery), its classifier cancels every `pending` lifecycle row with `cancel_reason='superseded'` BEFORE the deferred timer fires. Single message: `🔄 Restarted` / `📦 Upgraded` / `📊 Recovered`.
-3. If no replacement comes up (true `systemctl stop`), the timer fires, sees the row still `pending`, and ships it via Apprise. Single message: `🛑 Service Stopped`.
+1. **`systemctl stop eneru`** (systemd `Job=stop` queued): the old daemon ships `🛑 Service Stopped` synchronously via Apprise and exits. Single message, instant — no waiting around.
+2. **`systemctl restart eneru` / package upgrade**: the old daemon enqueues `🛑 Service Stopped` as a `pending` row, stops its worker, and schedules a transient `systemd-run` timer that re-invokes `eneru _deliver-stop` ~15 s later. The timer lives **outside** `eneru.service`'s cgroup so it survives our exit and doesn't gate the systemd restart cycle. The new daemon's classifier cancels the pending row with `cancel_reason='superseded'` before the timer fires → single `🔄 Restarted` / `📦 Upgraded` / `📊 Recovered`. (Package-upgrade also short-circuits via the upgrade marker in the old daemon's `_cleanup_and_exit`, skipping the enqueue entirely.)
+3. **Crash, kill, manual SIGTERM (no systemd job queued)**: defensive — same systemd-run timer as case 2. If a replacement comes up within 15 s the row is cancelled; otherwise the timer ships.
+4. **Not under systemd** (Docker, K8s, foreground `eneru run`): the defer-then-ship dance only makes sense when there's a service manager that will or won't restart us. The old daemon ships eagerly via Apprise, identical to case 1. Single message, instant.
 
-Fallback: if `systemd-run` isn't available (non-systemd containers, sandboxed builds), the old daemon ships the stop synchronously via Apprise instead. This loses the restart-coalescing benefit on those hosts but guarantees the user always sees a notification.
+The systemd intent is detected by querying `systemctl show -p Job eneru.service` at SIGTERM time — systemd has the job queued before it sends the signal, so by the time we read this we see whether it's a stop, a restart, or nothing (crash/kill).
 
 ---
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -274,18 +274,18 @@ Two related events that reach the queue close together get folded into one riche
 
 | Event | `event_type` (stats DB) | Category | Notes |
 |-------|-------------------------|----------|-------|
-| Power lost | `ON_BATTERY` | `power_event` | Coalescible with `POWER_RESTORED` if both pending |
-| Power restored | `POWER_RESTORED` | `power_event` | Suppressible via `notifications.suppress` |
-| Brief power outage (coalesced) | `BRIEF_POWER_OUTAGE` | `power_event` | v5.2 — replaces an `ON_BATTERY` + `POWER_RESTORED` pair |
+| Power lost | `ON_BATTERY` | `power_event_on_battery` | Sub-typed category lets the coalescer pair it with `power_event_on_line` by exact match |
+| Power restored | `POWER_RESTORED` | `power_event_on_line` | Suppressible via `notifications.suppress` |
+| Brief power outage (coalesced) | `BRIEF_POWER_OUTAGE` | `power_event` | v5.2 summary row that replaces an `ON_BATTERY` + `POWER_RESTORED` pair |
+| Connection lost / restored | `CONNECTION_LOST` / `CONNECTION_RESTORED` | `power_event` | Restored is suppressible |
 | Emergency shutdown initiated | `EMERGENCY_SHUTDOWN_INITIATED` | `shutdown` | Safety-critical (cannot be suppressed) |
 | Shutdown sequence complete | `SHUTDOWN_SEQUENCE_COMPLETE` | `shutdown_summary` | One per shutdown |
-| Voltage: brownout / over-voltage | `BROWNOUT_DETECTED` / `OVER_VOLTAGE_DETECTED` | `voltage` | Hysteresis-debounced; severe deviations bypass the dwell |
-| Voltage normalized | `VOLTAGE_NORMALIZED` | `voltage` | Suppressible |
-| AVR boost / trim / inactive | `AVR_BOOST_ACTIVE` / `AVR_TRIM_ACTIVE` / `AVR_INACTIVE` | `voltage` | All three suppressible |
-| Bypass active / inactive | `BYPASS_MODE_ACTIVE` / `BYPASS_MODE_INACTIVE` | `voltage` | Active is safety-critical |
-| Overload active / resolved | `OVERLOAD_ACTIVE` / `OVERLOAD_RESOLVED` | `voltage` | Active is safety-critical |
-| Connection lost / restored | `CONNECTION_LOST` / `CONNECTION_RESTORED` | `general` | Restored is suppressible |
-| Battery anomaly | `BATTERY_ANOMALY_DETECTED` | `general` | Charge dropped > 20% while on line power; sustained-reading filter (3 polls) for APC / CyberPower / UniFi firmware jitter |
+| Voltage: brownout / over-voltage | `BROWNOUT_DETECTED` / `OVER_VOLTAGE_DETECTED` | `power_event` | Hysteresis-debounced; severe deviations bypass the dwell |
+| Voltage normalized | `VOLTAGE_NORMALIZED` | `power_event` | Suppressible |
+| AVR boost / trim / inactive | `AVR_BOOST_ACTIVE` / `AVR_TRIM_ACTIVE` / `AVR_INACTIVE` | `power_event` | All three suppressible |
+| Bypass active / inactive | `BYPASS_MODE_ACTIVE` / `BYPASS_MODE_INACTIVE` | `power_event` | Active is safety-critical |
+| Overload active / resolved | `OVERLOAD_ACTIVE` / `OVERLOAD_RESOLVED` | `power_event` | Active is safety-critical |
+| Battery anomaly | `BATTERY_ANOMALY_DETECTED` | `health` | Charge dropped > 20% while on line power; sustained-reading filter (3 polls) for APC / CyberPower / UniFi firmware jitter |
 | Lifecycle: started / restarted / recovered / upgraded | `DAEMON_START` / `DAEMON_RESTARTED` / `DAEMON_RECOVERED` / `DAEMON_UPGRADED` | `lifecycle` | One per lifecycle transition (see "Lifecycle notifications") |
 | Lifecycle: restarted after fatal | `DAEMON_RESTARTED_AFTER_FATAL` | `lifecycle` | |
 | Lifecycle: started after crash | `DAEMON_AFTER_CRASH` | `lifecycle` | Marker-less restart with prior `last_seen_version` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -195,11 +195,11 @@ The E2E tests use scenario files to simulate different UPS states:
 
 ### E2E test cases
 
-The E2E workflow (`.github/workflows/e2e.yml`) runs 33 tests on every push and PR.
+The E2E workflow (`.github/workflows/e2e.yml`) runs 36 tests on every push and PR.
 Tests are partitioned into five parallel matrix jobs (`E2E CLI`,
 `E2E UPS Single`, `E2E UPS Multi`, `E2E Redundancy`, `E2E Stats`) so the
 total wall-clock is bounded by the slowest group rather than the sum of
-all 33 tests. v5.1.2 split the previous `Redundancy and Stats` group
+all 36 tests. v5.1.2 split the previous `Redundancy and Stats` group
 in two so the heaviest job no longer gates the matrix on its own.
 
 | Test | Group | Description |
@@ -237,6 +237,9 @@ in two so the heaviest job no longer gates the matrix on its own.
 | **Test 31** | Stats | `eneru monitor --once --events-only` reads from the SQLite events table — verified by injecting a known event row into the DB and asserting the line surfaces in the output |
 | **Test 32** | Stats | Voltage auto-detect re-snaps NUT mis-reported nominal — scenario `us-grid-misreport.dev` reports `input.voltage.nominal=230V` while actual `input.voltage=120V`; daemon detects the mismatch, logs `auto-detect re-snap`, records a `VOLTAGE_AUTODETECT_MISMATCH` event with `notification_sent=0`, and confirms `meta.schema_version=3` |
 | **Test 33** | UPS Single | Issue #4: voltage_sensitivity preset prevents Chris's false-alarm flood — scenario `us-grid-hot.dev` (120V/106/127, input 122.4V) does NOT fire `OVER_VOLTAGE_DETECTED` on default `normal` (warnings 108/132), startup log says `sensitivity=normal`, the migration warning surfaces for the narrow-firmware UPS, and `us-grid-brownout.dev` at 107V still fires `BROWNOUT_DETECTED` |
+| **Test 34** | Stats | v5.2 panic-attack coalescing: `ON_BATTERY` + `POWER_RESTORED` rows pointed at TEST-NET-1 stay pending; the worker folds them into one `📊 Brief Power Outage` summary with the originals cancelled with `cancel_reason='coalesced'` |
+| **Test 35** | Stats | v5.2.1 single-restart-notification (single-UPS): SIGTERM enqueues `🛑 Service Stopped` AFTER `flush()` so it lands as `pending`; the next daemon's classifier cancels it with `cancel_reason='superseded'` and emits a single `🔄 Restarted` row — proves one notification per restart, never two |
+| **Test 36** | UPS Multi | v5.2.1 single-restart-notification (multi-UPS coordinator): same contract as Test 35 but exercises `MultiUPSCoordinator._cancel_prev_pending_lifecycle_rows` which sweeps each per-UPS store on the next coordinator startup |
 
 ### Running E2E tests locally
 

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -101,6 +101,45 @@ notifications:
   # Timeout for notification delivery (seconds)
   timeout: 10
 
+  # ----- v5.2 persistent-queue knobs --------------------------------
+  # The notification queue is SQLite-backed (per-UPS stats DB) so
+  # messages survive process death and prolonged endpoint outages.
+  # Defaults are sized for "long weekend with the internet down".
+  # See docs/notifications.md "Persistent retry architecture" for the
+  # full architecture (cancel-on-startup, per-message backoff, etc.).
+
+  # Initial wait between retry attempts for a failed send. Per-message
+  # exponential backoff doubles this on each failure up to
+  # retry_backoff_max. Default 5s.
+  retry_interval: 5
+
+  # Ceiling on the per-message exponential backoff, in seconds. Keeps
+  # reconnection quick once the endpoint returns without hammering the
+  # network during a multi-hour outage. Default 300s (5 min).
+  retry_backoff_max: 300
+
+  # Per-message attempt cap. 0 = unlimited (default). Apprise's
+  # success/fail signal is a single bool — we can't tell "bad URL"
+  # from "internet down" — so capping attempts risks dropping
+  # legitimate messages during a long outage. Set this only as a
+  # poison-message kill switch.
+  max_attempts: 0
+
+  # Pending notifications older than this become 'cancelled' with
+  # reason='too_old'. The only TTL on pending rows; 0 disables it.
+  # Default 30 days.
+  max_age_days: 30
+
+  # Backlog cap on pending rows. When pending exceeds this, the
+  # oldest are cancelled with reason='backlog_overflow'. Bounds DB
+  # growth on runaway-event days. Default 10000.
+  max_pending: 10000
+
+  # Days to keep 'sent' and 'cancelled' rows around for forensic
+  # inspection via sqlite3. Pending rows are NEVER pruned by TTL —
+  # only max_age_days ages them out. Default 7 days.
+  retention_days: 7
+
   # ----- Issue #27: alert noise tuning ------------------------------
   # Defer voltage notifications until the condition has held for this
   # many seconds. The state log line is *always* written immediately

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -176,6 +176,13 @@ contents:
       owner: root
       group: root
 
+  - src: src/eneru/deferred_delivery.py
+    dst: /opt/ups-monitor/eneru/deferred_delivery.py
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
   # eneru.shutdown subpackage (mixin per shutdown phase)
   - src: src/eneru/shutdown/__init__.py
     dst: /opt/ups-monitor/eneru/shutdown/__init__.py

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -384,6 +384,7 @@ contents:
 
 # Scripts executed during package lifecycle
 scripts:
+  preinstall: packaging/scripts/preinstall.sh
   postinstall: packaging/scripts/postinstall.sh
   preremove: packaging/scripts/preremove.sh
   postremove: packaging/scripts/postremove.sh

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -52,9 +52,22 @@ if [ "$is_upgrade" = true ]; then
         # daemon's own __version__ at read time. Best-effort: a write
         # failure just means the user gets the legacy classification.
         # Marker is consumed (deleted) by the daemon on the next start.
-        OLD_VERSION="${2:-unknown}"      # DEB: $2 = previous version
-        # RPM passes "$1 = 2" on upgrade with no version string; we leave
-        # OLD_VERSION as "unknown" in that case rather than guessing.
+        # v5.2.1: preinstall.sh queries `rpm -q eneru` / `dpkg-query`
+        # BEFORE the new files unpack and stashes the outgoing version
+        # in /run/eneru/.old-version. Prefer that — RPM's postinstall
+        # gets nothing useful in $2 (DEB does), so without preinstall the
+        # default below would render as "vunknown" in the notification.
+        if [ -r /run/eneru/.old-version ]; then
+            OLD_VERSION=$(cat /run/eneru/.old-version 2>/dev/null || echo "")
+            rm -f /run/eneru/.old-version
+        fi
+        if [ -z "$OLD_VERSION" ]; then
+            # DEB postinst still gets the previous version in $2; if that's
+            # also missing (manual rpm -ivh --force, partial install, etc.)
+            # the daemon's classifier falls back to shutdown_marker.version
+            # / meta.last_seen_version, see lifecycle._resolve_old_version.
+            OLD_VERSION="${2:-unknown}"
+        fi
         # Resolve the stats directory the daemon will actually use.
         # Defaults to /var/lib/eneru but is overridable via
         # statistics.db_directory in /etc/ups-monitor/config.yaml
@@ -74,8 +87,14 @@ PY
 )
         MARKER_PATH="${STATS_DIR}/.upgrade_marker.json"
         mkdir -p "${STATS_DIR}" 2>/dev/null || true
-        printf '{"old_version":"%s"}\n' "${OLD_VERSION}" \
-            > "${MARKER_PATH}" 2>/dev/null || true
+        # JSON-encode via python3 so a version with shell-special or
+        # JSON-special chars (quotes, backslashes) can't produce a
+        # malformed marker. rpm/dpkg version policies don't permit "
+        # in practice, but the daemon's read_upgrade_marker degrades
+        # gracefully on JSONDecodeError to the _resolve_old_version
+        # fallback chain regardless.
+        python3 -c 'import json,sys; print(json.dumps({"old_version": sys.argv[1]}))' \
+            "${OLD_VERSION}" > "${MARKER_PATH}" 2>/dev/null || true
 
         echo "Restarting Eneru service..."
         systemctl restart eneru.service

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -57,6 +57,11 @@ if [ "$is_upgrade" = true ]; then
         # in /run/eneru/.old-version. Prefer that — RPM's postinstall
         # gets nothing useful in $2 (DEB does), so without preinstall the
         # default below would render as "vunknown" in the notification.
+        # Initialize explicitly so an environment-inherited OLD_VERSION
+        # (theoretically possible under manual rpm/dpkg invocations)
+        # can't slip past the empty-check below and render as a bogus
+        # version in the upgrade marker. (CodeRabbit P2 from PR #35.)
+        OLD_VERSION=""
         if [ -r /run/eneru/.old-version ]; then
             OLD_VERSION=$(cat /run/eneru/.old-version 2>/dev/null || echo "")
             rm -f /run/eneru/.old-version

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -16,6 +16,15 @@ set -e
 
 OLD_VERSION=""
 
+# Always wipe any stale /run/eneru/.old-version FIRST. Otherwise a
+# fresh install (or a reinstall after a previous failed transaction in
+# the same boot) could leave an old version string sitting on disk —
+# postinstall.sh would then read it and falsely classify the install
+# as an upgrade with the wrong "from" version. Tmpfs on /run normally
+# clears at boot but multiple transactions in one boot need explicit
+# cleanup. (CodeRabbit P1 from PR #35 review.)
+rm -f /run/eneru/.old-version 2>/dev/null || true
+
 # Prefer rpm when both are present (Fedora/RHEL with dpkg in containers
 # is rare; the reverse is more common and rpm correctly returns "package
 # not installed" when eneru came from a deb).
@@ -33,9 +42,10 @@ fi
 
 if [ -n "$OLD_VERSION" ]; then
     # /run/eneru is tmpfs on systemd hosts and is wiped on reboot, which
-    # is exactly the lifetime we want — the file lives just long enough
-    # for postinstall.sh to read it. No risk of stale data leaking into
-    # a future package upgrade.
+    # is the lifetime we want — the file lives just long enough for
+    # postinstall.sh to read it. We also wipe it explicitly above so
+    # cross-transaction stale data can't slip through within a single
+    # boot.
     mkdir -p /run/eneru 2>/dev/null || true
     printf '%s' "$OLD_VERSION" > /run/eneru/.old-version 2>/dev/null || true
 fi

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Pre-installation script for Eneru package
+# Called BEFORE the new package files are unpacked.
+#
+# RPM: $1 = 1 (install), $1 = 2 (upgrade)
+# DEB: $1 ∈ {install, upgrade, abort-upgrade}; $2 = new version when relevant
+#
+# Purpose (v5.2.1): capture the OUTGOING package version into a tmp file
+# so postinstall.sh can drop it into /var/lib/eneru/.upgrade_marker.json.
+#
+# DEB's postinst already gets the previous version via "$2", so this is
+# functionally needed only for RPM (rpm passes nothing useful in $2). We
+# query both package managers anyway — single code path, and lets DEB
+# benefit if the postinst arg ever stops being reliable.
+set -e
+
+OLD_VERSION=""
+
+# Prefer rpm when both are present (Fedora/RHEL with dpkg in containers
+# is rare; the reverse is more common and rpm correctly returns "package
+# not installed" when eneru came from a deb).
+if command -v rpm >/dev/null 2>&1 && rpm -q eneru >/dev/null 2>&1; then
+    OLD_VERSION=$(rpm -q eneru --queryformat '%{VERSION}' 2>/dev/null || true)
+elif command -v dpkg-query >/dev/null 2>&1 \
+        && dpkg-query -W -f='${Status}' eneru 2>/dev/null \
+        | grep -q "install ok installed"; then
+    # dpkg-query returns the full version (e.g. "5.2.0-1"); strip the
+    # debian revision so the displayed string matches the upstream
+    # version the user sees in the UI.
+    OLD_VERSION=$(dpkg-query -W -f='${Version}' eneru 2>/dev/null \
+                  | sed 's/-[^-]*$//' || true)
+fi
+
+if [ -n "$OLD_VERSION" ]; then
+    # /run/eneru is tmpfs on systemd hosts and is wiped on reboot, which
+    # is exactly the lifetime we want — the file lives just long enough
+    # for postinstall.sh to read it. No risk of stale data leaking into
+    # a future package upgrade.
+    mkdir -p /run/eneru 2>/dev/null || true
+    printf '%s' "$OLD_VERSION" > /run/eneru/.old-version 2>/dev/null || true
+fi
+
+exit 0

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -340,6 +340,32 @@ def _cmd_completion(args):
     sys.stdout.write(text)
 
 
+def _cmd_deliver_stop(args):
+    """v5.2.1 internal subcommand — invoked by the systemd-run timer
+    scheduled at the previous daemon's exit. Idempotent:
+
+    - If the lifecycle 'Service Stopped' row was already cancelled by
+      the next daemon's classifier (`status='cancelled'`,
+      `cancel_reason='superseded'`), we exit silently — the user gets
+      a single Restarted/Upgraded/Recovered notification.
+    - If the row is still `pending` (no replacement daemon came up),
+      we deliver via Apprise and mark the row `sent` — the user gets
+      a single Stopped notification.
+
+    The subcommand name is prefixed with `_` to mark it as internal;
+    it's intentionally absent from the `--help` listing.
+    """
+    from pathlib import Path
+    from eneru.deferred_delivery import deliver_pending_stop
+
+    config = _load_config(args)
+    sys.exit(deliver_pending_stop(
+        notification_id=int(args.notification_id),
+        db_path=Path(args.db_path),
+        config=config,
+    ))
+
+
 def _cmd_monitor(args):
     """Launch the TUI dashboard."""
     config = _load_config(args)
@@ -438,6 +464,17 @@ def main():
     comp_parser.add_argument("shell", choices=["bash", "zsh", "fish"],
                              help="Shell to emit completion for")
     comp_parser.set_defaults(func=_cmd_completion)
+
+    # --- _deliver-stop (internal, v5.2.1) ---
+    # Hidden from the --help listing on purpose: this is invoked by a
+    # systemd-run transient timer scheduled by the previous daemon's
+    # _cleanup_and_exit / _handle_signal, never by users directly.
+    ds_parser = subparsers.add_parser("_deliver-stop", help=argparse.SUPPRESS)
+    ds_parser.add_argument("--notification-id", required=True, type=int)
+    ds_parser.add_argument("--db-path", required=True)
+    ds_parser.add_argument("-c", "--config", required=True,
+                           help="Path to configuration file")
+    ds_parser.set_defaults(func=_cmd_deliver_stop)
 
     args = parser.parse_args()
 

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -345,6 +345,11 @@ class Config:
     notifications: NotificationsConfig = field(default_factory=NotificationsConfig)
     local_shutdown: LocalShutdownConfig = field(default_factory=LocalShutdownConfig)
     statistics: StatsConfig = field(default_factory=StatsConfig)
+    # v5.2.1: source path of the YAML this Config was loaded from.
+    # Used by deferred_delivery to spawn a systemd-run timer that
+    # re-loads the same config out-of-process. None when the Config
+    # was constructed in-memory (tests, programmatic usage).
+    config_path: Optional[str] = None
 
     # Notification types mapped to colors/severity
     NOTIFY_FAILURE: str = "failure"
@@ -452,6 +457,9 @@ class ConfigLoader:
 
         # Parse configuration sections
         config = cls._parse_config(data)
+        # v5.2.1: stash the source path so deferred_delivery can spawn
+        # a systemd-run timer that re-loads the same YAML out-of-process.
+        config.config_path = str(path)
         print(f"Configuration loaded from: {path}")
         return config
 

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -1,0 +1,255 @@
+"""Deferred delivery of the lifecycle 'Service Stopped' notification.
+
+v5.2 wanted ONE notification per lifecycle transition. v5.2.0 shipped
+the stop synchronously via ``flush(timeout=5)``, which beat the next
+daemon's classifier to the punch and produced two messages on every
+``systemctl restart``.
+
+v5.2.1's first attempt (defer the stop, let the next daemon's classifier
+cancel it) fixed restart but broke ``systemctl stop`` — without a next
+daemon, the row sat ``pending`` forever and the user never saw a
+notification.
+
+The fix here is option D from the v5.2.1 design discussion: at SIGTERM
+time the OLD daemon enqueues the stop row AND schedules a transient
+``systemd-run`` timer that re-invokes ``eneru _deliver-stop`` ~15 s
+later. The transient timer lives **outside** ``eneru.service``'s cgroup,
+so it survives our exit and doesn't gate ``systemctl restart`` on its
+own delivery (systemd starts the new daemon as soon as our cgroup
+empties — which happens immediately on our exit).
+
+When the timer fires:
+
+- If the new daemon already came up and its classifier cancelled the
+  pending row (via ``_emit_lifecycle_startup_notification``'s supersede
+  block, fired BEFORE the worker can deliver), the deliver helper sees
+  ``status != 'pending'`` and exits silently. The user gets a single
+  ``🔄 Restarted`` notification.
+- If no replacement came up (``systemctl stop``), the row is still
+  ``pending``. The deliver helper opens the per-UPS Apprise instance,
+  sends the row, and marks it ``sent``. The user gets a single
+  ``🛑 Service Stopped`` notification.
+
+Fallback path: when ``systemd-run`` isn't available (non-systemd
+containers, frozen-pristine sandboxes), the helper falls back to
+shipping the stop synchronously via the worker's Apprise instance.
+This loses the restart-coalescing benefit on those hosts but at least
+the user always sees a notification.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import sqlite3
+from pathlib import Path
+from typing import Callable, Optional
+
+
+# Window between OUR exit and the deferred-delivery timer firing.
+# Chosen to comfortably exceed systemd's `RestartSec=5` (eneru.service)
+# plus the new daemon's startup time (~2-5 s through `_initialize`)
+# plus a small margin. The new daemon's classifier-supersede pass
+# (monitor.py:_emit_lifecycle_startup_notification) is the cancel
+# mechanism that fires BEFORE the worker can deliver — as long as the
+# daemon comes up inside this window, the cancel beats us to the row
+# and the timer fire is a no-op.
+DEFAULT_DEFER_SECS = 15
+
+
+def _eneru_invocation_args() -> Optional[list]:
+    """Return ``[interpreter, script]`` args that re-invoke this eneru
+    installation in a fresh subprocess. The deb/rpm wrapper at
+    ``/opt/ups-monitor/eneru.py`` is preferred when present because it
+    sets ``sys.path`` explicitly (no PYTHONPATH dependency); otherwise
+    we use ``python -m eneru`` which works for pip / uv-venv installs.
+    """
+    deb_rpm_wrapper = "/opt/ups-monitor/eneru.py"
+    if os.path.exists(deb_rpm_wrapper):
+        return [sys.executable, deb_rpm_wrapper]
+    return [sys.executable, "-m", "eneru"]
+
+
+def schedule_deferred_stop_or_eager_send(
+    *,
+    notification_id: int,
+    db_path: Path,
+    config_path: Optional[str],
+    body: str,
+    notify_type: str,
+    worker,
+    log_fn: Callable[[str], None],
+    delay_secs: int = DEFAULT_DEFER_SECS,
+) -> None:
+    """Schedule a transient systemd-run timer to deliver the pending
+    stop notification ``delay_secs`` later, OR fall back to eager
+    Apprise delivery if systemd-run can't be used.
+
+    Caller is expected to have already enqueued the row via
+    ``_send_notification(..., category='lifecycle')`` and to pass that
+    row's id here.
+
+    ``log_fn`` is called with one short status line so the operator
+    can see in the log which path was taken.
+    """
+    if config_path:
+        invocation = _eneru_invocation_args()
+        cmd = [
+            "systemd-run",
+            f"--on-active={int(delay_secs)}s",
+            "--description=Eneru deferred stop-notification delivery (v5.2.1)",
+            f"--unit=eneru-deliver-stop-{notification_id}",
+            "--quiet",
+            "--collect",  # auto-cleanup the transient unit after exit
+            *invocation,
+            "_deliver-stop",
+            "--notification-id", str(notification_id),
+            "--db-path", str(db_path),
+            "--config", str(config_path),
+        ]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, timeout=5, check=False,
+            )
+            if result.returncode == 0:
+                log_fn(
+                    f"📅 Stop notification scheduled for delivery in "
+                    f"{delay_secs}s (will be superseded if a new "
+                    "daemon's classifier cancels the row first)"
+                )
+                return
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            log_fn(
+                f"⚠️ systemd-run rc={result.returncode}: "
+                f"{stderr[:200]} — falling back to eager delivery"
+            )
+        except FileNotFoundError:
+            log_fn(
+                "⚠️ systemd-run not on PATH — falling back to eager "
+                "delivery (restart-coalescing won't apply on this host)"
+            )
+        except subprocess.TimeoutExpired:
+            log_fn(
+                "⚠️ systemd-run timed out — falling back to eager delivery"
+            )
+    else:
+        log_fn(
+            "⚠️ No config_path on Config — falling back to eager "
+            "delivery (deferred path needs to re-load config out-of-process)"
+        )
+
+    _eager_send(
+        notification_id=notification_id,
+        db_path=db_path,
+        body=body,
+        notify_type=notify_type,
+        worker=worker,
+        log_fn=log_fn,
+    )
+
+
+def _eager_send(
+    *,
+    notification_id: int,
+    db_path: Path,
+    body: str,
+    notify_type: str,
+    worker,
+    log_fn: Callable[[str], None],
+) -> None:
+    """Fallback: ship the stop notification synchronously via the
+    worker's Apprise instance, then mark the row sent."""
+    if worker is None:
+        log_fn("⚠️ No worker — stop notification will stay pending")
+        return
+    try:
+        # _send_via_apprise is the worker's private synchronous-send
+        # method (see notifications.py); we reach in deliberately
+        # rather than re-instantiating an Apprise object because the
+        # worker has already validated the URLs at startup.
+        success = worker._send_via_apprise(body, notify_type)
+    except Exception as e:  # pragma: no cover -- defensive
+        log_fn(f"⚠️ Eager-send via Apprise raised: {e}")
+        return
+    if not success:
+        log_fn(
+            "⚠️ Eager-send via Apprise returned False (network down?) "
+            "— stop notification stays pending for the next start"
+        )
+        return
+    try:
+        from eneru.stats import StatsStore
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            store.mark_notification_sent(notification_id)
+        finally:
+            store.close()
+    except (sqlite3.Error, OSError, TypeError, ValueError) as e:
+        # TypeError / ValueError catch the case where db_path isn't a
+        # real path (mock objects in tests, malformed config). The
+        # caller still got their Apprise delivery; only the row's
+        # status didn't update. Worst case: the same row gets re-tried
+        # by the next start, harmless duplicate.
+        log_fn(
+            f"⚠️ Eager-send shipped via Apprise but mark_sent failed: "
+            f"{e} (row stays pending; harmless duplicate possible)"
+        )
+
+
+def deliver_pending_stop(
+    *,
+    notification_id: int,
+    db_path: Path,
+    config,
+) -> int:
+    """Invoked by the ``eneru _deliver-stop`` CLI subcommand from
+    inside the systemd-run transient unit. Idempotent: if the row was
+    already cancelled (next daemon's classifier superseded it) or
+    already sent (somehow), this returns 0 without delivering.
+
+    Returns a process exit code: 0 always (success or skipped); the
+    transient unit doesn't have anyone to report failures to anyway.
+    """
+    from eneru.notifications import NotificationWorker
+    from eneru.stats import StatsStore
+
+    if not db_path.exists():
+        return 0  # DB gone (uninstall? cleanup?). Nothing to do.
+
+    store = StatsStore(db_path)
+    try:
+        store.open()
+        row = store._conn.execute(
+            "SELECT body, notify_type, status FROM notifications "
+            "WHERE id = ?",
+            (notification_id,),
+        ).fetchone()
+        if row is None:
+            return 0  # row purged
+        body, notify_type, status = row
+        if status != "pending":
+            return 0  # superseded or already sent — skip
+
+        worker = NotificationWorker(config)
+        # start() initializes the Apprise instance from config.urls
+        # and validates each URL. It also spins up the worker thread,
+        # which we don't strictly need here, but the cost is
+        # negligible for a one-shot delivery.
+        if not worker.start():
+            return 0  # apprise unavailable / no urls / etc.
+        try:
+            success = worker._send_via_apprise(body, notify_type)
+            if success:
+                store.mark_notification_sent(notification_id)
+        finally:
+            worker.stop()
+    except (sqlite3.Error, OSError):
+        return 0  # best-effort
+    finally:
+        try:
+            store.close()
+        except (sqlite3.Error, OSError):
+            pass
+    return 0

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -43,6 +43,7 @@ import os
 import subprocess
 import sys
 import sqlite3
+import time
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -110,12 +111,21 @@ def _detect_systemd_stop_intent() -> bool:
     restart). When True, the OLD daemon ships the lifecycle stop
     notification eagerly because no replacement is coming.
 
-    Implementation: queries ``systemctl show -p Job eneru.service``.
-    The output is one of ``Job=`` (no job queued — usually a crash
-    or kill) or ``Job=N:type`` where ``type`` is ``stop`` /
-    ``restart`` / ``start`` / ``reload`` / etc. systemd queues the
-    job BEFORE sending SIGTERM, so by the time we read this we
-    should see the pending action.
+    Implementation: queries ``systemctl list-jobs --no-legend``,
+    NOT ``systemctl show -p Job``. The latter returns only the job
+    DBus path / numeric id (``Job=12345``) — it does NOT carry the
+    job's TYPE, so an earlier rc parsed ``Job=N:type`` and always
+    saw False (which silently regressed every `systemctl stop` to
+    the 15-second defensive timer; caught in PR #35 review).
+
+    ``list-jobs`` output (with ``--no-legend`` suppressing header
+    and footer) is one line per active job:
+
+        12345 eneru.service stop running
+
+    Columns: JobID, Unit, Type, State. We match by exact unit name
+    and treat the third field as the job type. ``LANG=C`` ensures
+    the column header isn't translated on non-English locales.
 
     Returns False on any uncertainty (query failed, systemd not
     available, racing the queue, unexpected output) — the caller
@@ -123,22 +133,23 @@ def _detect_systemd_stop_intent() -> bool:
     """
     try:
         result = subprocess.run(
-            ["systemctl", "show", "-p", "Job", "eneru.service"],
+            ["systemctl", "list-jobs", "--no-legend"],
             capture_output=True, timeout=2, check=False,
+            env={**os.environ, "LANG": "C", "LC_ALL": "C"},
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return False
     if result.returncode != 0:
         return False
-    line = result.stdout.decode("utf-8", errors="replace").strip()
-    # Format: "Job=" or "Job=N:type"
-    if "=" not in line:
-        return False
-    value = line.split("=", 1)[1].strip()
-    if not value or ":" not in value:
-        return False  # no job queued, or unexpected format
-    job_type = value.split(":", 1)[1].strip().lower()
-    return job_type == "stop"
+    output = result.stdout.decode("utf-8", errors="replace")
+    for line in output.splitlines():
+        parts = line.split()
+        # Expect at least: JobID Unit Type State
+        if len(parts) < 4:
+            continue
+        if parts[1] == "eneru.service":
+            return parts[2].lower() == "stop"
+    return False
 
 
 def schedule_deferred_stop_or_eager_send(
@@ -328,6 +339,7 @@ def deliver_pending_stop(
     store = StatsStore(db_path)
     try:
         store.open()
+        # Read the body so we know what to ship if we win the claim.
         row = store._conn.execute(
             "SELECT body, notify_type, status FROM notifications "
             "WHERE id = ?",
@@ -337,7 +349,27 @@ def deliver_pending_stop(
             return 0  # row purged
         body, notify_type, status = row
         if status != "pending":
-            return 0  # superseded or already sent — skip
+            return 0  # already cancelled (superseded) or already sent
+
+        # ATOMIC CLAIM (CodeRabbit P1): the previous version did a
+        # SELECT pending → send → mark_sent sequence with no claim
+        # step. If the next daemon's classifier cancelled the row
+        # between the SELECT and the send, we'd ship the stale stop
+        # AND mark_notification_sent would overwrite the row's
+        # `cancelled` status back to `sent` — reopening the
+        # duplicate-lifecycle race the v5.2.1 fix exists to close.
+        # Claim by transitioning pending→sent in a single statement;
+        # only proceed with delivery if we actually won the row.
+        with store._db_lock:
+            cur = store._conn.execute(
+                "UPDATE notifications SET status='sent', sent_at=?, "
+                "attempts=attempts+1 WHERE id=? AND status='pending'",
+                (int(time.time()), notification_id),
+            )
+            store._conn.commit()
+            won = cur.rowcount > 0
+        if not won:
+            return 0  # raced with the classifier; let it win
 
         worker = NotificationWorker(config)
         # start() initializes the Apprise instance from config.urls
@@ -345,11 +377,34 @@ def deliver_pending_stop(
         # which we don't strictly need here, but the cost is
         # negligible for a one-shot delivery.
         if not worker.start():
-            return 0  # apprise unavailable / no urls / etc.
+            # apprise unavailable / no urls — revert the claim so a
+            # future start can retry instead of leaving a row marked
+            # `sent` with no actual delivery.
+            try:
+                with store._db_lock:
+                    store._conn.execute(
+                        "UPDATE notifications SET status='pending', "
+                        "sent_at=NULL WHERE id=?",
+                        (notification_id,),
+                    )
+                    store._conn.commit()
+            except sqlite3.Error:
+                pass
+            return 0
         try:
-            success = worker._send_via_apprise(body, notify_type)
-            if success:
-                store.mark_notification_sent(notification_id)
+            if not worker._send_via_apprise(body, notify_type):
+                # Apprise rejected — revert claim to give the next
+                # daemon a chance to retry.
+                try:
+                    with store._db_lock:
+                        store._conn.execute(
+                            "UPDATE notifications SET status='pending', "
+                            "sent_at=NULL WHERE id=?",
+                            (notification_id,),
+                        )
+                        store._conn.commit()
+                except sqlite3.Error:
+                    pass
         finally:
             worker.stop()
     except (sqlite3.Error, OSError):

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -71,6 +71,76 @@ def _eneru_invocation_args() -> Optional[list]:
     return [sys.executable, "-m", "eneru"]
 
 
+# ============================================================================
+# systemd intent detection — keep the defer-then-ship complexity OPT-IN.
+#
+# ROADMAP NOTE (K8s / Docker support):
+# The whole defer+timer dance only makes sense when there's a service
+# manager that will or won't restart us — i.e., systemd. In container
+# contexts (Docker, K8s pods) the container runtime decides the
+# replacement at a different layer (RestartPolicy / ReplicaSet), there
+# is no "Job=restart" concept the daemon can introspect, and there's no
+# `systemd-run` to schedule a deferred timer against. So the right
+# behavior in container contexts is plain **eager send** — ship the
+# stop notification synchronously and exit, same as v5.2.0 did
+# unconditionally. When K8s / Docker support lands, this module's two
+# entry points (`schedule_deferred_stop_or_eager_send` and
+# `deliver_pending_stop`) can stay as-is — the systemd-specific paths
+# are gated by `_running_under_systemd()` below, so non-systemd
+# environments naturally take the eager path with no code changes.
+# Anything more sophisticated for K8s (e.g., a sidecar that delivers
+# the row when the pod terminates) is a future-release concern, not
+# a v5.2.1 one.
+# ============================================================================
+
+def _running_under_systemd() -> bool:
+    """True iff this process is being managed by systemd as a unit.
+
+    Checked via the ``INVOCATION_ID`` env var that systemd sets for
+    every service it launches. False in containers/K8s pods (no
+    systemd), under foreground manual invocation (``eneru run``
+    from a shell), and under most CI test environments.
+    """
+    return bool(os.environ.get("INVOCATION_ID"))
+
+
+def _detect_systemd_stop_intent() -> bool:
+    """True iff systemd is in the middle of a ``stop`` job for
+    ``eneru.service`` (user ran ``systemctl stop eneru``, NOT a
+    restart). When True, the OLD daemon ships the lifecycle stop
+    notification eagerly because no replacement is coming.
+
+    Implementation: queries ``systemctl show -p Job eneru.service``.
+    The output is one of ``Job=`` (no job queued — usually a crash
+    or kill) or ``Job=N:type`` where ``type`` is ``stop`` /
+    ``restart`` / ``start`` / ``reload`` / etc. systemd queues the
+    job BEFORE sending SIGTERM, so by the time we read this we
+    should see the pending action.
+
+    Returns False on any uncertainty (query failed, systemd not
+    available, racing the queue, unexpected output) — the caller
+    falls through to the defensive systemd-run timer in that case.
+    """
+    try:
+        result = subprocess.run(
+            ["systemctl", "show", "-p", "Job", "eneru.service"],
+            capture_output=True, timeout=2, check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+    if result.returncode != 0:
+        return False
+    line = result.stdout.decode("utf-8", errors="replace").strip()
+    # Format: "Job=" or "Job=N:type"
+    if "=" not in line:
+        return False
+    value = line.split("=", 1)[1].strip()
+    if not value or ":" not in value:
+        return False  # no job queued, or unexpected format
+    job_type = value.split(":", 1)[1].strip().lower()
+    return job_type == "stop"
+
+
 def schedule_deferred_stop_or_eager_send(
     *,
     notification_id: int,
@@ -93,6 +163,43 @@ def schedule_deferred_stop_or_eager_send(
     ``log_fn`` is called with one short status line so the operator
     can see in the log which path was taken.
     """
+    # v5.2.1: short-circuit to eager send in two cases — both produce
+    # an INSTANT 🛑 Stopped notification with no 15-second wait.
+    #
+    # 1. Not running under systemd (containers, K8s pods, manual
+    #    `eneru run` from a shell, CI tests). The defer-then-ship
+    #    mechanism only makes sense when there's a service manager
+    #    that will or won't restart us. See the ROADMAP NOTE above.
+    if not _running_under_systemd():
+        log_fn(
+            "📤 Not running under systemd — shipping stop notification "
+            "eagerly via Apprise"
+        )
+        _eager_send(
+            notification_id=notification_id, db_path=db_path,
+            body=body, notify_type=notify_type,
+            worker=worker, log_fn=log_fn,
+        )
+        return
+
+    # 2. systemd has queued a `stop` job for eneru.service — i.e. user
+    #    ran `systemctl stop eneru` (NOT a restart). No replacement is
+    #    coming, so the deferred-then-ship dance is pure latency: ship
+    #    eagerly. For Job=restart / Job=start (and unknown / no job),
+    #    fall through to the timer path so the cancel-on-startup
+    #    mechanism gets a chance to win.
+    if _detect_systemd_stop_intent():
+        log_fn(
+            "📤 systemctl stop detected — shipping stop notification "
+            "eagerly (no replacement daemon coming)"
+        )
+        _eager_send(
+            notification_id=notification_id, db_path=db_path,
+            body=body, notify_type=notify_type,
+            worker=worker, log_fn=log_fn,
+        )
+        return
+
     if config_path:
         invocation = _eneru_invocation_args()
         cmd = [

--- a/src/eneru/lifecycle.py
+++ b/src/eneru/lifecycle.py
@@ -125,6 +125,38 @@ def delete_upgrade_marker(directory: Path) -> None:
         pass
 
 
+def _resolve_old_version(*, upgrade_marker: Optional[dict],
+                         shutdown_marker: Optional[dict],
+                         last_seen_version: Optional[str]) -> str:
+    """Resolve the previous-version string for an Upgraded notification.
+
+    Primary source is ``upgrade_marker.old_version``, populated by
+    ``packaging/scripts/preinstall.sh`` via ``rpm -q eneru`` /
+    ``dpkg-query -W eneru`` BEFORE the new package files unpack.
+
+    The fallback chain handles edge cases where preinstall didn't fire
+    (manual ``rpm -ivh --force``, partial install, container-build paths
+    that bypass scriptlets) and the marker landed with the literal
+    ``"unknown"`` sentinel from ``postinstall.sh``'s pre-5.2.1 default:
+
+    1. ``upgrade_marker.old_version`` (if not ``unknown``/``?``/empty)
+    2. ``shutdown_marker.version`` (always populated on graceful exit)
+    3. ``last_seen_version`` (``meta.last_seen_version`` in the stats DB)
+    4. literal ``"?"`` — only if every source is missing
+    """
+    candidates = []
+    if upgrade_marker:
+        candidates.append(upgrade_marker.get("old_version"))
+    if shutdown_marker:
+        candidates.append(shutdown_marker.get("version"))
+    candidates.append(last_seen_version)
+    for raw in candidates:
+        candidate = str(raw or "").strip()
+        if candidate and candidate.lower() not in ("unknown", "?"):
+            return candidate
+    return "?"
+
+
 def classify_startup(*, current_version: str,
                      shutdown_marker: Optional[dict],
                      upgrade_marker: Optional[dict],
@@ -150,7 +182,11 @@ def classify_startup(*, current_version: str,
 
     # 1) Postinstall-set marker: deb/rpm upgrade. Authoritative.
     if upgrade_marker:
-        old = str(upgrade_marker.get("old_version", "?"))
+        old = _resolve_old_version(
+            upgrade_marker=upgrade_marker,
+            shutdown_marker=shutdown_marker,
+            last_seen_version=last_seen_version,
+        )
         new = str(upgrade_marker.get("new_version", current_version))
         return (
             f"📦 **Eneru Upgraded** v{old} → v{new}\n"

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -5,6 +5,7 @@ Monitors UPS status via NUT and triggers configurable shutdown sequences.
 https://github.com/m4r1k/Eneru
 """
 
+import sqlite3
 import sys
 import os
 import time
@@ -308,6 +309,29 @@ class UPSGroupMonitor(
                 f"{self._stats_db_path}: {e}. Notifications will not "
                 "persist across restarts."
             )
+
+        # v5.2.1: cancel any pending lifecycle row left by the previous
+        # instance BEFORE the worker can deliver it. The supersede block
+        # in _emit_lifecycle_startup_notification (lines ~405-407) is
+        # the canonical location, but it runs AFTER worker.start() +
+        # register_store() — opening a delivery-race window where the
+        # worker could ship the deferred 'Service Stopped' from the
+        # prior daemon before the classifier has a chance to cancel it
+        # (Cubic P2). Doing the cancel here too is idempotent: by the
+        # time the lifecycle classifier runs, there's nothing left.
+        # Best-effort: a transient sqlite error here just means the
+        # late cancel still has work to do — same outcome as v5.2.0
+        # in that worst case.
+        if self._stats_store._conn is not None:
+            try:
+                for row in self._stats_store.find_pending_by_category(
+                        "lifecycle"):
+                    self._stats_store.cancel_notification(
+                        row[0], "superseded")
+            except (sqlite3.Error, OSError) as e:
+                self._log_message(
+                    f"⚠️ WARNING: pre-worker lifecycle sweep failed: {e}"
+                )
 
         if self._notification_worker is not None:
             # Coordinator mode: register our store with the shared worker.

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -21,6 +21,7 @@ from eneru.state import MonitorState
 from eneru.logger import UPSLogger
 from eneru.notifications import NotificationWorker, APPRISE_AVAILABLE
 from eneru.stats import StatsStore, StatsWriter
+from eneru.deferred_delivery import schedule_deferred_stop_or_eager_send
 from eneru.lifecycle import (
     EVENT_TYPE_DAEMON_START,
     REASON_FATAL,
@@ -536,7 +537,7 @@ class UPSGroupMonitor(
         """
         del blocking  # see docstring
         if not self._notification_worker:
-            return
+            return None
 
         # Prefix notification body with UPS name in multi-UPS mode.
         prefixed_body = f"{self._log_prefix}{body}" if self._log_prefix else body
@@ -544,7 +545,7 @@ class UPSGroupMonitor(
         # Escape @ symbols to prevent Discord mentions (e.g., UPS@192.168.1.1)
         escaped_body = prefixed_body.replace("@", "@\u200B")  # Zero-width space after @
 
-        self._notification_worker.send(
+        return self._notification_worker.send(
             body=escaped_body,
             notify_type=notify_type,
             category=category,
@@ -1005,29 +1006,56 @@ class UPSGroupMonitor(
         # SIGTERM lands here on a deb/rpm upgrade. The next daemon will
         # emit a single "📦 Upgraded vX → vY" message that supersedes
         # this stop, so suppress the stop entirely — saves a write and
-        # avoids the prior-instance "Stopped" leaking through if the
-        # next daemon's classifier runs while the row is still pending.
+        # avoids the prior-instance "Stopped" leaking through.
         upgrade_in_progress = read_upgrade_marker(stats_dir) is not None
 
         # Drain anything ALREADY in the queue (emergency-shutdown summary,
-        # voltage events, etc.) BEFORE enqueueing the lifecycle stop. The
-        # order matters: the lifecycle stop is speculative — if a new
-        # daemon comes back within the restart-downtime threshold, its
-        # classifier emits Restarted/Upgraded/Recovered and cancels the
-        # pending stop via cancel_notification. By enqueueing AFTER the
-        # flush, we guarantee the row stays `pending` in SQLite (the
-        # worker is stopped, can't deliver) and is therefore cancellable.
-        # If the daemon never comes back, the next daemon to start
-        # (whenever that is) will cancel or supersede the pending row.
+        # voltage events, etc.) BEFORE enqueueing the lifecycle stop —
+        # so the worker doesn't pick up our deferred-stop row and ship
+        # it eagerly, defeating the deferred-delivery mechanism below.
+        # After this drain + stop, the worker is gone; the row we
+        # enqueue stays `pending` in SQLite and can be cancelled by
+        # either the next daemon's classifier (within the
+        # `schedule_deferred_stop_or_eager_send` window) or delivered
+        # by the systemd-run timer if no replacement comes up.
+        body = "🛑 **Eneru Service Stopped**\nMonitoring is now inactive."
+        notify_type = self.config.NOTIFY_WARNING
+
+        # Order matters: flush + stop FIRST, then enqueue. If we enqueued
+        # before stop(), the worker could pick the row up on its next
+        # iteration and ship it eagerly — defeating the deferred-delivery
+        # mechanism. After stop(), the worker thread is dead but
+        # `_send_notification` still writes the row to SQLite (the
+        # enqueue is a synchronous DB insert; only delivery requires the
+        # worker thread).
         if self._notification_worker:
             self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
 
+        notif_id = None
         if not upgrade_in_progress:
-            self._send_notification(
-                "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
-                self.config.NOTIFY_WARNING,
-                category="lifecycle",
+            notif_id = self._send_notification(
+                body, notify_type, category="lifecycle",
+            )
+
+        # Schedule deferred delivery via systemd-run (or fall back to
+        # eager Apprise send if systemd-run is unavailable). The timer
+        # fires ~15 s after our exit; if the new daemon's classifier
+        # cancels the row before then (single-UPS:
+        # `_emit_lifecycle_startup_notification`; multi-UPS:
+        # `_cancel_prev_pending_lifecycle_rows`), the timer is a no-op
+        # and the user sees a single Restarted/Upgraded/Recovered. If
+        # no replacement starts (true `systemctl stop`), the timer
+        # delivers the stop and the user sees a single Stopped.
+        if notif_id is not None and self._stats_store._conn is not None:
+            schedule_deferred_stop_or_eager_send(
+                notification_id=notif_id,
+                db_path=Path(self._stats_db_path),
+                config_path=getattr(self.config, "config_path", None),
+                body=body,
+                notify_type=notify_type,
+                worker=self._notification_worker,
+                log_fn=self._log_message,
             )
 
         self._stop_stats()

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -1047,16 +1047,34 @@ class UPSGroupMonitor(
         # and the user sees a single Restarted/Upgraded/Recovered. If
         # no replacement starts (true `systemctl stop`), the timer
         # delivers the stop and the user sees a single Stopped.
-        if notif_id is not None and self._stats_store._conn is not None:
-            schedule_deferred_stop_or_eager_send(
-                notification_id=notif_id,
-                db_path=Path(self._stats_db_path),
-                config_path=getattr(self.config, "config_path", None),
-                body=body,
-                notify_type=notify_type,
-                worker=self._notification_worker,
-                log_fn=self._log_message,
-            )
+        if not upgrade_in_progress:
+            if notif_id is not None and self._stats_store._conn is not None:
+                # Normal path: row was enqueued in SQLite, hand off to
+                # the deferred-delivery scheduler.
+                schedule_deferred_stop_or_eager_send(
+                    notification_id=notif_id,
+                    db_path=Path(self._stats_db_path),
+                    config_path=getattr(self.config, "config_path", None),
+                    body=body,
+                    notify_type=notify_type,
+                    worker=self._notification_worker,
+                    log_fn=self._log_message,
+                )
+            elif self._notification_worker is not None:
+                # CodeRabbit P1: stats DB open() failed (per the warning
+                # logged in _initialize_notifications), so notif_id is
+                # None and the row never landed in SQLite. Without this
+                # branch the lifecycle stop would be silently dropped on
+                # every graceful exit. Ship eagerly via Apprise so the
+                # user still gets a notification (loses restart-
+                # coalescing in this degraded case, but the alternative
+                # is no notification at all).
+                try:
+                    self._notification_worker._send_via_apprise(
+                        body, notify_type,
+                    )
+                except Exception:
+                    pass  # best-effort; nothing more we can do here
 
         self._stop_stats()
 

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -976,22 +976,36 @@ class UPSGroupMonitor(
         except Exception:
             pass
 
-        # Send notification (non-blocking - fire and forget)
-        self._send_notification(
-            "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
-            self.config.NOTIFY_WARNING,
-            category="lifecycle",
-        )
+        # v5.2.1: postinstall.sh drops the upgrade marker BEFORE invoking
+        # `systemctl restart`, so the marker is on disk by the time
+        # SIGTERM lands here on a deb/rpm upgrade. The next daemon will
+        # emit a single "📦 Upgraded vX → vY" message that supersedes
+        # this stop, so suppress the stop entirely — saves a write and
+        # avoids the prior-instance "Stopped" leaking through if the
+        # next daemon's classifier runs while the row is still pending.
+        upgrade_in_progress = read_upgrade_marker(stats_dir) is not None
 
+        # Drain anything ALREADY in the queue (emergency-shutdown summary,
+        # voltage events, etc.) BEFORE enqueueing the lifecycle stop. The
+        # order matters: the lifecycle stop is speculative — if a new
+        # daemon comes back within the restart-downtime threshold, its
+        # classifier emits Restarted/Upgraded/Recovered and cancels the
+        # pending stop via cancel_notification. By enqueueing AFTER the
+        # flush, we guarantee the row stays `pending` in SQLite (the
+        # worker is stopped, can't deliver) and is therefore cancellable.
+        # If the daemon never comes back, the next daemon to start
+        # (whenever that is) will cancel or supersede the pending row.
         if self._notification_worker:
-            # Closes the SIGTERM race that produced the v5.1 "Stopping
-            # notification worker with 1 message(s) pending" warning:
-            # we now WAIT for the worker to actually deliver the
-            # 'Stopped' notification before joining its thread.
-            # Returns as soon as pending hits 0; bounded at 5s so a
-            # systemctl stop doesn't hang on an unreachable endpoint.
             self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
+
+        if not upgrade_in_progress:
+            self._send_notification(
+                "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
+                self.config.NOTIFY_WARNING,
+                category="lifecycle",
+            )
+
         self._stop_stats()
 
         # Slice 3: drop the shutdown marker so the next start can

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -131,6 +131,22 @@ class MultiUPSCoordinator:
             upgrade_marker=upgrade_marker,
             last_seen_version=last_seen,
         )
+        # v5.2.1: sweep each per-UPS store for any pending lifecycle row
+        # left over from the previous instance (the deferred 'Service
+        # Stopped' from _handle_signal) and cancel it BEFORE the new
+        # lifecycle send. The single-UPS path does this inside
+        # _emit_lifecycle_startup_notification (monitor.py) but that
+        # function early-returns in coordinator mode without reaching
+        # the cancel block, so without this sweep multi-UPS users still
+        # see two notifications on every restart/upgrade. Order matters:
+        # the new lifecycle send below goes to the worker's in-memory
+        # buffer (no stores are registered yet at this point in startup);
+        # the per-UPS monitors register their stores in _start_monitors,
+        # which drains the buffer into them as new pending rows. So the
+        # cancel-then-send order here is safe — the cancel only sees
+        # rows already on disk from the previous process.
+        self._cancel_prev_pending_lifecycle_rows(stats_dir)
+
         if self._notification_worker:
             self._notification_worker.send(
                 body=body, notify_type=notify_type, category="lifecycle",
@@ -142,6 +158,41 @@ class MultiUPSCoordinator:
         # (which still runs in coordinator mode for the meta side).
         delete_shutdown_marker(stats_dir)
         delete_upgrade_marker(stats_dir)
+
+    def _cancel_prev_pending_lifecycle_rows(self, stats_dir: Path) -> None:
+        """Cancel any pending lifecycle row left in each per-UPS store
+        from the previous process instance. Mirrors the cancel block in
+        ``UPSGroupMonitor._emit_lifecycle_startup_notification`` so the
+        coordinator path produces exactly one lifecycle notification per
+        restart/upgrade — same contract as single-UPS mode.
+
+        Best-effort by design: any sqlite or filesystem error during the
+        sweep is swallowed (a transient failure must not break startup;
+        the worst case is the user sees a stop + start pair on this one
+        restart, which is the v5.2.0 bug — not worse than the prior
+        state). Stores that don't exist yet (first-ever start) are
+        silently skipped.
+        """
+        for group in self.config.ups_groups:
+            sanitized = (group.ups.name
+                         .replace("@", "-")
+                         .replace(":", "-")
+                         .replace("/", "-"))
+            db_path = stats_dir / f"{sanitized}.db"
+            if not db_path.exists():
+                continue
+            store = StatsStore(db_path)
+            try:
+                store.open()
+                for row in store.find_pending_by_category("lifecycle"):
+                    store.cancel_notification(row[0], "superseded")
+            except Exception:
+                pass
+            finally:
+                try:
+                    store.close()
+                except Exception:
+                    pass
 
     def _read_last_seen_version_from_first_group(self, stats_dir):
         """Read meta.last_seen_version from the first group's stats DB
@@ -427,13 +478,6 @@ class MultiUPSCoordinator:
         """Handle SIGTERM/SIGINT for clean shutdown."""
         self._log("🛑 Service stopped by signal (SIGTERM/SIGINT). Monitoring is inactive.")
 
-        if self._notification_worker:
-            self._notification_worker.send(
-                "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
-                "warning",
-                category="lifecycle",
-            )
-
         self._stop_event.set()
 
         # Wait briefly for monitor + evaluator threads to finish
@@ -442,12 +486,26 @@ class MultiUPSCoordinator:
         for thread in self._evaluator_threads:
             thread.join(timeout=5)
 
+        # v5.2.1: see UPSGroupMonitor._cleanup_and_exit for the rationale.
+        # The lifecycle stop notification is enqueued AFTER the worker is
+        # drained and stopped, so the row stays `pending` in SQLite for
+        # the next daemon's classifier to cancel via cancel_notification
+        # (single message per restart/upgrade/reinstall transition).
+        # Skip the enqueue entirely when an upgrade is in flight — the
+        # next daemon's "📦 Upgraded" classification supersedes it.
+        stats_dir = Path(self.config.statistics.db_directory)
+        upgrade_in_progress = read_upgrade_marker(stats_dir) is not None
+
         if self._notification_worker:
-            # Same SIGTERM-race fix as in monitor.py:_cleanup_and_exit:
-            # drain the queue before joining the worker thread so the
-            # final 'Service Stopped' notification actually ships.
             self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
+
+        if self._notification_worker and not upgrade_in_progress:
+            self._notification_worker.send(
+                "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
+                "warning",
+                category="lifecycle",
+            )
 
         # Slice 3: tag this exit so the next start can emit "🔄 Restarted"
         # if it comes back within RESTART_DOWNTIME_THRESHOLD_SECS, else
@@ -459,7 +517,6 @@ class MultiUPSCoordinator:
         # service down should preserve "we shut ourselves down for a
         # reason" so the next start emits "📊 Recovered" rather than
         # "🔄 Restarted".
-        stats_dir = Path(self.config.statistics.db_directory)
         existing = read_shutdown_marker(stats_dir)
         if not (existing
                 and existing.get("reason") == REASON_SEQUENCE_COMPLETE):

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -6,6 +6,7 @@ owns the shared resources (logger, notification worker) plus local-shutdown
 arbitration with defense-in-depth (in-memory lock + filesystem flag).
 """
 
+import sqlite3
 import sys
 import time
 import signal
@@ -186,13 +187,22 @@ class MultiUPSCoordinator:
                 store.open()
                 for row in store.find_pending_by_category("lifecycle"):
                     store.cancel_notification(row[0], "superseded")
-            except Exception:
-                pass
+            except (sqlite3.Error, OSError) as e:
+                # Visible-failure (CodeRabbit + Cubic P2): a silent
+                # except: pass made the duplicate-lifecycle symptom
+                # opaque if SQLite or the filesystem misbehaved during
+                # the sweep. One log line keeps it best-effort while
+                # giving the operator a thread to pull on.
+                self._log(
+                    f"⚠️ Lifecycle sweep skipped for {db_path.name}: {e}"
+                )
             finally:
                 try:
                     store.close()
-                except Exception:
-                    pass
+                except (sqlite3.Error, OSError) as e:
+                    self._log(
+                        f"⚠️ Failed to close stats DB {db_path.name}: {e}"
+                    )
 
     def _read_last_seen_version_from_first_group(self, stats_dir):
         """Read meta.last_seen_version from the first group's stats DB

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -20,6 +20,7 @@ from eneru.config import Config
 from eneru.logger import UPSLogger
 from eneru.notifications import APPRISE_AVAILABLE, NotificationWorker
 from eneru.monitor import UPSGroupMonitor
+from eneru.deferred_delivery import schedule_deferred_stop_or_eager_send
 from eneru.redundancy import RedundancyGroupEvaluator, RedundancyGroupExecutor
 from eneru.stats import StatsStore
 from eneru.lifecycle import (
@@ -496,25 +497,53 @@ class MultiUPSCoordinator:
         for thread in self._evaluator_threads:
             thread.join(timeout=5)
 
-        # v5.2.1: see UPSGroupMonitor._cleanup_and_exit for the rationale.
-        # The lifecycle stop notification is enqueued AFTER the worker is
-        # drained and stopped, so the row stays `pending` in SQLite for
-        # the next daemon's classifier to cancel via cancel_notification
-        # (single message per restart/upgrade/reinstall transition).
+        # v5.2.1: see UPSGroupMonitor._cleanup_and_exit for the full
+        # rationale. Drain pending non-lifecycle rows first, then enqueue
+        # the speculative lifecycle stop and stop the worker, then hand
+        # off to the systemd-run timer (or eager fallback) for delivery.
         # Skip the enqueue entirely when an upgrade is in flight — the
-        # next daemon's "📦 Upgraded" classification supersedes it.
+        # next daemon's "📦 Upgraded" classification covers both ends.
         stats_dir = Path(self.config.statistics.db_directory)
         upgrade_in_progress = read_upgrade_marker(stats_dir) is not None
 
-        if self._notification_worker:
+        body = "🛑 **Eneru Service Stopped**\nMonitoring is now inactive."
+        notify_type = "warning"
+
+        # Order matters: flush + stop the worker FIRST, then enqueue —
+        # see UPSGroupMonitor._cleanup_and_exit for the rationale.
+        # Capturing first_store BEFORE stop() because stop() doesn't
+        # actually clear the registered stores list, but doing it here
+        # is symmetric with how we'll use it for the deferred handoff.
+        first_store = None
+        if self._notification_worker is not None:
+            with self._notification_worker._stores_lock:
+                first_store = (self._notification_worker._stores[0]
+                               if self._notification_worker._stores else None)
             self._notification_worker.flush(timeout=5)
             self._notification_worker.stop()
 
+        notif_id = None
         if self._notification_worker and not upgrade_in_progress:
-            self._notification_worker.send(
-                "🛑 **Eneru Service Stopped**\nMonitoring is now inactive.",
-                "warning",
+            notif_id = self._notification_worker.send(
+                body=body,
+                notify_type=notify_type,
                 category="lifecycle",
+            )
+
+        # Schedule deferred delivery against the FIRST registered store
+        # (which is what worker.send() above wrote to). The systemd-run
+        # timer fires ~15 s after our exit; if a new coordinator's
+        # `_cancel_prev_pending_lifecycle_rows` cancels the row first,
+        # the timer is a no-op and the user sees a single Restarted.
+        if notif_id is not None and first_store is not None:
+            schedule_deferred_stop_or_eager_send(
+                notification_id=notif_id,
+                db_path=first_store.db_path,
+                config_path=getattr(self.config, "config_path", None),
+                body=body,
+                notify_type=notify_type,
+                worker=self._notification_worker,
+                log_fn=self._log,
             )
 
         # Slice 3: tag this exit so the next start can emit "🔄 Restarted"

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -535,16 +535,28 @@ class MultiUPSCoordinator:
         # timer fires ~15 s after our exit; if a new coordinator's
         # `_cancel_prev_pending_lifecycle_rows` cancels the row first,
         # the timer is a no-op and the user sees a single Restarted.
-        if notif_id is not None and first_store is not None:
-            schedule_deferred_stop_or_eager_send(
-                notification_id=notif_id,
-                db_path=first_store.db_path,
-                config_path=getattr(self.config, "config_path", None),
-                body=body,
-                notify_type=notify_type,
-                worker=self._notification_worker,
-                log_fn=self._log,
-            )
+        if not upgrade_in_progress:
+            if notif_id is not None and first_store is not None:
+                schedule_deferred_stop_or_eager_send(
+                    notification_id=notif_id,
+                    db_path=first_store.db_path,
+                    config_path=getattr(self.config, "config_path", None),
+                    body=body,
+                    notify_type=notify_type,
+                    worker=self._notification_worker,
+                    log_fn=self._log,
+                )
+            elif self._notification_worker is not None:
+                # CodeRabbit P1 (mirrored from monitor.py): no store
+                # registered means worker.send() returned None and the
+                # row never landed in SQLite. Ship eagerly via Apprise
+                # so the lifecycle stop isn't silently lost.
+                try:
+                    self._notification_worker._send_via_apprise(
+                        body, notify_type,
+                    )
+                except Exception:
+                    pass
 
         # Slice 3: tag this exit so the next start can emit "🔄 Restarted"
         # if it comes back within RESTART_DOWNTIME_THRESHOLD_SECS, else

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -296,6 +296,35 @@ def parse_log_events(log_path: str, max_events: int = 8) -> List[str]:
         return []
 
 
+def _sanitize_event_detail(detail: str) -> str:
+    """Strip markdown formatting and collapse newlines so the detail
+    fits on a single row of the events panel.
+
+    The body strings written to ``events.detail`` come from the same
+    text that goes to Apprise (Discord / Slack render ``**bold**`` and
+    multi-line bodies natively). The TUI's curses surface can't:
+
+    - Markdown bold ``**...**`` shows as literal asterisks in the
+      panel — distracting and ugly.
+    - An embedded ``\\n`` mid-string causes ``curses.addstr`` to advance
+      to a new row before the gold background fill completes, leaving
+      cells unpainted and exposing the underlying terminal default
+      colors. Looks like artifacts / "broken colors" on the row.
+
+    Sanitization is per-display only — the events table keeps the
+    original body so notifications still render correctly on the
+    Apprise side.
+    """
+    if not detail:
+        return ""
+    cleaned = detail.replace("**", "")
+    # Collapse newlines (and surrounding indentation) into a single
+    # visual separator so the line stays intact.
+    parts = [p.strip() for p in cleaned.split("\n")]
+    parts = [p for p in parts if p]
+    return " · ".join(parts)
+
+
 def _format_event_line(ts: int, label: str, event_type: str,
                        detail: str, multi_ups: bool) -> str:
     """Format one event row from the SQLite events table for display."""
@@ -304,8 +333,9 @@ def _format_event_line(ts: int, label: str, event_type: str,
     except (TypeError, ValueError, OSError):
         time_str = "????-??-?? ??:??:??"
     prefix = f"[{label}] " if multi_ups else ""
-    if detail:
-        return f"{time_str}  {prefix}{event_type}: {detail}"
+    cleaned_detail = _sanitize_event_detail(detail)
+    if cleaned_detail:
+        return f"{time_str}  {prefix}{event_type}: {cleaned_detail}"
     return f"{time_str}  {prefix}{event_type}"
 
 

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -1,5 +1,5 @@
 """Version information for Eneru."""
 
 # Version is set at build time via git describe --tags
-# Format: "5.2.0" for tagged releases, "5.2.0-5-gabcdef1" for dev builds
-__version__ = "5.2.0"
+# Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
+__version__ = "5.2.1"

--- a/tests/e2e/config-e2e-restart-multi.yaml
+++ b/tests/e2e/config-e2e-restart-multi.yaml
@@ -1,0 +1,78 @@
+# Eneru E2E test config — v5.2.1 single-restart-notification (multi-UPS).
+#
+# Same contract as config-e2e-restart.yaml but routes through
+# MultiUPSCoordinator instead of single-UPS UPSGroupMonitor. The fix
+# in v5.2.1 covers both paths: _handle_signal defers the stop, and
+# _cancel_prev_pending_lifecycle_rows sweeps each per-UPS store on
+# the next coordinator startup. Without the second half, multi-UPS
+# users would still see two notifications on every restart.
+#
+# Notifications point at TEST-NET-1 (RFC 5737) so every Apprise call
+# fails fast and rows stay 'pending' long enough for the test to
+# inspect them.
+
+ups:
+  - name: "UPS1@localhost:3493"
+    display_name: "E2E Restart UPS1"
+    check_interval: 1
+    is_local: true
+    triggers:
+      low_battery_threshold: 5
+      critical_runtime_threshold: 1
+      depletion:
+        window: 300
+        critical_rate: 1000.0
+        grace_period: 300
+      extended_time:
+        enabled: false
+
+  - name: "UPS2@localhost:3493"
+    display_name: "E2E Restart UPS2"
+    check_interval: 1
+    triggers:
+      low_battery_threshold: 5
+      critical_runtime_threshold: 1
+      depletion:
+        window: 300
+        critical_rate: 1000.0
+        grace_period: 300
+      extended_time:
+        enabled: false
+
+triggers:
+  low_battery_threshold: 5
+  critical_runtime_threshold: 1
+  depletion:
+    window: 300
+    critical_rate: 1000.0
+    grace_period: 300
+  extended_time:
+    enabled: false
+
+statistics:
+  db_directory: "/tmp/eneru-e2e-restart-multi"
+  retention:
+    raw_hours: 24
+    agg_5min_days: 30
+    agg_hourly_days: 1825
+
+behavior:
+  dry_run: true
+
+logging:
+  file: null
+  state_file: "/tmp/eneru-e2e-restart-multi-state"
+  battery_history_file: "/tmp/eneru-e2e-restart-multi-history"
+  shutdown_flag_file: "/tmp/eneru-e2e-restart-multi-shutdown-flag"
+
+notifications:
+  enabled: true
+  urls:
+    - "json://192.0.2.1/notify"
+  timeout: 1
+  retry_interval: 1
+  retry_backoff_max: 5
+  max_attempts: 0
+
+local_shutdown:
+  enabled: false

--- a/tests/e2e/config-e2e-restart.yaml
+++ b/tests/e2e/config-e2e-restart.yaml
@@ -1,0 +1,59 @@
+# Eneru E2E test config — v5.2.1 single-restart-notification.
+#
+# Notifications are enabled but pointed at an unreachable Apprise URL
+# (RFC 5737 TEST-NET-1) so every Apprise call returns False and rows
+# stay 'pending' in SQLite long enough for the test to inspect them.
+#
+# The contract being tested:
+#  1. SIGTERM enqueues the "Service Stopped" lifecycle row AFTER
+#     flush() — so it lands in SQLite as 'pending', NOT delivered.
+#  2. The next daemon's classify_startup runs cancel_notification on
+#     pending lifecycle rows ('superseded') before emitting the new
+#     "🔄 Restarted (downtime: Ns)" notification.
+#  3. Net result: one pending lifecycle row at any time, never two.
+#
+# Stats and logging paths are isolated per-test to avoid bleed-over
+# from the panic-attack coalescing test (config-e2e-coalesce.yaml).
+
+ups:
+  name: "TestUPS@localhost:3493"
+  display_name: "E2E Restart UPS"
+  check_interval: 1
+
+triggers:
+  low_battery_threshold: 5
+  critical_runtime_threshold: 1
+  depletion:
+    window: 300
+    critical_rate: 1000.0
+    grace_period: 300
+  extended_time:
+    enabled: false
+
+statistics:
+  db_directory: "/tmp/eneru-e2e-restart"
+  retention:
+    raw_hours: 24
+    agg_5min_days: 30
+    agg_hourly_days: 1825
+
+behavior:
+  dry_run: true
+
+logging:
+  file: null
+  state_file: "/tmp/eneru-e2e-restart-state"
+  battery_history_file: "/tmp/eneru-e2e-restart-history"
+  shutdown_flag_file: "/tmp/eneru-e2e-restart-shutdown-flag"
+
+notifications:
+  enabled: true
+  urls:
+    - "json://192.0.2.1/notify"
+  timeout: 1
+  retry_interval: 1
+  retry_backoff_max: 5
+  max_attempts: 0
+
+local_shutdown:
+  enabled: false

--- a/tests/e2e/groups/multi-ups.sh
+++ b/tests/e2e/groups/multi-ups.sh
@@ -440,11 +440,11 @@ mkdir -p /tmp/eneru-e2e-restart-multi
 rm -f /tmp/eneru-e2e-restart-multi-shutdown-flag
 
 # Start from on-line.
-cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+cp "$E2E_DIR/scenarios/online-charging.dev" "$E2E_DIR/scenarios/apply.dev"
 sleep 3
 
 # --- First run: coordinator startup, then SIGTERM. ---
-eneru run --config $E2E_DIR/config-e2e-restart-multi.yaml > /tmp/test36-run1.log 2>&1 &
+eneru run --config "$E2E_DIR/config-e2e-restart-multi.yaml" > /tmp/test36-run1.log 2>&1 &
 ENERU_PID=$!
 sleep 6  # coordinator init + per-UPS monitors register stores + drain memory buffer
 kill -TERM $ENERU_PID 2>/dev/null || true
@@ -480,7 +480,7 @@ fi
 echo "PASS (36a): coordinator left $total_pending_stop pending 'Service Stopped' row(s)"
 
 # --- Second run: same config, simulating restart. ---
-eneru run --config $E2E_DIR/config-e2e-restart-multi.yaml > /tmp/test36-run2.log 2>&1 &
+eneru run --config "$E2E_DIR/config-e2e-restart-multi.yaml" > /tmp/test36-run2.log 2>&1 &
 ENERU_PID=$!
 sleep 7  # coordinator startup → _cancel_prev_pending_lifecycle_rows → new lifecycle send
 kill -TERM $ENERU_PID 2>/dev/null || true

--- a/tests/e2e/groups/multi-ups.sh
+++ b/tests/e2e/groups/multi-ups.sh
@@ -439,8 +439,14 @@ rm -rf /tmp/eneru-e2e-restart-multi /tmp/eneru-e2e-restart-multi-*
 mkdir -p /tmp/eneru-e2e-restart-multi
 rm -f /tmp/eneru-e2e-restart-multi-shutdown-flag
 
-# Start from on-line.
+# Start from on-line on BOTH UPSes. Earlier tests in this group mutate
+# apply-UPS1.dev / apply-UPS2.dev (the per-UPS dummy-driver state files
+# the multi-UPS scenarios use); without resetting them here Test 36
+# inherits whatever state the previous test left, becoming order-
+# dependent. (CodeRabbit P1 from PR #35 review.)
 cp "$E2E_DIR/scenarios/online-charging.dev" "$E2E_DIR/scenarios/apply.dev"
+cp "$E2E_DIR/scenarios/online-charging.dev" "$E2E_DIR/scenarios/apply-UPS1.dev"
+cp "$E2E_DIR/scenarios/online-charging.dev" "$E2E_DIR/scenarios/apply-UPS2.dev"
 sleep 3
 
 # --- First run: coordinator startup, then SIGTERM. ---
@@ -450,9 +456,11 @@ sleep 6  # coordinator init + per-UPS monitors register stores + drain memory bu
 kill -TERM $ENERU_PID 2>/dev/null || true
 wait $ENERU_PID 2>/dev/null || true
 
-# At least one per-UPS store should have a pending 'Service Stopped'
-# row from the coordinator's _handle_signal (the send goes through the
-# worker's first registered store).
+# Exactly one per-UPS store should have a pending 'Service Stopped'
+# row (the coordinator's _handle_signal sends ONE notification through
+# the worker's first registered store; we should NOT see duplicates).
+# Cubic P2 from PR #35 review: -lt 1 also passes if the coordinator
+# accidentally creates duplicates across stores; tighten to == 1.
 DBS=$(find /tmp/eneru-e2e-restart-multi -maxdepth 1 -name '*.db' 2>/dev/null)
 if [ -z "$DBS" ]; then
   echo "FAIL: no SQLite stats DB created at /tmp/eneru-e2e-restart-multi/"
@@ -468,8 +476,8 @@ for db in $DBS; do
        AND body LIKE '%Service Stopped%';" 2>/dev/null || echo 0)
   total_pending_stop=$((total_pending_stop + c))
 done
-if [ "$total_pending_stop" -lt "1" ]; then
-  echo "FAIL (36a): expected at least 1 pending 'Service Stopped' row across stores, got $total_pending_stop"
+if [ "$total_pending_stop" != "1" ]; then
+  echo "FAIL (36a): expected exactly 1 pending 'Service Stopped' row across stores, got $total_pending_stop"
   for db in $DBS; do
     echo "--- $db: ---"
     sqlite3 "$db" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
@@ -477,7 +485,7 @@ if [ "$total_pending_stop" -lt "1" ]; then
   cat /tmp/test36-run1.log
   exit 1
 fi
-echo "PASS (36a): coordinator left $total_pending_stop pending 'Service Stopped' row(s)"
+echo "PASS (36a): coordinator left exactly 1 pending 'Service Stopped' row"
 
 # --- Second run: same config, simulating restart. ---
 eneru run --config "$E2E_DIR/config-e2e-restart-multi.yaml" > /tmp/test36-run2.log 2>&1 &
@@ -486,7 +494,7 @@ sleep 7  # coordinator startup → _cancel_prev_pending_lifecycle_rows → new l
 kill -TERM $ENERU_PID 2>/dev/null || true
 wait $ENERU_PID 2>/dev/null || true
 
-# After the second coordinator's startup sweep, every prior 'Service
+# After the second coordinator's startup sweep, the prior 'Service
 # Stopped' row should be status='cancelled' with cancel_reason='superseded'.
 total_superseded=0
 for db in $DBS; do
@@ -497,8 +505,8 @@ for db in $DBS; do
        AND body LIKE '%Service Stopped%';" 2>/dev/null || echo 0)
   total_superseded=$((total_superseded + c))
 done
-if [ "$total_superseded" -lt "$total_pending_stop" ]; then
-  echo "FAIL (36b): expected >= $total_pending_stop superseded rows, got $total_superseded"
+if [ "$total_superseded" != "$total_pending_stop" ]; then
+  echo "FAIL (36b): expected $total_pending_stop superseded rows, got $total_superseded"
   for db in $DBS; do
     echo "--- $db: ---"
     sqlite3 "$db" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
@@ -506,7 +514,30 @@ if [ "$total_superseded" -lt "$total_pending_stop" ]; then
   cat /tmp/test36-run2.log
   exit 1
 fi
-echo "PASS (36b): $total_superseded prior 'Service Stopped' row(s) cancelled with reason='superseded'"
+echo "PASS (36b): prior 'Service Stopped' row cancelled with reason='superseded'"
+
+# Also verify the new daemon emitted a Restarted lifecycle row — without
+# this assertion, a regression where the supersede happens but the
+# replacement notification never fires would still pass. (Cubic P2 from
+# PR #35 review.)
+total_restarted=0
+for db in $DBS; do
+  c=$(sqlite3 "$db" \
+    "SELECT COUNT(*) FROM notifications \
+     WHERE category='lifecycle' \
+       AND body LIKE '%Restarted%';" 2>/dev/null || echo 0)
+  total_restarted=$((total_restarted + c))
+done
+if [ "$total_restarted" -lt "1" ]; then
+  echo "FAIL (36c): expected at least 1 Restarted lifecycle row, got $total_restarted"
+  for db in $DBS; do
+    echo "--- $db: ---"
+    sqlite3 "$db" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  done
+  cat /tmp/test36-run2.log
+  exit 1
+fi
+echo "PASS (36c): new daemon emitted $total_restarted Restarted row(s)"
 
 echo ""
 echo "=== Test 36 PASSED: coordinator single-notification on restart verified ==="

--- a/tests/e2e/groups/multi-ups.sh
+++ b/tests/e2e/groups/multi-ups.sh
@@ -417,5 +417,100 @@ echo ""
 echo "=== Test 19 PASSED: multi-phase shutdown ordering verified ==="
 )
 
+
+# ======================================================================
+# Test 36: v5.2.1 single-restart-notification — multi-UPS coordinator
+#
+# Same contract as Test 35 but exercises MultiUPSCoordinator instead of
+# single-UPS UPSGroupMonitor. Verifies that
+# _cancel_prev_pending_lifecycle_rows sweeps each per-UPS store on the
+# next coordinator startup. Without that sweep, multi-UPS users still
+# see two notifications on every restart even though _handle_signal
+# correctly defers the stop.
+# ======================================================================
+(
+echo ""
+echo ">>> Running: Test 36: single-restart-notification multi-UPS (v5.2.1)"
+
+echo "=== Test 36: v5.2.1 single-restart-notification (coord mode) ==="
+
+# Clean slate.
+rm -rf /tmp/eneru-e2e-restart-multi /tmp/eneru-e2e-restart-multi-*
+mkdir -p /tmp/eneru-e2e-restart-multi
+rm -f /tmp/eneru-e2e-restart-multi-shutdown-flag
+
+# Start from on-line.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+sleep 3
+
+# --- First run: coordinator startup, then SIGTERM. ---
+eneru run --config $E2E_DIR/config-e2e-restart-multi.yaml > /tmp/test36-run1.log 2>&1 &
+ENERU_PID=$!
+sleep 6  # coordinator init + per-UPS monitors register stores + drain memory buffer
+kill -TERM $ENERU_PID 2>/dev/null || true
+wait $ENERU_PID 2>/dev/null || true
+
+# At least one per-UPS store should have a pending 'Service Stopped'
+# row from the coordinator's _handle_signal (the send goes through the
+# worker's first registered store).
+DBS=$(find /tmp/eneru-e2e-restart-multi -maxdepth 1 -name '*.db' 2>/dev/null)
+if [ -z "$DBS" ]; then
+  echo "FAIL: no SQLite stats DB created at /tmp/eneru-e2e-restart-multi/"
+  cat /tmp/test36-run1.log
+  exit 1
+fi
+
+total_pending_stop=0
+for db in $DBS; do
+  c=$(sqlite3 "$db" \
+    "SELECT COUNT(*) FROM notifications \
+     WHERE category='lifecycle' AND status='pending' \
+       AND body LIKE '%Service Stopped%';" 2>/dev/null || echo 0)
+  total_pending_stop=$((total_pending_stop + c))
+done
+if [ "$total_pending_stop" -lt "1" ]; then
+  echo "FAIL (36a): expected at least 1 pending 'Service Stopped' row across stores, got $total_pending_stop"
+  for db in $DBS; do
+    echo "--- $db: ---"
+    sqlite3 "$db" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  done
+  cat /tmp/test36-run1.log
+  exit 1
+fi
+echo "PASS (36a): coordinator left $total_pending_stop pending 'Service Stopped' row(s)"
+
+# --- Second run: same config, simulating restart. ---
+eneru run --config $E2E_DIR/config-e2e-restart-multi.yaml > /tmp/test36-run2.log 2>&1 &
+ENERU_PID=$!
+sleep 7  # coordinator startup → _cancel_prev_pending_lifecycle_rows → new lifecycle send
+kill -TERM $ENERU_PID 2>/dev/null || true
+wait $ENERU_PID 2>/dev/null || true
+
+# After the second coordinator's startup sweep, every prior 'Service
+# Stopped' row should be status='cancelled' with cancel_reason='superseded'.
+total_superseded=0
+for db in $DBS; do
+  c=$(sqlite3 "$db" \
+    "SELECT COUNT(*) FROM notifications \
+     WHERE category='lifecycle' AND status='cancelled' \
+       AND cancel_reason='superseded' \
+       AND body LIKE '%Service Stopped%';" 2>/dev/null || echo 0)
+  total_superseded=$((total_superseded + c))
+done
+if [ "$total_superseded" -lt "$total_pending_stop" ]; then
+  echo "FAIL (36b): expected >= $total_pending_stop superseded rows, got $total_superseded"
+  for db in $DBS; do
+    echo "--- $db: ---"
+    sqlite3 "$db" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  done
+  cat /tmp/test36-run2.log
+  exit 1
+fi
+echo "PASS (36b): $total_superseded prior 'Service Stopped' row(s) cancelled with reason='superseded'"
+
+echo ""
+echo "=== Test 36 PASSED: coordinator single-notification on restart verified ==="
+)
+
 echo ""
 echo "=== Group 'multi-ups' completed successfully ==="

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -445,5 +445,109 @@ echo ""
 echo "=== Test 34 PASSED: panic-attack coalescing verified ==="
 )
 
+
+# ======================================================================
+# Test 35: v5.2.1 single-restart-notification
+#
+# Contract: a `systemctl restart eneru` (i.e. SIGTERM → start) produces
+# exactly ONE pending lifecycle row at any time, never two. The old
+# daemon enqueues "Service Stopped" AFTER flush() so the row stays
+# pending; the new daemon's classify_startup runs cancel_notification on
+# pending lifecycle rows ('superseded') before emitting the new
+# "Restarted" message. Reproduces the v5.2.0 bug from TODO.md.
+# ======================================================================
+(
+echo ""
+echo ">>> Running: Test 35: single-restart-notification (v5.2.1)"
+
+echo "=== Test 35: v5.2.1 single-restart-notification ==="
+
+# Clean slate.
+rm -rf /tmp/eneru-e2e-restart /tmp/eneru-e2e-restart-*
+mkdir -p /tmp/eneru-e2e-restart
+rm -f /tmp/eneru-e2e-restart-shutdown-flag
+
+# Start from on-line so the daemon doesn't try to trigger anything
+# unrelated while we're testing the lifecycle path.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+sleep 3
+
+# --- First run: clean start, then SIGTERM. ---
+eneru run --config $E2E_DIR/config-e2e-restart.yaml > /tmp/test35-run1.log 2>&1 &
+ENERU_PID=$!
+sleep 5  # _initialize finishes, lifecycle classifier emits DAEMON_START
+kill -TERM $ENERU_PID 2>/dev/null || true
+wait $ENERU_PID 2>/dev/null || true
+
+DB=$(find /tmp/eneru-e2e-restart -maxdepth 1 -name '*.db' 2>/dev/null | head -1)
+if [ -z "$DB" ]; then
+  echo "FAIL: no SQLite stats DB created at /tmp/eneru-e2e-restart/"
+  cat /tmp/test35-run1.log
+  exit 1
+fi
+
+# After first SIGTERM: exactly one pending lifecycle row containing
+# "Service Stopped" (the unreachable Apprise endpoint guarantees the
+# worker can't deliver it within flush(timeout=5), so it stays pending).
+pending_stop=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM notifications \
+   WHERE category='lifecycle' AND status='pending' \
+     AND body LIKE '%Service Stopped%';")
+if [ "$pending_stop" != "1" ]; then
+  echo "FAIL (35a): expected 1 pending lifecycle 'Service Stopped' row, got $pending_stop"
+  echo "--- ALL notifications rows: ---"
+  sqlite3 "$DB" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  echo "--- /tmp/test35-run1.log: ---"
+  cat /tmp/test35-run1.log
+  exit 1
+fi
+echo "PASS (35a): old daemon left exactly 1 pending lifecycle 'Service Stopped' row"
+
+# --- Second run: same config, simulating `systemctl restart`. ---
+eneru run --config $E2E_DIR/config-e2e-restart.yaml > /tmp/test35-run2.log 2>&1 &
+ENERU_PID=$!
+sleep 6  # _initialize → classify_startup → cancel pending + send Restarted
+
+# Stop cleanly so the test environment isn't left with a runaway daemon.
+kill -TERM $ENERU_PID 2>/dev/null || true
+wait $ENERU_PID 2>/dev/null || true
+
+# After the second daemon's classify_startup fires:
+#   - The first run's "Service Stopped" row is now status='cancelled'
+#     with cancel_reason='superseded' (set by _emit_lifecycle_startup_
+#     notification BEFORE the new lifecycle row is enqueued).
+#   - A new lifecycle row containing "Restarted" is in the table.
+superseded=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM notifications \
+   WHERE category='lifecycle' AND status='cancelled' \
+     AND cancel_reason='superseded' \
+     AND body LIKE '%Service Stopped%';")
+if [ "$superseded" != "1" ]; then
+  echo "FAIL (35b): expected 1 cancelled (superseded) 'Service Stopped' row, got $superseded"
+  echo "--- ALL notifications rows: ---"
+  sqlite3 "$DB" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  echo "--- /tmp/test35-run2.log: ---"
+  cat /tmp/test35-run2.log
+  exit 1
+fi
+echo "PASS (35b): prior 'Service Stopped' row is cancelled with reason='superseded'"
+
+restarted=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM notifications \
+   WHERE category='lifecycle' \
+     AND body LIKE '%Restarted%';")
+if [ "$restarted" -lt "1" ]; then
+  echo "FAIL (35c): expected at least 1 'Restarted' row, got $restarted"
+  echo "--- ALL notifications rows: ---"
+  sqlite3 "$DB" "SELECT id, ts, category, status, cancel_reason, substr(body,1,80) FROM notifications ORDER BY id;"
+  cat /tmp/test35-run2.log
+  exit 1
+fi
+echo "PASS (35c): new daemon emitted a 'Restarted' lifecycle row"
+
+echo ""
+echo "=== Test 35 PASSED: single notification per restart verified ==="
+)
+
 echo ""
 echo "=== Group 'stats' completed successfully ==="

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -469,11 +469,11 @@ rm -f /tmp/eneru-e2e-restart-shutdown-flag
 
 # Start from on-line so the daemon doesn't try to trigger anything
 # unrelated while we're testing the lifecycle path.
-cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+cp "$E2E_DIR/scenarios/online-charging.dev" "$E2E_DIR/scenarios/apply.dev"
 sleep 3
 
 # --- First run: clean start, then SIGTERM. ---
-eneru run --config $E2E_DIR/config-e2e-restart.yaml > /tmp/test35-run1.log 2>&1 &
+eneru run --config "$E2E_DIR/config-e2e-restart.yaml" > /tmp/test35-run1.log 2>&1 &
 ENERU_PID=$!
 sleep 5  # _initialize finishes, lifecycle classifier emits DAEMON_START
 kill -TERM $ENERU_PID 2>/dev/null || true
@@ -504,7 +504,7 @@ fi
 echo "PASS (35a): old daemon left exactly 1 pending lifecycle 'Service Stopped' row"
 
 # --- Second run: same config, simulating `systemctl restart`. ---
-eneru run --config $E2E_DIR/config-e2e-restart.yaml > /tmp/test35-run2.log 2>&1 &
+eneru run --config "$E2E_DIR/config-e2e-restart.yaml" > /tmp/test35-run2.log 2>&1 &
 ENERU_PID=$!
 sleep 6  # _initialize → classify_startup → cancel pending + send Restarted
 

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -73,34 +73,72 @@ class TestRunningUnderSystemd:
 # ==============================================================================
 
 class TestDetectSystemdStopIntent:
+    """v5.2.1 fix: parse `systemctl list-jobs --no-legend`, not
+    `systemctl show -p Job` (which only carries the job ID, not the
+    type — an earlier rc shipped that wrong format and silently
+    regressed every `systemctl stop` to the 15-second timer)."""
 
     @pytest.mark.unit
     def test_returns_true_for_stop_job(self):
-        result = MagicMock(returncode=0, stdout=b"Job=42:stop\n")
+        result = MagicMock(
+            returncode=0,
+            stdout=b"12345 eneru.service stop running\n",
+        )
         with patch("eneru.deferred_delivery.subprocess.run",
                    return_value=result):
             assert _detect_systemd_stop_intent() is True
 
     @pytest.mark.unit
     def test_returns_false_for_restart_job(self):
-        result = MagicMock(returncode=0, stdout=b"Job=42:restart\n")
+        result = MagicMock(
+            returncode=0,
+            stdout=b"12345 eneru.service restart running\n",
+        )
         with patch("eneru.deferred_delivery.subprocess.run",
                    return_value=result):
             assert _detect_systemd_stop_intent() is False
 
     @pytest.mark.unit
     def test_returns_false_for_start_job(self):
-        result = MagicMock(returncode=0, stdout=b"Job=42:start\n")
+        result = MagicMock(
+            returncode=0,
+            stdout=b"12345 eneru.service start running\n",
+        )
         with patch("eneru.deferred_delivery.subprocess.run",
                    return_value=result):
             assert _detect_systemd_stop_intent() is False
 
     @pytest.mark.unit
     def test_returns_false_for_no_job_queued(self):
-        result = MagicMock(returncode=0, stdout=b"Job=\n")
+        result = MagicMock(returncode=0, stdout=b"")
         with patch("eneru.deferred_delivery.subprocess.run",
                    return_value=result):
             assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_returns_false_for_unrelated_unit(self):
+        """A stop job for a DIFFERENT unit shouldn't trigger our
+        eager-send path."""
+        result = MagicMock(
+            returncode=0,
+            stdout=b"12345 some-other.service stop running\n",
+        )
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_handles_multiple_jobs_picks_eneru(self):
+        """Multiple jobs queued — find ours by unit name match."""
+        result = MagicMock(
+            returncode=0,
+            stdout=(b"100 nut-server.service start running\n"
+                    b"101 eneru.service stop waiting\n"
+                    b"102 docker.service reload running\n"),
+        )
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is True
 
     @pytest.mark.unit
     def test_returns_false_when_systemctl_missing(self):
@@ -124,10 +162,30 @@ class TestDetectSystemdStopIntent:
 
     @pytest.mark.unit
     def test_case_insensitive_on_job_type(self):
-        result = MagicMock(returncode=0, stdout=b"Job=42:STOP\n")
+        result = MagicMock(
+            returncode=0,
+            stdout=b"12345 eneru.service STOP running\n",
+        )
         with patch("eneru.deferred_delivery.subprocess.run",
                    return_value=result):
             assert _detect_systemd_stop_intent() is True
+
+    @pytest.mark.unit
+    def test_invocation_forces_lang_c(self):
+        """Localized environments could translate the column header,
+        breaking the parser. We force LANG=C / LC_ALL=C in the
+        subprocess env."""
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            return MagicMock(returncode=0, stdout=b"")
+
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=fake_run):
+            _detect_systemd_stop_intent()
+        assert captured["env"].get("LANG") == "C"
+        assert captured["env"].get("LC_ALL") == "C"
 
 
 # ==============================================================================
@@ -557,3 +615,92 @@ class TestDeliverPendingStop:
             notification_id=999, db_path=db_path, config=cfg,
         )
         assert rc == 0
+
+    @pytest.mark.unit
+    def test_atomic_claim_does_not_overwrite_cancelled_row(self, tmp_path):
+        """v5.2.1 (CodeRabbit P1): if the next daemon's classifier
+        cancels the row between our SELECT and our send, the prior
+        implementation would still ship and then mark_notification_sent
+        would overwrite the `cancelled` status back to `sent` —
+        reopening the duplicate-lifecycle race. The atomic UPDATE
+        ... WHERE status='pending' claim closes that window: an
+        already-cancelled row simply isn't claimed and the timer
+        exits without delivering."""
+        db_path = tmp_path / "ups.db"
+        # Pre-create a CANCELLED row to simulate the race outcome.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row_id = store.enqueue_notification(
+                body="🛑 Stopped", notify_type="warning",
+                category="lifecycle", ts=1000,
+            )
+            store.cancel_notification(row_id, "superseded")
+        finally:
+            store.close()
+
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker:
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.return_value = True
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+        assert rc == 0
+        # Apprise must NOT have been called — the row was already
+        # cancelled when we ran.
+        worker._send_via_apprise.assert_not_called()
+        # Row must still be cancelled (not overwritten back to sent).
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status, cancel_reason FROM notifications "
+                "WHERE id = ?", (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row == ("cancelled", "superseded"), (
+            f"Cancelled row was overwritten by mark_sent: {row}"
+        )
+
+    @pytest.mark.unit
+    def test_reverts_claim_on_apprise_failure(self, tmp_path):
+        """If Apprise rejects the send (network down, bad URL), the
+        atomic claim should be reverted so a future start can retry
+        — otherwise the row sits as `sent` despite never being
+        delivered, and the user gets nothing."""
+        db_path = tmp_path / "ups.db"
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row_id = store.enqueue_notification(
+                body="🛑 Stopped", notify_type="warning",
+                category="lifecycle", ts=1000,
+            )
+        finally:
+            store.close()
+
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker:
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.return_value = False
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+        assert rc == 0
+        # Row should be back to pending so the next start can retry.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status FROM notifications WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row[0] == "pending", (
+            f"Failed Apprise send should leave row pending; got: {row}"
+        )

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -9,8 +9,10 @@ import pytest
 
 from eneru.deferred_delivery import (
     DEFAULT_DEFER_SECS,
+    _detect_systemd_stop_intent,
     _eager_send,
     _eneru_invocation_args,
+    _running_under_systemd,
     deliver_pending_stop,
     schedule_deferred_stop_or_eager_send,
 )
@@ -43,10 +45,107 @@ class TestEneruInvocationArgs:
 
 
 # ==============================================================================
+# _running_under_systemd
+# ==============================================================================
+
+class TestRunningUnderSystemd:
+
+    @pytest.mark.unit
+    def test_true_when_invocation_id_set(self):
+        with patch.dict("os.environ", {"INVOCATION_ID": "abc123"}, clear=False):
+            assert _running_under_systemd() is True
+
+    @pytest.mark.unit
+    def test_false_when_invocation_id_unset(self):
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "INVOCATION_ID"}
+        with patch.dict("os.environ", env, clear=True):
+            assert _running_under_systemd() is False
+
+    @pytest.mark.unit
+    def test_false_when_invocation_id_empty(self):
+        with patch.dict("os.environ", {"INVOCATION_ID": ""}, clear=False):
+            assert _running_under_systemd() is False
+
+
+# ==============================================================================
+# _detect_systemd_stop_intent
+# ==============================================================================
+
+class TestDetectSystemdStopIntent:
+
+    @pytest.mark.unit
+    def test_returns_true_for_stop_job(self):
+        result = MagicMock(returncode=0, stdout=b"Job=42:stop\n")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is True
+
+    @pytest.mark.unit
+    def test_returns_false_for_restart_job(self):
+        result = MagicMock(returncode=0, stdout=b"Job=42:restart\n")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_returns_false_for_start_job(self):
+        result = MagicMock(returncode=0, stdout=b"Job=42:start\n")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_returns_false_for_no_job_queued(self):
+        result = MagicMock(returncode=0, stdout=b"Job=\n")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_returns_false_when_systemctl_missing(self):
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=FileNotFoundError):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_returns_false_when_query_times_out(self):
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(
+                       cmd="systemctl", timeout=2)):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_returns_false_on_nonzero_exit(self):
+        result = MagicMock(returncode=1, stdout=b"")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is False
+
+    @pytest.mark.unit
+    def test_case_insensitive_on_job_type(self):
+        result = MagicMock(returncode=0, stdout=b"Job=42:STOP\n")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result):
+            assert _detect_systemd_stop_intent() is True
+
+
+# ==============================================================================
 # schedule_deferred_stop_or_eager_send
 # ==============================================================================
 
 class TestScheduleDeferred:
+
+    @pytest.fixture(autouse=True)
+    def _under_systemd_no_stop_intent(self):
+        """All TestScheduleDeferred tests assume the timer-scheduling
+        path: under systemd AND not a `systemctl stop` (which is the
+        v5.2.1 instant-eager short-circuit). Tests that exercise the
+        short-circuit paths live in TestScheduleShortCircuits below."""
+        with patch.dict("os.environ", {"INVOCATION_ID": "test-invocation"}), \
+             patch("eneru.deferred_delivery._detect_systemd_stop_intent",
+                   return_value=False):
+            yield
 
     def _stub_run_success(self, cmd, **kwargs):
         result = MagicMock()
@@ -206,6 +305,73 @@ class TestScheduleDeferred:
             )
         run.assert_not_called()
         worker._send_via_apprise.assert_called_once()
+
+
+# ==============================================================================
+# v5.2.1 short-circuit paths in schedule_deferred_stop_or_eager_send
+# ==============================================================================
+
+class TestScheduleShortCircuits:
+    """The instant-eager paths added in v5.2.1 to drop the 15-second
+    notification latency on `systemctl stop` and in non-systemd
+    contexts (containers, K8s, manual `eneru run`)."""
+
+    @pytest.mark.unit
+    def test_short_circuit_when_not_under_systemd(self, tmp_path):
+        """No INVOCATION_ID env var → eager send, no systemd-run call,
+        no Job query. This is the K8s / Docker / foreground path."""
+        log = MagicMock()
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+        # Drop INVOCATION_ID from env to simulate non-systemd context.
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "INVOCATION_ID"}
+        with patch.dict("os.environ", env, clear=True), \
+             patch("eneru.deferred_delivery.subprocess.run") as run, \
+             patch("eneru.stats.StatsStore.open"), \
+             patch("eneru.stats.StatsStore.mark_notification_sent"), \
+             patch("eneru.stats.StatsStore.close"):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=1,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="🛑 stop", notify_type="warning",
+                worker=worker, log_fn=log,
+            )
+        run.assert_not_called()
+        worker._send_via_apprise.assert_called_once_with("🛑 stop", "warning")
+        assert any("Not running under systemd" in c.args[0]
+                   for c in log.call_args_list)
+
+    @pytest.mark.unit
+    def test_short_circuit_on_systemctl_stop_intent(self, tmp_path):
+        """systemd Job=stop detected → eager send, no systemd-run timer.
+        This is the instant-Stopped UX win for `systemctl stop eneru`."""
+        log = MagicMock()
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+        with patch.dict("os.environ",
+                        {"INVOCATION_ID": "test-invocation"}), \
+             patch("eneru.deferred_delivery._detect_systemd_stop_intent",
+                   return_value=True), \
+             patch("eneru.deferred_delivery.subprocess.run") as run, \
+             patch("eneru.stats.StatsStore.open"), \
+             patch("eneru.stats.StatsStore.mark_notification_sent"), \
+             patch("eneru.stats.StatsStore.close"):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=1,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="🛑 stop", notify_type="warning",
+                worker=worker, log_fn=log,
+            )
+        # subprocess.run is mocked but _detect_systemd_stop_intent
+        # is also mocked, so subprocess.run shouldn't have been
+        # called (the systemd-run path is what would call it).
+        run.assert_not_called()
+        worker._send_via_apprise.assert_called_once_with("🛑 stop", "warning")
+        assert any("systemctl stop detected" in c.args[0]
+                   for c in log.call_args_list)
 
 
 # ==============================================================================

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -1,0 +1,393 @@
+"""Tests for ``src/eneru/deferred_delivery.py`` — the v5.2.1 systemd-run
+based deferred-stop notification mechanism."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from eneru.deferred_delivery import (
+    DEFAULT_DEFER_SECS,
+    _eager_send,
+    _eneru_invocation_args,
+    deliver_pending_stop,
+    schedule_deferred_stop_or_eager_send,
+)
+from eneru.stats import StatsStore
+
+
+# ==============================================================================
+# _eneru_invocation_args
+# ==============================================================================
+
+class TestEneruInvocationArgs:
+
+    @pytest.mark.unit
+    def test_prefers_deb_rpm_wrapper_when_present(self):
+        """When /opt/ups-monitor/eneru.py exists, use it (no PYTHONPATH
+        dependency). The deb/rpm wrapper sets sys.path explicitly."""
+        with patch("eneru.deferred_delivery.os.path.exists",
+                   return_value=True):
+            args = _eneru_invocation_args()
+        assert args[1] == "/opt/ups-monitor/eneru.py"
+
+    @pytest.mark.unit
+    def test_falls_back_to_python_dash_m_for_pip_installs(self):
+        """No deb/rpm wrapper → use `python -m eneru` (works for pip
+        and uv-venv installs)."""
+        with patch("eneru.deferred_delivery.os.path.exists",
+                   return_value=False):
+            args = _eneru_invocation_args()
+        assert args[1:] == ["-m", "eneru"]
+
+
+# ==============================================================================
+# schedule_deferred_stop_or_eager_send
+# ==============================================================================
+
+class TestScheduleDeferred:
+
+    def _stub_run_success(self, cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = b""
+        return result
+
+    @pytest.mark.unit
+    def test_invokes_systemd_run_with_correct_args(self, tmp_path):
+        log = MagicMock()
+        worker = MagicMock()
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["timeout"] = kwargs.get("timeout")
+            return self._stub_run_success(cmd, **kwargs)
+
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=fake_run):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=42,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/ups-monitor/config.yaml",
+                body="🛑 Stopped",
+                notify_type="warning",
+                worker=worker,
+                log_fn=log,
+                delay_secs=15,
+            )
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "systemd-run"
+        assert "--on-active=15s" in cmd
+        assert any("eneru-deliver-stop-42" in p for p in cmd)
+        assert "_deliver-stop" in cmd
+        assert "--notification-id" in cmd
+        assert "42" in cmd
+        assert "--db-path" in cmd
+        assert str(tmp_path / "ups.db") in cmd
+        assert "--config" in cmd
+        assert "/etc/ups-monitor/config.yaml" in cmd
+        # Eager-send fallback should NOT have fired.
+        worker._send_via_apprise.assert_not_called()
+        # Log should mention scheduling.
+        assert any("scheduled" in c.args[0].lower()
+                   for c in log.call_args_list)
+
+    @pytest.mark.unit
+    def test_uses_default_delay_when_unspecified(self, tmp_path):
+        log = MagicMock()
+        worker = MagicMock()
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return self._stub_run_success(cmd, **kwargs)
+
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=fake_run):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=1,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="x",
+                notify_type="warning",
+                worker=worker,
+                log_fn=log,
+            )
+        assert f"--on-active={DEFAULT_DEFER_SECS}s" in captured["cmd"]
+
+    @pytest.mark.unit
+    def test_falls_back_when_systemd_run_missing(self, tmp_path):
+        """No systemd-run on PATH → eager Apprise delivery."""
+        log = MagicMock()
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=FileNotFoundError("systemd-run")), \
+             patch("eneru.stats.StatsStore.open"), \
+             patch("eneru.stats.StatsStore.mark_notification_sent"), \
+             patch("eneru.stats.StatsStore.close"):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=7,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="🛑 Stopped",
+                notify_type="warning",
+                worker=worker,
+                log_fn=log,
+            )
+        worker._send_via_apprise.assert_called_once_with("🛑 Stopped", "warning")
+        assert any("falling back" in c.args[0].lower()
+                   for c in log.call_args_list)
+
+    @pytest.mark.unit
+    def test_falls_back_when_systemd_run_returns_nonzero(self, tmp_path):
+        log = MagicMock()
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+
+        result = MagicMock(returncode=1, stderr=b"some systemd error")
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   return_value=result), \
+             patch("eneru.stats.StatsStore.open"), \
+             patch("eneru.stats.StatsStore.mark_notification_sent"), \
+             patch("eneru.stats.StatsStore.close"):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=7,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="x", notify_type="warning",
+                worker=worker, log_fn=log,
+            )
+        worker._send_via_apprise.assert_called_once()
+
+    @pytest.mark.unit
+    def test_falls_back_when_systemd_run_times_out(self, tmp_path):
+        log = MagicMock()
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+
+        with patch("eneru.deferred_delivery.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="systemd-run",
+                                                         timeout=5)), \
+             patch("eneru.stats.StatsStore.open"), \
+             patch("eneru.stats.StatsStore.mark_notification_sent"), \
+             patch("eneru.stats.StatsStore.close"):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=7,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="x", notify_type="warning",
+                worker=worker, log_fn=log,
+            )
+        worker._send_via_apprise.assert_called_once()
+
+    @pytest.mark.unit
+    def test_falls_back_to_eager_when_no_config_path(self, tmp_path):
+        """No config_path → can't spawn out-of-process re-loader → eager
+        delivery via the worker's Apprise instance."""
+        log = MagicMock()
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+
+        with patch("eneru.deferred_delivery.subprocess.run") as run, \
+             patch("eneru.stats.StatsStore.open"), \
+             patch("eneru.stats.StatsStore.mark_notification_sent"), \
+             patch("eneru.stats.StatsStore.close"):
+            schedule_deferred_stop_or_eager_send(
+                notification_id=1,
+                db_path=tmp_path / "ups.db",
+                config_path=None,
+                body="x", notify_type="warning",
+                worker=worker, log_fn=log,
+            )
+        run.assert_not_called()
+        worker._send_via_apprise.assert_called_once()
+
+
+# ==============================================================================
+# _eager_send
+# ==============================================================================
+
+class TestEagerSend:
+
+    @pytest.mark.unit
+    def test_marks_sent_on_apprise_success(self, tmp_path):
+        """Worker.send_via_apprise returns True → row gets marked sent."""
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = True
+        db_path = tmp_path / "ups.db"
+        # Pre-create a row via real StatsStore so mark_notification_sent
+        # has something to update.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row_id = store.enqueue_notification(
+                body="x", notify_type="warning",
+                category="lifecycle", ts=1000,
+            )
+        finally:
+            store.close()
+
+        log = MagicMock()
+        _eager_send(
+            notification_id=row_id, db_path=db_path,
+            body="🛑 stop", notify_type="warning",
+            worker=worker, log_fn=log,
+        )
+        # Re-open and verify status.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status FROM notifications WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row[0] == "sent"
+
+    @pytest.mark.unit
+    def test_leaves_pending_on_apprise_failure(self, tmp_path):
+        worker = MagicMock()
+        worker._send_via_apprise.return_value = False
+        db_path = tmp_path / "ups.db"
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row_id = store.enqueue_notification(
+                body="x", notify_type="warning",
+                category="lifecycle", ts=1000,
+            )
+        finally:
+            store.close()
+
+        log = MagicMock()
+        _eager_send(
+            notification_id=row_id, db_path=db_path,
+            body="🛑 stop", notify_type="warning",
+            worker=worker, log_fn=log,
+        )
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status FROM notifications WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row[0] == "pending"
+
+    @pytest.mark.unit
+    def test_no_op_when_worker_is_none(self, tmp_path):
+        log = MagicMock()
+        # Should not raise.
+        _eager_send(
+            notification_id=1, db_path=tmp_path / "x.db",
+            body="x", notify_type="warning",
+            worker=None, log_fn=log,
+        )
+        assert any("No worker" in c.args[0] for c in log.call_args_list)
+
+
+# ==============================================================================
+# deliver_pending_stop (CLI entry point body)
+# ==============================================================================
+
+class TestDeliverPendingStop:
+
+    def _make_pending_row(self, db_path, body="🛑 Stopped", status="pending"):
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row_id = store.enqueue_notification(
+                body=body, notify_type="warning",
+                category="lifecycle", ts=1000,
+            )
+            if status != "pending":
+                store.cancel_notification(row_id, status)
+            return row_id
+        finally:
+            store.close()
+
+    def _make_config(self, urls=None):
+        from eneru.config import Config, NotificationsConfig
+        cfg = Config()
+        cfg.notifications = NotificationsConfig()
+        cfg.notifications.urls = urls or ["json://192.0.2.1/x"]
+        return cfg
+
+    @pytest.mark.unit
+    def test_returns_zero_when_db_missing(self, tmp_path):
+        cfg = self._make_config()
+        rc = deliver_pending_stop(
+            notification_id=42,
+            db_path=tmp_path / "does-not-exist.db",
+            config=cfg,
+        )
+        assert rc == 0
+
+    @pytest.mark.unit
+    def test_skips_when_row_is_already_cancelled(self, tmp_path):
+        """Next daemon's classifier already superseded the row →
+        timer is a no-op (single Restarted will be visible to the user)."""
+        db_path = tmp_path / "ups.db"
+        # Use cancel_notification's reason argument to drop the row to
+        # status='cancelled' as the classifier would.
+        row_id = self._make_pending_row(db_path, status="superseded")
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker:
+            worker = Worker.return_value
+            worker.start.return_value = True
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+        assert rc == 0
+        # Worker should NOT have been used.
+        worker._send_via_apprise.assert_not_called()
+
+    @pytest.mark.unit
+    def test_delivers_when_row_is_pending(self, tmp_path):
+        """No replacement daemon came up — row is still pending → ship
+        via Apprise and mark sent."""
+        db_path = tmp_path / "ups.db"
+        row_id = self._make_pending_row(db_path)
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker:
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.return_value = True
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+        assert rc == 0
+        worker._send_via_apprise.assert_called_once_with("🛑 Stopped", "warning")
+        worker.stop.assert_called_once()
+        # Verify row is now sent.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status FROM notifications WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row[0] == "sent"
+
+    @pytest.mark.unit
+    def test_returns_zero_when_row_is_purged(self, tmp_path):
+        """Row was purged (e.g., max_age_days TTL) between scheduling
+        and timer fire → silent no-op."""
+        db_path = tmp_path / "ups.db"
+        # Open store so the DB file exists, but DON'T insert a row.
+        StatsStore(db_path).open()
+        cfg = self._make_config()
+        rc = deliver_pending_stop(
+            notification_id=999, db_path=db_path, config=cfg,
+        )
+        assert rc == 0

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -331,6 +331,123 @@ class TestClassifyStartup:
 
 
 # ==============================================================================
+# v5.2.1: defensive old-version fallback chain in classify_startup
+# ==============================================================================
+
+class TestUpgradeOldVersionFallback:
+    """The RPM postinstall path used to land with old_version='unknown'
+    (RPM passes nothing in $2 and the v5.2.0 default was the literal
+    string 'unknown'). v5.2.1 fixes the source via preinstall.sh and
+    adds a defensive fallback chain in classify_startup so a marker
+    that still arrives with 'unknown'/'?'/empty doesn't render as
+    'vunknown' on screen."""
+
+    @pytest.mark.unit
+    def test_unknown_old_version_falls_back_to_shutdown_marker(self):
+        """Marker says 'unknown'; shutdown_marker.version is the next
+        most authoritative source (graceful exit always populates it)."""
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker={"shutdown_at": 1, "version": "5.2.0",
+                             "reason": "signal"},
+            upgrade_marker={"old_version": "unknown",
+                            "new_version": "5.2.1"},
+            last_seen_version="5.1.2",
+            now_ts=100,
+        )
+        assert "vunknown" not in body
+        assert "v5.2.0 → v5.2.1" in body
+
+    @pytest.mark.unit
+    def test_question_mark_old_version_falls_back_to_shutdown_marker(self):
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker={"shutdown_at": 1, "version": "5.2.0",
+                             "reason": "signal"},
+            upgrade_marker={"old_version": "?", "new_version": "5.2.1"},
+            last_seen_version=None,
+            now_ts=100,
+        )
+        assert "v?" not in body
+        assert "v5.2.0" in body
+
+    @pytest.mark.unit
+    def test_empty_old_version_falls_back_to_shutdown_marker(self):
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker={"shutdown_at": 1, "version": "5.2.0",
+                             "reason": "signal"},
+            upgrade_marker={"old_version": "", "new_version": "5.2.1"},
+            last_seen_version=None,
+            now_ts=100,
+        )
+        assert "v5.2.0" in body
+
+    @pytest.mark.unit
+    def test_falls_back_to_last_seen_when_no_shutdown_marker(self):
+        """No shutdown_marker (e.g., upgrade landed before the daemon
+        could write it on a prior run); meta.last_seen_version is the
+        last resort before the literal '?'."""
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker=None,
+            upgrade_marker={"old_version": "unknown",
+                            "new_version": "5.2.1"},
+            last_seen_version="5.1.2",
+            now_ts=100,
+        )
+        assert "vunknown" not in body
+        assert "v5.1.2 → v5.2.1" in body
+
+    @pytest.mark.unit
+    def test_renders_question_mark_only_when_every_source_is_missing(self):
+        """The original behaviour for the truly-no-info case. Should be
+        very rare in practice — preinstall + shutdown marker + stats DB
+        all absent means a fresh-on-fresh package install with no daemon
+        run in between, which doesn't trigger the upgrade branch
+        anyway. Belt-and-suspenders."""
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker=None,
+            upgrade_marker={"old_version": "unknown"},
+            last_seen_version=None,
+            now_ts=100,
+        )
+        assert "v? → v5.2.1" in body
+
+    @pytest.mark.unit
+    def test_explicit_old_version_wins_over_shutdown_marker(self):
+        """Sanity check: when preinstall succeeded and the marker has a
+        real old_version, that's authoritative — don't override it with
+        a possibly-stale shutdown_marker.version."""
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker={"shutdown_at": 1, "version": "5.0.0",
+                             "reason": "signal"},
+            upgrade_marker={"old_version": "5.2.0",
+                            "new_version": "5.2.1"},
+            last_seen_version="5.1.2",
+            now_ts=100,
+        )
+        assert "v5.2.0 → v5.2.1" in body
+        assert "v5.0.0" not in body  # shutdown marker NOT used
+
+    @pytest.mark.unit
+    def test_unknown_case_insensitive(self):
+        body, _ = classify_startup(
+            current_version="5.2.1",
+            shutdown_marker={"shutdown_at": 1, "version": "5.2.0",
+                             "reason": "signal"},
+            upgrade_marker={"old_version": "UNKNOWN",
+                            "new_version": "5.2.1"},
+            last_seen_version=None,
+            now_ts=100,
+        )
+        assert "vUNKNOWN" not in body
+        assert "v5.2.0" in body
+
+
+# ==============================================================================
 # Slice 4: coalesce Recovered with previous shutdown headline
 # ==============================================================================
 

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -738,20 +738,23 @@ class TestEventsTableMirroring:
         )
 
     @pytest.mark.unit
-    def test_cleanup_and_exit_enqueues_stop_after_flush(self, tmp_path):
+    def test_cleanup_and_exit_enqueues_stop_after_flush_and_stop(self, tmp_path):
         """v5.2.1: when no upgrade is in flight, the stop notification
-        is enqueued AFTER the worker is drained and stopped. This way
-        the row stays `pending` in SQLite (the worker is gone, can't
-        deliver) and is therefore cancellable by the next daemon's
-        classifier — exactly one notification per restart."""
+        is enqueued AFTER the worker is drained AND stopped. This way
+        the row stays `pending` in SQLite (the worker thread is dead,
+        can't deliver eagerly) and is either cancelled by the next
+        daemon's classifier (single Restarted) or delivered by the
+        systemd-run timer scheduled below (single Stopped)."""
         monitor = make_monitor(tmp_path)
         monitor._stats_store = MagicMock()
         with patch("eneru.monitor.read_upgrade_marker", return_value=None), \
              patch("eneru.monitor.read_shutdown_marker", return_value=None), \
              patch("eneru.monitor.write_shutdown_marker"), \
+             patch("eneru.monitor.schedule_deferred_stop_or_eager_send") as sched, \
              pytest.raises(SystemExit):
             monitor._cleanup_and_exit(15, None)
-        # Walk method_calls in order; flush + stop must precede send.
+        # Walk method_calls in order; flush + stop must BOTH precede send
+        # so the worker thread is dead before we enqueue the row.
         names = [c[0] for c in monitor._notification_worker.method_calls]
         assert "flush" in names
         assert "stop" in names
@@ -762,6 +765,27 @@ class TestEventsTableMirroring:
         assert names.index("stop") < names.index("send"), (
             f"stop must happen before send; got order: {names}"
         )
+        # Schedule helper must be called with the lifecycle send's id.
+        sched.assert_called_once()
+        kwargs = sched.call_args.kwargs
+        assert kwargs["body"].startswith("🛑")
+        assert kwargs["notify_type"] == monitor.config.NOTIFY_WARNING
+
+    @pytest.mark.unit
+    def test_cleanup_and_exit_skips_schedule_on_upgrade(self, tmp_path):
+        """v5.2.1: with an upgrade marker on disk, the lifecycle stop is
+        suppressed entirely — no notification enqueued, no systemd-run
+        timer scheduled. The next daemon's '📦 Upgraded' covers both."""
+        monitor = make_monitor(tmp_path)
+        monitor._stats_store = MagicMock()
+        marker = {"old_version": "5.2.0", "new_version": "5.2.1"}
+        with patch("eneru.monitor.read_upgrade_marker", return_value=marker), \
+             patch("eneru.monitor.read_shutdown_marker", return_value=None), \
+             patch("eneru.monitor.write_shutdown_marker"), \
+             patch("eneru.monitor.schedule_deferred_stop_or_eager_send") as sched, \
+             pytest.raises(SystemExit):
+            monitor._cleanup_and_exit(15, None)
+        sched.assert_not_called()
 
     @pytest.mark.unit
     def test_emit_lifecycle_skips_event_for_fresh_start(self, tmp_path):

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -713,6 +713,57 @@ class TestEventsTableMirroring:
         assert "stopped by signal" in stops[0].args[1]
 
     @pytest.mark.unit
+    def test_cleanup_and_exit_skips_stop_notification_on_upgrade(self, tmp_path):
+        """v5.2.1: when postinstall.sh has dropped the upgrade marker
+        before invoking systemctl restart, the SIGTERM that lands here
+        comes from the upgrade. The next daemon will emit a single
+        '📦 Upgraded' message that supersedes the stop, so the stop
+        notification must NOT be enqueued."""
+        monitor = make_monitor(tmp_path)
+        monitor._stats_store = MagicMock()
+        marker = {"old_version": "5.2.0", "new_version": "5.2.1"}
+        with patch("eneru.monitor.read_upgrade_marker", return_value=marker), \
+             patch("eneru.monitor.read_shutdown_marker", return_value=None), \
+             patch("eneru.monitor.write_shutdown_marker"), \
+             pytest.raises(SystemExit):
+            monitor._cleanup_and_exit(15, None)
+        # The worker's send() is what _send_notification routes through;
+        # zero send calls means no lifecycle stop was enqueued.
+        send_calls = [c for c in monitor._notification_worker.send.call_args_list
+                      if c.kwargs.get("category") == "lifecycle"
+                      or (len(c.args) >= 3 and c.args[2] == "lifecycle")]
+        assert send_calls == [], (
+            "Expected no lifecycle send when upgrade marker present; "
+            f"got: {monitor._notification_worker.send.call_args_list}"
+        )
+
+    @pytest.mark.unit
+    def test_cleanup_and_exit_enqueues_stop_after_flush(self, tmp_path):
+        """v5.2.1: when no upgrade is in flight, the stop notification
+        is enqueued AFTER the worker is drained and stopped. This way
+        the row stays `pending` in SQLite (the worker is gone, can't
+        deliver) and is therefore cancellable by the next daemon's
+        classifier — exactly one notification per restart."""
+        monitor = make_monitor(tmp_path)
+        monitor._stats_store = MagicMock()
+        with patch("eneru.monitor.read_upgrade_marker", return_value=None), \
+             patch("eneru.monitor.read_shutdown_marker", return_value=None), \
+             patch("eneru.monitor.write_shutdown_marker"), \
+             pytest.raises(SystemExit):
+            monitor._cleanup_and_exit(15, None)
+        # Walk method_calls in order; flush + stop must precede send.
+        names = [c[0] for c in monitor._notification_worker.method_calls]
+        assert "flush" in names
+        assert "stop" in names
+        assert "send" in names
+        assert names.index("flush") < names.index("send"), (
+            f"flush must happen before send; got order: {names}"
+        )
+        assert names.index("stop") < names.index("send"), (
+            f"stop must happen before send; got order: {names}"
+        )
+
+    @pytest.mark.unit
     def test_emit_lifecycle_skips_event_for_fresh_start(self, tmp_path):
         """First-ever start (no marker, no last_seen) classifies as
         DAEMON_START — _start_stats already inserts that row, so the
@@ -739,12 +790,16 @@ class TestEventsTableMirroring:
         """sequence_complete shutdown marker → DAEMON_RECOVERED in the
         events table, mirroring the user's '📊 Recovered' notification."""
         from eneru.lifecycle import REASON_SEQUENCE_COMPLETE
+        from eneru.version import __version__
         monitor = make_monitor(tmp_path)
         monitor._stats_store = MagicMock()
         monitor._stats_store._conn = object()
-        monitor._stats_store.get_meta.return_value = "5.2.0"
+        # Use the current __version__ on both sides so the classifier
+        # picks RECOVERED rather than the (pip-path) UPGRADED branch
+        # that fires when last_seen_version != current_version.
+        monitor._stats_store.get_meta.return_value = __version__
         monitor._stats_store.find_pending_by_category.return_value = []
-        marker = {"shutdown_at": 1000, "version": "5.2.0",
+        marker = {"shutdown_at": 1000, "version": __version__,
                   "reason": REASON_SEQUENCE_COMPLETE}
         with patch("eneru.monitor.read_shutdown_marker", return_value=marker), \
              patch("eneru.monitor.read_upgrade_marker", return_value=None), \

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1366,6 +1366,144 @@ class TestCoordinatorHandleSignal:
         for thread in threads:
             thread.join.assert_called_once_with(timeout=5)
 
+    @pytest.mark.unit
+    def test_handle_signal_enqueues_stop_after_flush(self, tmp_path):
+        """v5.2.1: stop notification is enqueued AFTER flush+stop on the
+        worker, mirroring UPSGroupMonitor._cleanup_and_exit. The row
+        stays `pending` in SQLite for the next coordinator's startup
+        sweep to cancel — same contract as single-UPS mode."""
+        import signal as _signal
+
+        config = _coord_config(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+        coord._notification_worker = MagicMock()
+        coord._threads = []
+
+        with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
+             patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
+             patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.sys.exit"):
+            coord._handle_signal(_signal.SIGTERM, None)
+
+        names = [c[0] for c in coord._notification_worker.method_calls]
+        assert "flush" in names
+        assert "stop" in names
+        assert "send" in names
+        assert names.index("flush") < names.index("send"), (
+            f"flush must happen before send; got order: {names}"
+        )
+        assert names.index("stop") < names.index("send"), (
+            f"stop must happen before send; got order: {names}"
+        )
+
+    @pytest.mark.unit
+    def test_handle_signal_skips_stop_notification_on_upgrade(self, tmp_path):
+        """v5.2.1: when an upgrade marker is on disk (postinstall.sh
+        dropped it before systemctl restart), the coordinator skips the
+        lifecycle stop entirely — the next daemon's '📦 Upgraded' message
+        will cover this transition."""
+        import signal as _signal
+
+        config = _coord_config(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+        coord._notification_worker = MagicMock()
+        coord._threads = []
+
+        marker = {"old_version": "5.2.0", "new_version": "5.2.1"}
+        with patch("eneru.multi_ups.read_upgrade_marker", return_value=marker), \
+             patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
+             patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.sys.exit"):
+            coord._handle_signal(_signal.SIGTERM, None)
+
+        send_calls = coord._notification_worker.send.call_args_list
+        assert send_calls == [], (
+            "Expected no lifecycle send when upgrade marker present; "
+            f"got: {send_calls}"
+        )
+        # flush + stop still happen (drains any non-lifecycle rows
+        # like a sequence-complete summary that landed mid-shutdown).
+        coord._notification_worker.flush.assert_called_once()
+        coord._notification_worker.stop.assert_called_once()
+
+    @pytest.mark.unit
+    def test_initialize_cancels_prev_pending_lifecycle_rows(self, tmp_path):
+        """v5.2.1: coordinator startup sweeps each per-UPS store and
+        cancels any pending lifecycle row from the previous instance
+        (the deferred 'Service Stopped' from _handle_signal). Without
+        this, multi-UPS users still see two notifications on every
+        restart — the single-UPS path does this inside
+        UPSGroupMonitor._emit_lifecycle_startup_notification but that
+        function early-returns in coordinator mode."""
+        from eneru.stats import StatsStore
+
+        config = _coord_config(tmp_path)
+        # Point statistics at tmp_path so we can pre-populate a real
+        # SQLite store with a pending lifecycle row, then verify the
+        # coordinator's sweep cancels it.
+        config.statistics.db_directory = str(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+
+        # Sanitize the same way the coordinator does to find the DB.
+        ups_name = config.ups_groups[0].ups.name
+        sanitized = (ups_name.replace("@", "-")
+                     .replace(":", "-").replace("/", "-"))
+        db_path = tmp_path / f"{sanitized}.db"
+
+        # Pre-populate: create a store, insert a pending lifecycle row.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row_id = store.enqueue_notification(
+                body="🛑 Eneru Service Stopped\nMonitoring is now inactive.",
+                notify_type="warning",
+                category="lifecycle",
+                ts=1000,
+            )
+            assert row_id is not None
+            pending_before = store.find_pending_by_category("lifecycle")
+            assert len(pending_before) == 1, (
+                f"Expected 1 pending row, got {pending_before}"
+            )
+        finally:
+            store.close()
+
+        # Run the sweep.
+        coord._cancel_prev_pending_lifecycle_rows(tmp_path)
+
+        # Verify the row is now cancelled with reason='superseded'.
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            pending_after = store.find_pending_by_category("lifecycle")
+            assert pending_after == [], (
+                "Expected zero pending lifecycle rows after sweep; "
+                f"got: {pending_after}"
+            )
+            # Confirm the cancel_reason is 'superseded' specifically.
+            row = store._conn.execute(
+                "SELECT status, cancel_reason FROM notifications "
+                "WHERE id = ?", (row_id,)
+            ).fetchone()
+            assert row == ("cancelled", "superseded")
+        finally:
+            store.close()
+
+    @pytest.mark.unit
+    def test_cancel_prev_pending_lifecycle_rows_skips_missing_db(self, tmp_path):
+        """First-ever start has no per-UPS DB on disk yet; the sweep
+        must silently skip and not raise."""
+        config = _coord_config(tmp_path)
+        config.statistics.db_directory = str(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+        # No DB created; nothing to sweep. Should be a no-op.
+        coord._cancel_prev_pending_lifecycle_rows(tmp_path)
+        # If we got here, the no-op succeeded.
+
 
 # ==============================================================================
 # COORDINATOR LOG FALLBACK

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1334,11 +1334,16 @@ class TestCoordinatorHandleSignal:
         coord = MultiUPSCoordinator(config)
         coord._log = lambda msg: None
         coord._notification_worker = MagicMock()
+        # Empty store list so the v5.2.1 deferred-delivery branch is a
+        # no-op (no first_store to schedule against).
+        coord._notification_worker._stores = []
+        coord._notification_worker._stores_lock = threading.RLock()
         coord._threads = []
 
         Path(config.logging.shutdown_flag_file).touch()
 
-        with patch("eneru.multi_ups.sys.exit") as mock_exit:
+        with patch("eneru.multi_ups.schedule_deferred_stop_or_eager_send"), \
+             patch("eneru.multi_ups.sys.exit") as mock_exit:
             coord._handle_signal(_signal.SIGTERM, None)
 
         coord._notification_worker.send.assert_called_once()
@@ -1367,22 +1372,25 @@ class TestCoordinatorHandleSignal:
             thread.join.assert_called_once_with(timeout=5)
 
     @pytest.mark.unit
-    def test_handle_signal_enqueues_stop_after_flush(self, tmp_path):
-        """v5.2.1: stop notification is enqueued AFTER flush+stop on the
-        worker, mirroring UPSGroupMonitor._cleanup_and_exit. The row
-        stays `pending` in SQLite for the next coordinator's startup
-        sweep to cancel — same contract as single-UPS mode."""
+    def test_handle_signal_enqueues_stop_after_flush_and_stop(self, tmp_path):
+        """v5.2.1: coordinator enqueues the stop AFTER flush+stop on the
+        worker so the row stays `pending` in SQLite, then schedules a
+        systemd-run timer (or eager-fallback) to deliver it ~15s later
+        unless the next daemon's classifier supersedes it first."""
         import signal as _signal
 
         config = _coord_config(tmp_path)
         coord = MultiUPSCoordinator(config)
         coord._log = lambda msg: None
         coord._notification_worker = MagicMock()
+        coord._notification_worker._stores = []
+        coord._notification_worker._stores_lock = threading.RLock()
         coord._threads = []
 
         with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
              patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
              patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.schedule_deferred_stop_or_eager_send"), \
              patch("eneru.multi_ups.sys.exit"):
             coord._handle_signal(_signal.SIGTERM, None)
 
@@ -1401,20 +1409,23 @@ class TestCoordinatorHandleSignal:
     def test_handle_signal_skips_stop_notification_on_upgrade(self, tmp_path):
         """v5.2.1: when an upgrade marker is on disk (postinstall.sh
         dropped it before systemctl restart), the coordinator skips the
-        lifecycle stop entirely — the next daemon's '📦 Upgraded' message
-        will cover this transition."""
+        lifecycle stop entirely AND the deferred-delivery scheduler —
+        the next daemon's '📦 Upgraded' message covers the transition."""
         import signal as _signal
 
         config = _coord_config(tmp_path)
         coord = MultiUPSCoordinator(config)
         coord._log = lambda msg: None
         coord._notification_worker = MagicMock()
+        coord._notification_worker._stores = []
+        coord._notification_worker._stores_lock = threading.RLock()
         coord._threads = []
 
         marker = {"old_version": "5.2.0", "new_version": "5.2.1"}
         with patch("eneru.multi_ups.read_upgrade_marker", return_value=marker), \
              patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
              patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.schedule_deferred_stop_or_eager_send") as sched, \
              patch("eneru.multi_ups.sys.exit"):
             coord._handle_signal(_signal.SIGTERM, None)
 
@@ -1423,6 +1434,7 @@ class TestCoordinatorHandleSignal:
             "Expected no lifecycle send when upgrade marker present; "
             f"got: {send_calls}"
         )
+        sched.assert_not_called()
         # flush + stop still happen (drains any non-lifecycle rows
         # like a sequence-complete summary that landed mid-shutdown).
         coord._notification_worker.flush.assert_called_once()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1159,6 +1159,86 @@ class TestQueryEventsForDisplay:
         assert line.startswith("????-??-?? ??:??:??")
 
 
+class TestSanitizeEventDetail:
+    """v5.2.1: lifecycle bodies stored in events.detail include
+    `**markdown bold**` and embedded `\\n` (the same body that goes to
+    Apprise where Discord/Slack render them natively). The TUI's curses
+    panel can't, so the sanitizer flattens to one line and strips the
+    asterisks. See screenshots in PR #35 for the broken-render case."""
+
+    @pytest.mark.unit
+    def test_strips_markdown_bold_markers(self):
+        from eneru.tui import _sanitize_event_detail
+        out = _sanitize_event_detail("📦 **Eneru Upgraded** v5.2.0 → v5.2.1")
+        assert "**" not in out
+        assert "📦 Eneru Upgraded v5.2.0 → v5.2.1" == out
+
+    @pytest.mark.unit
+    def test_collapses_embedded_newline(self):
+        """Embedded `\\n` mid-string used to make `curses.addstr` jump to
+        a new row before the gold background fill completed, leaving
+        cells unpainted (the 'broken colors' visible on the
+        'Service is back online' continuation row)."""
+        from eneru.tui import _sanitize_event_detail
+        out = _sanitize_event_detail(
+            "📦 **Eneru Upgraded** v5.2.0 → v5.2.1\n"
+            "Service is back online with the new version."
+        )
+        assert "\n" not in out
+        assert "**" not in out
+        assert "📦 Eneru Upgraded v5.2.0 → v5.2.1" in out
+        assert "Service is back online with the new version." in out
+        # Multi-line bodies join with " · " for visual separation.
+        assert " · " in out
+
+    @pytest.mark.unit
+    def test_collapses_multiple_newlines(self):
+        from eneru.tui import _sanitize_event_detail
+        out = _sanitize_event_detail("a\nb\nc")
+        assert out == "a · b · c"
+
+    @pytest.mark.unit
+    def test_strips_indentation_on_continuation_lines(self):
+        """A continuation line indented for Apprise readability shouldn't
+        leave a leading-space artifact in the joined one-liner."""
+        from eneru.tui import _sanitize_event_detail
+        out = _sanitize_event_detail("first\n   indented")
+        assert out == "first · indented"
+
+    @pytest.mark.unit
+    def test_drops_empty_continuation_lines(self):
+        from eneru.tui import _sanitize_event_detail
+        out = _sanitize_event_detail("a\n\n\nb")
+        assert out == "a · b"
+
+    @pytest.mark.unit
+    def test_passthrough_when_already_clean(self):
+        from eneru.tui import _sanitize_event_detail
+        assert _sanitize_event_detail("plain text 85%") == "plain text 85%"
+
+    @pytest.mark.unit
+    def test_empty_input(self):
+        from eneru.tui import _sanitize_event_detail
+        assert _sanitize_event_detail("") == ""
+        assert _sanitize_event_detail(None) == ""
+
+    @pytest.mark.unit
+    def test_format_event_line_renders_sanitized_detail(self):
+        """End-to-end: the rendered event line never contains `**` or
+        embedded `\\n` for any of the v5.2 lifecycle bodies."""
+        from eneru.tui import _format_event_line
+        line = _format_event_line(
+            ts=1700000000, label="UPS@h", event_type="DAEMON_UPGRADED",
+            detail=("📦 **Eneru Upgraded** v5.2.0 → v5.2.1\n"
+                    "Service is back online with the new version."),
+            multi_ups=False,
+        )
+        assert "\n" not in line
+        assert "**" not in line
+        assert "DAEMON_UPGRADED:" in line
+        assert "Service is back online" in line
+
+
 class TestRunOnceEventsOnly:
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary

Bug-fix release for two regressions reported within an hour of v5.2.0 shipping. Drop-in upgrade.

- **`📦 Eneru Upgraded vunknown → v5.2.0` on RPM**: RPM doesn't pass the previous version to postinstall (DEB does, RPM doesn't); v5.2.0's `${2:-unknown}` default rendered as the literal string. New `preinstall.sh` captures the outgoing version via `rpm -q eneru` (or `dpkg-query -W eneru`) BEFORE the new files unpack, plus a defensive fallback in `lifecycle.classify_startup` (`shutdown_marker.version` → `meta.last_seen_version` → literal `?`) so the user never sees `vunknown` regardless of how the marker was populated.

- **Two notifications on every `systemctl restart` and package upgrade**: v5.2's stateful classifier was meant to collapse stop+start within 30 s into a single `🔄 Restarted` (or `📦 Upgraded`), but the synchronous `flush(timeout=5)` shipped the `🛑 Service Stopped` before the new daemon could supersede it. Fix: enqueue the lifecycle stop AFTER `flush()`+`stop()` so the row stays `pending` in SQLite for the next daemon's classifier to cancel via `cancel_notification(reason='superseded')`. Same fix in `MultiUPSCoordinator._handle_signal`. New coordinator-startup sweep `_cancel_prev_pending_lifecycle_rows` extends the fix to multi-UPS mode (the per-monitor cancel block early-returns in coordinator mode, so the sweep is the symmetric piece).

- **`docs/notifications.md` caught up with v5.0/5.1/5.2**: still described the v4.7-era in-memory FIFO + retry architecture. Now covers SQLite-backed persistent queue, per-message exponential backoff, the new config knobs (`retention_days`, `max_attempts`, `max_age_days`, `max_pending`, `retry_backoff_max`), the lifecycle classifier states, and the brief-power-outage / recovery coalescing semantics. Comparison table extended to three columns (v4.6 / v4.7+ / v5.2+) per maintainer feedback.

## Test plan
- [ ] All 11 required CI checks green (`validate` × 6 + `E2E` × 5)
- [ ] New E2E Test 35 (stats group) proves single-UPS restart contract end-to-end
- [ ] New E2E Test 36 (multi-ups group) proves coordinator restart contract end-to-end
- [ ] Manual verification: `dnf reinstall eneru` produces a single `📦 Upgraded v5.2.0 → v5.2.1` notification (no `vunknown`, no preceding `Service Stopped`)
- [ ] Manual verification: `systemctl restart eneru` produces a single `🔄 Restarted (downtime: Ns)` notification
- [ ] Manual verification: pip upgrade path (`pip install --upgrade eneru` + `systemctl restart`) produces a single `📦 Upgraded v5.2.0 → v5.2.1` driven by `meta.last_seen_version` comparison
- [ ] After CI green, trigger `@coderabbitai full review` and `@cubic-dev-ai review this pull request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate lifecycle notifications and the RPM “vunknown” old version. v5.2.1 sends exactly one message for restart/upgrade, delivers “Service Stopped” instantly on `systemctl stop`, shows the correct previous version, and cleans up the TUI events panel. Drop‑in upgrade.

- **Bug Fixes**
  - Single lifecycle notification on restart/stop
    - Decision tree: if not under systemd or `systemctl list-jobs --no-legend` shows a `stop`, send eagerly; otherwise enqueue after `flush()+stop()` and schedule a transient `systemd-run` to call `eneru _deliver-stop` ~15s later. Locale forced via `LANG=C` for reliable parsing.
    - Early cancel of leftover pending lifecycle rows now runs before the worker starts; multi‑UPS still sweeps per‑UPS stores on coordinator startup.
    - Robustness: atomic UPDATE claim in `_deliver-stop` prevents double-send; on Apprise failure, revert to `pending`. If the stats DB can’t open, fall back to eager Apprise send so the stop isn’t lost.
  - Correct old version on RPM upgrades
    - New `preinstall.sh` records the outgoing version and clears any stale `/run/eneru/.old-version`; `postinstall.sh` initializes `OLD_VERSION` safely, prefers the preinstall value, and JSON‑encodes the marker. Startup falls back to `shutdown_marker.version` then `meta.last_seen_version`.
  - TUI events panel
    - Strips markdown bold and collapses newlines so event lines render cleanly on one row.
  - Docs/tests
    - `docs/notifications.md` updated with the 4‑case decision tree and aligned event categories; `docs/configuration.md` and `examples/config-reference.yaml` now include v5.2 queue knobs. Added unit tests for systemd job detection, atomic claim/revert, and coordinator sweep; tightened E2E assertions for single‑notification restarts (single and multi‑UPS).

<sup>Written for commit 2add11845abd44423faf54cd333fd7aac7a6ee13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate notifications during restarts/upgrades and improved prior-version detection for upgrade messages
  * Ensured single lifecycle message is emitted after restart/upgrade

* **New Features**
  * Deferred stop-delivery to allow replacement daemon to cancel superseded lifecycle notifications

* **Documentation**
  * Expanded notifications docs and config reference with persistent-queue controls and exponential backoff

* **UX**
  * TUI now sanitizes event details for cleaner single-line display

* **Tests**
  * Added E2E and unit tests covering restart, multi-UPS, deferred delivery, and lifecycle behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->