### PR TITLE
docs: revamp ReadTheDocs structure and restore reference depth

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,290 @@
+# Architecture
+
+Eneru is intentionally split into small, boring pieces. The daemon has to keep making shutdown decisions while networks are flaky, notification endpoints are unreachable, SQLite is slow, or a remote server is already half gone. Most architectural choices come from that constraint.
+
+This page is a map for operators and contributors. It explains the main runtime paths and points to the files to read next.
+
+## System shape
+
+Eneru does not talk to UPS hardware directly. NUT owns drivers and hardware communication; Eneru consumes NUT data and runs policy.
+
+```text
+  Hardware and drivers                 Eneru policy and action
+
++-----------------------+     +-----------------------+     +-----------------------+
+| UPS hardware          |     | NUT server / upsc     |     | Eneru monitor         |
+| USB, SNMP, vendor     +---->| driver-specific data  +---->| triggers and policy   |
+| protocol              |     | UPS variables         |     | shutdown coordinator  |
++-----------------------+     +-----------------------+     +-----------+-----------+
+                                                                  |
+                  +-------------------------------+---------------+----------------+
+                  |                               |                                |
+                  v                               v                                v
+       +----------+-----------+       +-----------+----------+        +------------+---------+
+       | Shutdown phases      |       | Observability        |        | Notifications        |
+       | VMs, containers, SSH |       | SQLite, events, TUI  |        | Apprise queue, retry |
+       | filesystems, local   |       | graphs, state file   |        | coalescing          |
+       +----------------------+       +----------------------+        +----------------------+
+```
+
+Start reading in [`src/eneru/monitor.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/monitor.py). The module owns the per-UPS monitor loop, UPS polling, trigger evaluation, state updates, and shutdown orchestration.
+
+## Per-UPS monitor loop
+
+Each UPS group runs the same core loop. The loop polls NUT, updates state, records a stats sample, evaluates health checks, and triggers shutdown when a policy condition is met.
+
+```text
+UPSGroupMonitor loop
+
+    +-----------------------+
+    | poll NUT via upsc     |
+    | one snapshot/cycle    |
+    +-----------+-----------+
+                |
+                v
+    +-----------+-----------+        +-------------------------+
+    | update MonitorState   +------->| state file              |
+    | status, timers, flags |        | SQLite sample buffer    |
+    +-----------+-----------+        +-------------------------+
+                |
+                v
+    +-----------+-----------+
+    | health checks         |
+    | voltage, AVR, bypass  |
+    | overload, battery     |
+    +-----------+-----------+
+                |
+                v
+    +-----------+-----------+
+    | shutdown triggers     |
+    | FSD, battery, runtime |
+    | depletion, extended   |
+    +-----------+-----------+
+                |
+                v
+    +-----------+-----------+
+    | shutdown sequence     |
+    | only when triggered   |
+    +-----------------------+
+```
+
+Key files:
+
+| File | What to read there |
+|------|--------------------|
+| [`src/eneru/monitor.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/monitor.py) | `UPSGroupMonitor`, polling, trigger evaluation, shutdown sequence, lifecycle cleanup |
+| [`src/eneru/state.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/state.py) | `MonitorState`, the in-memory state shared by the loop, TUI snapshots, and redundancy evaluator |
+| [`src/eneru/health/voltage.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/health/voltage.py) | Voltage thresholds, auto-detect re-snap, hysteresis, AVR, bypass, overload |
+| [`src/eneru/health/battery.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/health/battery.py) | Depletion-rate history and battery anomaly confirmation |
+
+## Shutdown phases are mixins
+
+Shutdown behavior is decomposed into mixins instead of one large monitor file. `UPSGroupMonitor` owns the sequence; each phase owns its own implementation.
+
+```text
+UPSGroupMonitor
+  |
+  +-- VMShutdownMixin
+  |     libvirt / virsh graceful shutdown, force-destroy fallback
+  |
+  +-- ContainerShutdownMixin
+  |     Docker / Podman detection, compose stacks, remaining containers
+  |
+  +-- FilesystemShutdownMixin
+  |     sync, per-mount unmount, timeout handling
+  |
+  +-- RemoteShutdownMixin
+        SSH phases, pre-shutdown actions, final shutdown command
+```
+
+The sequence stays readable in `monitor.py`, while the mechanics live in small files:
+
+| File | Phase |
+|------|-------|
+| [`src/eneru/shutdown/vms.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/shutdown/vms.py) | Libvirt/KVM VMs |
+| [`src/eneru/shutdown/containers.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/shutdown/containers.py) | Docker, Podman, compose |
+| [`src/eneru/shutdown/filesystems.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/shutdown/filesystems.py) | Sync and unmount |
+| [`src/eneru/shutdown/remote.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/shutdown/remote.py) | SSH-based remote shutdown |
+| [`src/eneru/actions.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/actions.py) | Predefined remote action command templates |
+
+This makes shutdown extensions easier to review. A new phase should be a small mixin, wired into `UPSGroupMonitor`, documented in the config reference, and covered by unit and E2E tests.
+
+## Multi-UPS coordination
+
+Single-UPS mode runs one `UPSGroupMonitor`. Multi-UPS mode creates one monitor per UPS group and shares the logger, notification worker, and local-shutdown coordination.
+
+```text
+                    +------------------------+
+                    | MultiUPSCoordinator    |
+                    | starts one monitor per |
+                    | configured UPS group   |
+                    +-----------+------------+
+                                |
+       +------------------------+------------------------+
+       |                        |                        |
+       v                        v                        v
++------+---------+      +-------+--------+       +-------+--------+
+| UPS group A    |      | UPS group B    |       | UPS group C    |
+| monitor thread |      | monitor thread |       | monitor thread |
++------+---------+      +-------+--------+       +-------+--------+
+       |                        |                        |
+       +------------------------+------------------------+
+                                |
+                                v
+                    +-----------+------------+
+                    | shared services        |
+                    | notification worker    |
+                    | local shutdown lock    |
+                    | lifecycle coordination |
+                    +------------------------+
+```
+
+The important rule is ownership. Only the group marked `is_local: true` can manage local resources such as VMs, containers, and filesystems. Remote servers can belong to any UPS group, but validation prevents duplicate ownership.
+
+Read [`src/eneru/multi_ups.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/multi_ups.py) for coordinator lifecycle, monitor thread management, local shutdown locking, and signal handling.
+
+## Redundancy groups
+
+Redundancy groups are separate from independent UPS groups. They watch multiple UPS snapshots and shut down shared resources only when quorum is lost.
+
+```text
+ +----------------------+     +----------------------+
+ | UPS-A monitor state  |     | UPS-B monitor state  |
+ | health + advisory    |     | health + advisory    |
+ +----------+-----------+     +----------+-----------+
+            |                            |
+            +-------------+--------------+
+                          |
+                          v
+            +-------------+--------------+
+            | RedundancyGroupEvaluator   |
+            | classify each member as    |
+            | HEALTHY, DEGRADED,         |
+            | CRITICAL, or UNKNOWN       |
+            +-------------+--------------+
+                          |
+                          v
+                  quorum still healthy?
+                     |              |
+                    yes             no
+                     |              |
+                     v              v
+             keep monitoring   run group shutdown
+```
+
+Per-UPS triggers still run for redundancy members, but they become advisory flags. The evaluator decides whether the group should act based on `min_healthy`, `degraded_counts_as`, and `unknown_counts_as`.
+
+Read [`src/eneru/redundancy.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/redundancy.py) for the evaluator, executor, group flag files, and shutdown reuse.
+
+## Persistent notifications
+
+Notifications are deliberately asynchronous. The monitor inserts a row into SQLite and continues; a worker thread handles delivery, retry, coalescing, and lifecycle cleanup.
+
+```text
+ +-------------------+      insert row       +------------------------+
+ | monitor thread    +---------------------->| SQLite notifications   |
+ | power/lifecycle   |                       | pending/sent/cancelled |
+ | event occurs      |                       +-----------+------------+
+ +---------+---------+                                   ^
+           |                                             |
+           | continue shutdown                           | retry/update rows
+           v                                             |
+ +---------+---------+                         +---------+--------------+
+ | shutdown work     |                         | NotificationWorker    |
+ | never waits on    |                         | Apprise delivery      |
+ | network delivery  |                         | coalescing, pruning   |
+ +-------------------+                         +------------------------+
+```
+
+This solves a real outage problem: when power is unstable, the network path to Discord, email, ntfy, or a phone push provider is often unstable too. Eneru should not delay VM shutdown because a notification endpoint is down.
+
+Key files:
+
+| File | What to read there |
+|------|--------------------|
+| [`src/eneru/notifications.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/notifications.py) | `NotificationWorker`, retry, backoff, coalescing, flush behavior |
+| [`src/eneru/stats.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/stats.py) | SQLite `notifications` table and persistence helpers |
+| [`src/eneru/lifecycle.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/lifecycle.py) | Startup classification, recovery fold-in, lifecycle coalescing |
+| [`src/eneru/deferred_delivery.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/deferred_delivery.py) | systemd deferred stop delivery and restart suppression |
+
+## SQLite stats and TUI separation
+
+The monitoring loop writes samples to an in-memory buffer. `StatsWriter` flushes that buffer in the background. The TUI opens the database read-only and blends in live state-file samples so graphs do not lag by the full writer interval.
+
+```text
+ +--------------+      +------------------+      +------------------+
+ | monitor loop +----->| sample buffer    +----->| StatsWriter      |
+ | one UPS poll |      | in memory        |      | flush every 10s  |
+ +--------------+      +------------------+      +--------+---------+
+                                                           |
+                                                           v
+                                                 +---------+----------+
+                                                 | per-UPS SQLite    |
+                                                 | samples, events   |
+                                                 | aggregates, queue |
+                                                 +---------+----------+
+                                                           ^
+                                                           |
+                                       read-only queries   |
+                                                           |
+                                                 +---------+----------+
+                                                 | TUI dashboard     |
+                                                 | status, graph     |
+                                                 | recent events     |
+                                                 +--------------------+
+```
+
+Read [`src/eneru/stats.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/stats.py), [`src/eneru/tui.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/tui.py), and [`src/eneru/graph.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/graph.py) for the data store, dashboard, and Braille graph renderer.
+
+## Configuration as a safety boundary
+
+Config parsing is not just YAML loading. It encodes safety rules:
+
+- Raw voltage warning thresholds are not user-configurable; users choose bounded presets.
+- Safety-critical notification events cannot be suppressed.
+- Non-local UPS groups cannot own local resources.
+- A remote server cannot be owned by both an independent UPS group and a redundancy group.
+- `shutdown_order` and legacy `parallel` are mutually exclusive.
+- Exactly one UPS or redundancy group may be local.
+
+```text
+config.yaml
+    |
+    v
++---+----------------+
+| ConfigLoader       |
+| parse YAML         |
+| apply defaults     |
+| validate safety    |
++---+----------------+
+    |
+    v
+typed dataclasses used by monitors, coordinator, TUI, and workers
+```
+
+Read [`src/eneru/config.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/config.py) for the dataclasses, parser, compatibility aliases, and validator rules.
+
+## Packaging matters
+
+Eneru is a system daemon first. The native package path and the PyPI path intentionally differ:
+
+| Install path | Runtime shape |
+|--------------|---------------|
+| deb/rpm | `/opt/ups-monitor/eneru.py` wrapper, systemd service, config under `/etc/ups-monitor/`, command exposed as `eneru` |
+| PyPI | Python package entry point, user-managed service or foreground process |
+
+This is why packaging tests check installed files and import layout. The deb/rpm build enumerates package contents explicitly in `nfpm.yaml`, so adding a new module under `src/eneru/` requires a matching package entry.
+
+Read [`packaging/eneru-wrapper.py`](https://github.com/m4r1k/Eneru/blob/main/packaging/eneru-wrapper.py), [`packaging/eneru.service`](https://github.com/m4r1k/Eneru/blob/main/packaging/eneru.service), [`nfpm.yaml`](https://github.com/m4r1k/Eneru/blob/main/nfpm.yaml), and [`tests/test_packaging.py`](https://github.com/m4r1k/Eneru/blob/main/tests/test_packaging.py).
+
+## Contributor reading order
+
+If you want to dig deeper, read in this order:
+
+1. [`src/eneru/CLAUDE.md`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/CLAUDE.md) for the module map and mixin conventions.
+2. [`src/eneru/config.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/config.py) for the data model.
+3. [`src/eneru/monitor.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/monitor.py) for the single-UPS runtime.
+4. [`src/eneru/multi_ups.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/multi_ups.py) for group coordination.
+5. [`src/eneru/redundancy.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/redundancy.py) if you are working on A+B power.
+6. [`src/eneru/notifications.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/notifications.py) and [`src/eneru/stats.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/stats.py) if you are working on observability.
+7. The matching tests under [`tests/`](https://github.com/m4r1k/Eneru/tree/main/tests) before changing behavior.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,7 +139,7 @@ Single-UPS mode runs one `UPSGroupMonitor`. Multi-UPS mode creates one monitor p
                     +------------------------+
 ```
 
-The important rule is ownership. Only the group marked `is_local: true` can manage local resources such as VMs, containers, and filesystems. Remote servers can belong to any UPS group, but validation prevents duplicate ownership.
+Only the group marked `is_local: true` can manage local resources such as VMs, containers, and filesystems. Remote servers can belong to any UPS group, but validation prevents duplicate ownership.
 
 Read [`src/eneru/multi_ups.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/multi_ups.py) for coordinator lifecycle, monitor thread management, local shutdown locking, and signal handling.
 
@@ -196,7 +196,7 @@ Notifications are deliberately asynchronous. The monitor inserts a row into SQLi
  +-------------------+                         +------------------------+
 ```
 
-This solves a real outage problem: when power is unstable, the network path to Discord, email, ntfy, or a phone push provider is often unstable too. Eneru should not delay VM shutdown because a notification endpoint is down.
+When power is unstable, the network is usually unstable too. Discord, email, ntfy, and phone push services can all be unreachable while shutdown is in progress. Eneru should not block VM shutdown because a notification endpoint is down.
 
 Key files:
 
@@ -238,7 +238,7 @@ Read [`src/eneru/stats.py`](https://github.com/m4r1k/Eneru/blob/main/src/eneru/s
 
 ## Configuration as a safety boundary
 
-Config parsing is not just YAML loading. It encodes safety rules:
+Config loading enforces a set of safety rules at parse time:
 
 - Raw voltage warning thresholds are not user-configurable; users choose bounded presets.
 - Safety-critical notification events cannot be suppressed.
@@ -273,7 +273,7 @@ Eneru is a system daemon first. The native package path and the PyPI path intent
 | deb/rpm | `/opt/ups-monitor/eneru.py` wrapper, systemd service, config under `/etc/ups-monitor/`, command exposed as `eneru` |
 | PyPI | Python package entry point, user-managed service or foreground process |
 
-This is why packaging tests check installed files and import layout. The deb/rpm build enumerates package contents explicitly in `nfpm.yaml`, so adding a new module under `src/eneru/` requires a matching package entry.
+Packaging tests check installed files and import layout because the deb/rpm build enumerates package contents explicitly in `nfpm.yaml`. Adding a new module under `src/eneru/` requires a matching package entry.
 
 Read [`packaging/eneru-wrapper.py`](https://github.com/m4r1k/Eneru/blob/main/packaging/eneru-wrapper.py), [`packaging/eneru.service`](https://github.com/m4r1k/Eneru/blob/main/packaging/eneru.service), [`nfpm.yaml`](https://github.com/m4r1k/Eneru/blob/main/nfpm.yaml), and [`tests/test_packaging.py`](https://github.com/m4r1k/Eneru/blob/main/tests/test_packaging.py).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,6 +207,8 @@ In single-UPS mode this is `ups:`. In multi-UPS mode each list entry accepts the
 
 The grace period never weakens failsafe behavior. If Eneru loses UPS visibility while the UPS is on battery, shutdown starts immediately.
 
+See [Troubleshooting](troubleshooting.md#intermittent-nut-drops) for tuning guidance on flaky NUT servers and the flap-counter behavior.
+
 ## Triggers
 
 | Key | Default | Description |
@@ -220,7 +222,7 @@ The grace period never weakens failsafe behavior. If Eneru loses UPS visibility 
 | `extended_time.threshold` | `900` | Seconds on battery before extended-time shutdown |
 | `voltage_sensitivity` | `normal` | Voltage warning preset: `tight`, `normal`, or `loose` |
 
-See [Shutdown triggers](triggers.md) for decision order and voltage threshold details.
+See [Shutdown triggers](triggers.md) for decision order, voltage threshold details, and common UPS transfer points by vendor.
 
 ## Notifications
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,34 +1,24 @@
-# Configuration
+# Configuration reference
 
-Configuration is stored in `/etc/ups-monitor/config.yaml`. Features are disabled by removing their section or setting `enabled: false`.
+Eneru reads YAML from `/etc/ups-monitor/config.yaml` by default. Pass a different file with `--config`.
 
-For a comprehensive reference config with every feature flag documented, see [`examples/config-reference.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-reference.yaml). For real-world shapes, see [`examples/config-minimal.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-minimal.yaml), [`examples/config-homelab.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-homelab.yaml), [`examples/config-enterprise.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-enterprise.yaml), and [`examples/config-dual-ups.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-dual-ups.yaml).
+The config has two shapes:
 
----
+| Shape | Use it when | Resource placement |
+|-------|-------------|--------------------|
+| Single UPS | One UPS protects the Eneru host and its resources | Top-level `virtual_machines`, `containers`, `filesystems`, and `remote_servers` |
+| Multi UPS | One Eneru instance monitors several independent UPSes | Resources live under each `ups:` list entry |
 
-## Two configuration modes
+Features are off unless their section enables them, except `local_shutdown`, `filesystems.sync_enabled`, extended-time shutdown, and statistics, which have safe defaults.
 
-Eneru supports two top-level shapes for the `ups:` key:
+The tables below cover every YAML key currently parsed by `ConfigLoader`, including the legacy `docker:` and `discord:` compatibility forms. The exhaustive commented sample is [`examples/config-reference.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-reference.yaml). Shorter starting points are in [`examples/`](https://github.com/m4r1k/Eneru/tree/main/examples).
 
-- **Single-UPS (legacy)**: `ups:` is a mapping. Resources (`virtual_machines`, `containers`, `remote_servers`, `filesystems`) sit at the top level. Use this when one UPS protects everything.
-- **Multi-UPS (recommended for >1 UPS)**: `ups:` is a list of entries. Each entry carries its own `triggers:`, resources, and `is_local` flag. Use this when independent UPSes each protect their own set of servers.
-
-Both modes parse through the same dataclasses, so the per-section reference tables below apply to both. Multi-UPS adds [redundancy groups](redundancy-groups.md) on top: shared resources protected by 2+ UPS sources (dual-PSU servers behind A+B feeds), with quorum-based shutdown.
-
----
-
-## Single-UPS configuration example
+## Single UPS example
 
 ```yaml
-# UPS Monitor Configuration File
-# All sections are optional - features are disabled if not configured
-
-# ==============================================================================
-# UPS CONNECTION
-# ==============================================================================
 ups:
-  name: "UPS@192.168.178.11"
-  display_name: "Homelab UPS"        # optional, used in logs / notifications
+  name: "UPS@192.168.1.100"
+  display_name: "Homelab UPS"
   check_interval: 1
   max_stale_data_tolerance: 3
   connection_loss_grace_period:
@@ -36,108 +26,52 @@ ups:
     duration: 60
     flap_threshold: 5
 
-# ==============================================================================
-# SHUTDOWN TRIGGERS
-# ==============================================================================
 triggers:
   low_battery_threshold: 20
   critical_runtime_threshold: 600
-  voltage_sensitivity: normal        # tight / normal / loose -- see triggers.md
-
+  voltage_sensitivity: normal
   depletion:
     window: 300
     critical_rate: 15.0
     grace_period: 90
-
   extended_time:
     enabled: true
     threshold: 900
 
-# ==============================================================================
-# BEHAVIOR
-# ==============================================================================
-behavior:
-  dry_run: false
-
-# ==============================================================================
-# LOGGING
-# ==============================================================================
-logging:
-  file: "/var/log/ups-monitor.log"
-  state_file: "/var/run/ups-monitor.state"
-  battery_history_file: "/var/run/ups-battery-history"
-  shutdown_flag_file: "/var/run/ups-shutdown-scheduled"
-
-# ==============================================================================
-# NOTIFICATIONS (via Apprise)
-# ==============================================================================
-# Apprise supports 100+ notification services
-# See: https://github.com/caronc/apprise/wiki
 notifications:
-  title: "⚡ Homelab UPS"            # optional title prefix
-  avatar_url: "https://raw.githubusercontent.com/m4r1k/Eneru/main/docs/images/eneru-avatar.png"
-  timeout: 10
-  retry_interval: 5
-  voltage_hysteresis_seconds: 30     # debounce voltage flap (default 30s)
-  suppress: []                       # per-event mute -- see Notifications table
+  title: "Homelab UPS"
   urls:
     - "discord://webhook_id/webhook_token"
-    # - "slack://token_a/token_b/token_c/#channel"
-    # - "telegram://bot_token/chat_id"
 
-# ==============================================================================
-# STATISTICS (always-on per-UPS SQLite store)
-# ==============================================================================
-statistics:
-  db_directory: "/var/lib/eneru"
-  retention:
-    raw_hours: 24
-    agg_5min_days: 30
-    agg_hourly_days: 1825             # ~5 years
-
-# ==============================================================================
-# SHUTDOWN SEQUENCE
-# ==============================================================================
-
-# Virtual Machines (libvirt/KVM)
 virtual_machines:
   enabled: true
-  max_wait: 30
+  max_wait: 60
 
-# Container Runtime (Docker/Podman)
 containers:
   enabled: true
-  runtime: "auto"                    # auto / docker / podman
+  runtime: auto
   stop_timeout: 60
   compose_files:
     - path: "/opt/database/docker-compose.yml"
-      stop_timeout: 120              # per-file override
-    - "/opt/apps/docker-compose.yml" # uses global stop_timeout
+      stop_timeout: 120
+    - "/opt/apps/docker-compose.yml"
   shutdown_all_remaining_containers: true
-  include_user_containers: false     # podman-only: also stop rootless user containers
 
-# Filesystem Operations
 filesystems:
   sync_enabled: true
   unmount:
     enabled: true
     timeout: 15
     mounts:
-      - "/mnt/media"
       - path: "/mnt/nas"
-        options: "-l"                # lazy unmount
-      - "/mnt/backup"
+        options: "-l"
 
-# Remote Server Shutdown
-# Use shutdown_order to define phases. Same order = parallel, ascending = sequential.
-# Legacy parallel: false still works for simple two-group setups.
 remote_servers:
   - name: "Proxmox Host"
     enabled: true
-    host: "192.168.178.100"
+    host: "192.168.1.60"
     user: "root"
-    command_timeout: 30
-    shutdown_order: 1                # phase 1
+    shutdown_order: 1
     pre_shutdown_commands:
       - action: "stop_proxmox_vms"
         timeout: 180
@@ -146,452 +80,362 @@ remote_servers:
       - action: "sync"
     shutdown_command: "shutdown -h now"
 
-  - name: "Synology NAS"
-    enabled: true
-    host: "192.168.178.229"
-    user: "nas-admin"
-    shutdown_order: 2                # phase 2 -- runs after phase 1 completes
-    shutdown_command: "sudo -i synoshutdown -s"
-
-# Local Server Shutdown
 local_shutdown:
   enabled: true
   command: "shutdown -h now"
-  message: "UPS battery critical - emergency shutdown"
-  drain_on_local_shutdown: false     # multi-UPS: drain all groups before local shutdown
-  trigger_on: "any"                  # multi-UPS: "any" or "none"
-  wall: false                        # broadcast shutdown via wall(1) to every tty (off since v5.2)
 ```
 
----
+## Multi UPS example
 
-## Multi-UPS configuration example
-
-When you have more than one UPS, list them under `ups:` so each carries its own resources and triggers. Only the entry marked `is_local: true` may own local resources (VMs, containers, filesystems). Per-UPS `triggers:` overrides the global defaults; absent keys inherit.
+Use a list under `ups:` when each UPS protects a different set of resources. Exactly one group may set `is_local: true` if Eneru should manage local VMs, containers, filesystems, or local shutdown ownership.
 
 ```yaml
 ups:
-  # UPS 1 powers the Eneru host + its local resources
   - name: "UPS1@192.168.1.10"
-    display_name: "Main Rack"
+    display_name: "Main rack"
     is_local: true
     triggers:
-      voltage_sensitivity: tight     # clean PDU -- want early warning
-
+      voltage_sensitivity: tight
     virtual_machines:
       enabled: true
     containers:
       enabled: true
-      runtime: auto
     remote_servers:
-      - name: "Proxmox Node 1"
+      - name: "Proxmox Node"
         enabled: true
         host: "192.168.1.20"
         user: "root"
 
-  # UPS 2 powers a separate rack
   - name: "UPS2@192.168.1.11"
-    display_name: "Backup Rack"
+    display_name: "Storage rack"
     triggers:
-      voltage_sensitivity: loose     # generator-fed -- dial back
-
+      voltage_sensitivity: loose
     remote_servers:
-      - name: "Synology NAS"
+      - name: "NAS"
         enabled: true
         host: "192.168.1.30"
-        user: "nas-admin"
+        user: "admin"
         shutdown_command: "sudo -i synoshutdown -s"
 
-# Global triggers used as defaults when a per-UPS entry omits them
 triggers:
   low_battery_threshold: 20
   critical_runtime_threshold: 600
 
-# Global notifications, statistics, logging, local_shutdown -- shared
-notifications:
-  urls: ["discord://webhook_id/webhook_token"]
-
 local_shutdown:
   enabled: true
-  drain_on_local_shutdown: false     # don't shut other groups when local UPS dies
-  trigger_on: "any"                  # any group's shutdown triggers local shutdown
+  drain_on_local_shutdown: false
+  trigger_on: any
 ```
 
-See [`examples/config-dual-ups.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-dual-ups.yaml) for a complete multi-UPS example.
+Top-level `triggers:` acts as the default. Per-UPS `triggers:` overrides only the keys it sets.
 
----
+## Redundancy group example
 
-## Redundancy groups
-
-For dual-PSU servers fed by two UPSes (A+B power feeds), define a redundancy group. Eneru only fires the group's shutdown when fewer than `min_healthy` member UPSes still report a healthy snapshot. UPSes referenced in `ups_sources:` must also appear in the top-level `ups:` list.
+Redundancy groups are for shared resources fed by multiple UPSes, usually dual-PSU servers. Members still appear under top-level `ups:`; the group references their exact names.
 
 ```yaml
 ups:
-  - name: "UPS-A@192.168.1.10"
-  - name: "UPS-B@192.168.1.11"
+  - name: "UPS-A@10.0.0.10"
+  - name: "UPS-B@10.0.0.11"
 
 redundancy_groups:
   - name: "rack-1-dual-psu"
     ups_sources:
-      - "UPS-A@192.168.1.10"
-      - "UPS-B@192.168.1.11"
-    min_healthy: 1                   # shutdown when fewer than 1 healthy
-    degraded_counts_as: "healthy"    # voltage warnings still count as healthy
-    unknown_counts_as: "critical"    # stale NUT data treated as failed
-    is_local: false
+      - "UPS-A@10.0.0.10"
+      - "UPS-B@10.0.0.11"
+    min_healthy: 1
+    degraded_counts_as: healthy
+    unknown_counts_as: critical
     remote_servers:
-      - name: "Dual-PSU Server"
+      - name: "Dual PSU server"
         enabled: true
-        host: "192.168.1.50"
+        host: "10.0.0.20"
         user: "root"
 ```
 
-See [Redundancy Groups](redundancy-groups.md) for the full semantics: quorum policy, advisory-mode triggers on members, cross-group cascades, and the validator's ownership rules.
+See [Redundancy groups](redundancy-groups.md) for quorum behavior.
 
----
+## Validate config
 
-## Configuration reference
+Package install:
 
-### UPS section
+```bash
+sudo eneru validate --config /etc/ups-monitor/config.yaml
+```
 
-In single-UPS mode, this section sits at the top level. In multi-UPS mode, the same keys live under each `ups[].` entry.
+PyPI install:
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `name` | `UPS@localhost` | UPS identifier in `NAME@HOST` format |
-| `display_name` | `null` | Optional human-readable name used in logs / notifications. Falls back to `name` |
-| `check_interval` | `1` | Seconds between status checks |
-| `max_stale_data_tolerance` | `3` | Stale data attempts before connection is marked lost |
-| `is_local` | `false` | Multi-UPS only. Marks the UPS that powers the Eneru host. At most one `is_local: true` entry across `ups_groups + redundancy_groups`. Required to own local resources (VMs, containers, filesystems) |
-| `connection_loss_grace_period.enabled` | `true` | Enable grace period for connection loss notifications |
-| `connection_loss_grace_period.duration` | `60` | Seconds to suppress notifications after connection loss |
-| `connection_loss_grace_period.flap_threshold` | `5` | Send warning after this many grace-period recoveries within 24h |
+```bash
+eneru validate --config /etc/ups-monitor/config.yaml
+```
 
-#### Connection loss grace period
+Validation catches YAML errors, invalid enum values, local-resource ownership mistakes, duplicate remote-server ownership, bad redundancy-group references, and unsafe notification suppression.
 
-When a NUT server becomes unreachable while the UPS is on line power, Eneru waits
-for the configured duration before sending a `CONNECTION_LOST` notification. If the
-connection recovers within this window, no notification is sent. This avoids
-notification storms from flaky NUT server connections, which are common with
-integrated NUT servers on some UPS devices.
+## Top-level sections
 
-If the connection repeatedly flaps (recovers within the grace period), Eneru sends a
-single `WARNING` notification after the configured number of flaps (`flap_threshold`)
-within a 24-hour window to indicate the NUT server is unstable.
+| Section | Scope | Purpose |
+|---------|-------|---------|
+| `ups` | Required | One UPS mapping or a list of UPS groups |
+| `triggers` | Global defaults, overridable per group | Shutdown thresholds and voltage sensitivity |
+| `behavior` | Global | Dry-run mode |
+| `logging` | Global | Log, state, history, and shutdown flag paths |
+| `notifications` | Global | Apprise URLs, retry, coalescing, and event suppression |
+| `statistics` | Global | SQLite history location and retention |
+| `virtual_machines` | Single UPS or local group only | Libvirt VM shutdown |
+| `containers` | Single UPS or local group only | Docker or Podman shutdown |
+| `filesystems` | Single UPS or local group only | Sync and unmounts |
+| `remote_servers` | Single UPS, UPS group, or redundancy group | SSH-based remote shutdown |
+| `local_shutdown` | Global | Local host poweroff behavior |
+| `redundancy_groups` | Global | Quorum-controlled shared resources |
+| `docker` | Legacy single-UPS alias | Compatibility alias for `containers:` with Docker runtime |
+| `discord` | Legacy notification alias | Compatibility alias converted into `notifications.urls` |
 
-**Important:** The grace period never affects the failsafe mechanism. If the UPS is
-on battery power when the connection is lost, Eneru triggers an immediate emergency
-shutdown regardless of the grace period setting.
+## UPS
 
-### Triggers section
-
-Per-UPS in multi-UPS mode. Top-level `triggers:` provides the defaults that per-UPS entries inherit unless they override.
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `low_battery_threshold` | `20` | Battery percentage that triggers immediate shutdown |
-| `critical_runtime_threshold` | `600` | Runtime (seconds) that triggers shutdown |
-| `depletion.window` | `300` | Seconds of history for depletion calculation |
-| `depletion.critical_rate` | `15.0` | Percentage per minute threshold |
-| `depletion.grace_period` | `90` | Seconds to ignore high depletion after power loss |
-| `extended_time.enabled` | `true` | Enable extended time on battery shutdown |
-| `extended_time.threshold` | `900` | Seconds on battery before shutdown |
-| `voltage_sensitivity` | `normal` | Voltage warning band preset: `tight` (±5%), `normal` (±10%, EN 50160), `loose` (±15%). See [voltage thresholds](triggers.md#voltage-thresholds-preset-driven-raw-thresholds-not-user-configurable) |
-
-See [Shutdown triggers](triggers.md) for details on each trigger.
-
-### Notifications section
-
-Global (one block for the whole daemon). Notifications are dispatched via Apprise.
+In single-UPS mode this is `ups:`. In multi-UPS mode each list entry accepts the same fields.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `urls` | `[]` | List of Apprise notification URLs. Empty = notifications disabled |
-| `title` | `null` | Optional title prefix for notifications |
-| `avatar_url` | `null` | Avatar URL for supported services (Discord, Slack, Mattermost, Guilded, Zulip) |
-| `timeout` | `10` | Notification delivery timeout in seconds |
-| `retry_interval` | `5` | Initial wait between retry attempts for a failed notification. Per-message exponential backoff doubles this on each failure up to `retry_backoff_max` |
-| `retry_backoff_max` | `300` | Ceiling on the per-message exponential backoff, in seconds (5 min). Keeps reconnection quick once the endpoint returns without hammering the network during a long outage |
-| `max_attempts` | `0` | Per-message attempt cap. `0` = unlimited (default). Apprise's success/fail signal is a bool — Eneru can't tell "bad URL" from "internet down", so capping attempts risks dropping legitimate messages during a long outage. Set this only as a poison-message kill switch |
-| `max_age_days` | `30` | Pending notifications older than this become `cancelled` with reason `too_old`. The only TTL on `pending` rows; `0` disables it. Sized for "long weekend with the internet down" |
-| `max_pending` | `10000` | Backlog cap on pending rows. When pending exceeds this, the oldest are cancelled with reason `backlog_overflow`. Bounds DB growth on runaway-event days |
-| `retention_days` | `7` | Days to keep `sent` and `cancelled` rows around for forensic inspection via `sqlite3`. `pending` rows are NEVER pruned by TTL — only `max_age_days` ages them out |
-| `voltage_hysteresis_seconds` | `30` | Defer voltage `BROWNOUT` / `OVER_VOLTAGE` notifications until the condition has held this long. State log row is always immediate; only notification dispatch is deferred. `0` = legacy immediate behaviour. Severe deviations (>±15%) bypass the dwell |
-| `suppress` | `[]` | Per-event mute. Logs always record the event; only the notification is muted. Safety-critical events (`OVER_VOLTAGE_DETECTED`, `BROWNOUT_DETECTED`, `OVERLOAD_ACTIVE`, `BYPASS_MODE_ACTIVE`, `ON_BATTERY`, `CONNECTION_LOST`, any `SHUTDOWN_*`) are validator-rejected. Suppressible: `POWER_RESTORED`, `VOLTAGE_NORMALIZED`, `AVR_BOOST_ACTIVE`, `AVR_TRIM_ACTIVE`, `AVR_INACTIVE`, `BYPASS_MODE_INACTIVE`, `OVERLOAD_RESOLVED`, `CONNECTION_RESTORED`, `VOLTAGE_AUTODETECT_MISMATCH`, `VOLTAGE_FLAP_SUPPRESSED` |
+| `name` | `UPS@localhost` | NUT UPS identifier in `NAME@HOST` form. Use `NAME@HOST:PORT` if needed |
+| `display_name` | `null` | Human label for logs, notifications, and TUI |
+| `check_interval` | `1` | Poll interval in seconds |
+| `max_stale_data_tolerance` | `3` | Failed or stale polls before connection handling starts |
+| `is_local` | `false` | Multi-UPS only. This group powers the Eneru host and may own local resources |
+| `connection_loss_grace_period.enabled` | `true` | Suppress notifications for brief NUT outages while the UPS is on line power |
+| `connection_loss_grace_period.duration` | `60` | Seconds to wait before sending `CONNECTION_LOST` |
+| `connection_loss_grace_period.flap_threshold` | `5` | Warning threshold for repeated grace-period recoveries within 24 hours |
 
-See [Notifications](notifications.md) for service-specific URL formats and setup.
+The grace period never weakens failsafe behavior. If Eneru loses UPS visibility while the UPS is on battery, shutdown starts immediately.
 
-### Statistics section
-
-Global. Eneru always writes per-UPS SQLite stats; this section tunes where they live and how long each tier is kept.
+## Triggers
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `db_directory` | `/var/lib/eneru` | Directory for per-UPS `.db` files. One file per UPS, named after the sanitised UPS label |
-| `retention.raw_hours` | `24` | Hours of raw 1Hz samples kept |
-| `retention.agg_5min_days` | `30` | Days of 5-minute aggregates kept |
-| `retention.agg_hourly_days` | `1825` | Days (~5 years) of hourly aggregates kept |
+| `low_battery_threshold` | `20` | Battery percentage that triggers shutdown |
+| `critical_runtime_threshold` | `600` | UPS runtime estimate, in seconds, that triggers shutdown |
+| `depletion.window` | `300` | Battery-history window for depletion calculation |
+| `depletion.critical_rate` | `15.0` | Percentage points per minute that triggers shutdown |
+| `depletion.grace_period` | `90` | Seconds after power loss before depletion rate can trigger shutdown |
+| `extended_time.enabled` | `true` | Enable wall-clock time-on-battery shutdown |
+| `extended_time.threshold` | `900` | Seconds on battery before extended-time shutdown |
+| `voltage_sensitivity` | `normal` | Voltage warning preset: `tight`, `normal`, or `loose` |
 
-See [Statistics](statistics.md) for the schema, query examples, and storage volume estimates.
+See [Shutdown triggers](triggers.md) for decision order and voltage threshold details.
 
-### Logging section
+## Notifications
 
-Global.
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `file` | `/var/log/ups-monitor.log` | Log file path. Set to `null` to disable file logging (stdout still works) |
-| `state_file` | `/var/run/ups-monitor.state` | Current UPS state file (read by `eneru monitor`) |
-| `battery_history_file` | `/var/run/ups-battery-history` | Battery depletion history file |
-| `shutdown_flag_file` | `/var/run/ups-shutdown-scheduled` | Sentinel file written when a shutdown is in progress |
-
-### Behavior section
-
-Global.
+Notifications use Apprise. Empty `urls` disables notification delivery.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `dry_run` | `false` | Log actions without executing them. Equivalent to `eneru run --dry-run` |
+| `urls` | `[]` | Apprise service URLs |
+| `title` | `null` | Optional notification title prefix |
+| `avatar_url` | `null` | Avatar URL for supported services |
+| `timeout` | `10` | Per-send timeout in seconds |
+| `retry_interval` | `5` | Initial retry delay for failed sends |
+| `retry_backoff_max` | `300` | Maximum exponential backoff delay |
+| `max_attempts` | `0` | Attempt cap per pending message. `0` means unlimited until age/backlog policy cancels it |
+| `max_age_days` | `30` | Pending-message age limit. `0` disables age cancellation |
+| `max_pending` | `10000` | Pending backlog cap |
+| `retention_days` | `7` | Retention for sent and cancelled notification rows |
+| `voltage_hysteresis_seconds` | `30` | Delay voltage warnings until they persist. Severe events bypass this |
+| `suppress` | `[]` | Mute specific non-critical event notifications while still logging them |
 
-### Virtual machines section
+See [Notifications](notifications.md) for URL examples, retry behavior, coalescing, and suppressible event names.
 
-Per-UPS in multi-UPS mode (only allowed under `is_local: true`). Top-level in single-UPS mode.
+### Legacy Discord compatibility
+
+Older configs can still use the Discord webhook shape. Eneru converts it to an Apprise `discord://...` URL at load time.
+
+Top-level legacy form:
+
+```yaml
+discord:
+  webhook_url: "https://discord.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN"
+  timeout: 3
+```
+
+Nested legacy form:
+
+```yaml
+notifications:
+  discord:
+    webhook_url: "https://discord.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN"
+    timeout: 3
+```
+
+If both `notifications.urls` and `notifications.discord.webhook_url` are present, Eneru keeps the URL list and prepends the converted Discord URL if it is not already present.
+
+## Statistics
+
+Eneru writes one SQLite database per UPS. The writer is best effort; stats failures are logged and monitoring continues.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `enabled` | `false` | Enable VM shutdown (libvirt / KVM via `virsh`) |
+| `db_directory` | `/var/lib/eneru` | Directory for per-UPS `.db` files |
+| `retention.raw_hours` | `24` | Raw poll sample retention |
+| `retention.agg_5min_days` | `30` | Five-minute aggregate retention |
+| `retention.agg_hourly_days` | `1825` | Hourly aggregate retention |
+
+See [Statistics](statistics.md) for schema and queries.
+
+## Logging and behavior
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `logging.file` | `/var/log/ups-monitor.log` | File log path. Set `null` to disable file logging |
+| `logging.state_file` | `/var/run/ups-monitor.state` | Current state file read by `eneru monitor` |
+| `logging.battery_history_file` | `/var/run/ups-battery-history` | Rolling battery history for depletion calculations |
+| `logging.shutdown_flag_file` | `/var/run/ups-shutdown-scheduled` | Idempotency flag for shutdown in progress |
+| `behavior.dry_run` | `false` | Log shutdown actions without executing them |
+
+## Virtual machines
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Enable libvirt VM shutdown through `virsh` |
 | `max_wait` | `30` | Seconds to wait for graceful shutdown before force-destroy |
 
-### Containers section
-
-Per-UPS in multi-UPS mode (only allowed under `is_local: true`). Top-level in single-UPS mode.
+## Containers
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `enabled` | `false` | Enable container shutdown |
-| `runtime` | `auto` | Runtime: `auto` (prefers podman), `docker`, or `podman` |
-| `stop_timeout` | `60` | Default seconds to wait for graceful stop |
-| `compose_files` | `[]` | List of compose files to shutdown first (in order, best effort) |
-| `shutdown_all_remaining_containers` | `true` | Shutdown remaining containers after compose stacks |
-| `include_user_containers` | `false` | Podman only: also stop rootless user containers |
+| `runtime` | `auto` | `auto`, `docker`, or `podman`. Auto prefers Podman when present |
+| `stop_timeout` | `60` | Default graceful stop timeout |
+| `compose_files` | `[]` | Compose files to stop first, in order |
+| `shutdown_all_remaining_containers` | `true` | Stop remaining containers after compose stacks |
+| `include_user_containers` | `false` | Podman only. Also inspect rootless user containers |
 
-Compose files can be specified as strings or objects with custom timeout:
+Compose entries can be strings or objects:
 
 ```yaml
 compose_files:
-  - "/opt/apps/docker-compose.yml"        # uses global stop_timeout
+  - "/opt/apps/docker-compose.yml"
   - path: "/opt/database/docker-compose.yml"
-    stop_timeout: 120                      # per-file override
+    stop_timeout: 120
 ```
 
-### Filesystems section
+### Legacy `docker:` compatibility
 
-Per-UPS in multi-UPS mode (only allowed under `is_local: true`). Top-level in single-UPS mode.
+Older single-UPS configs may use a top-level `docker:` section instead of `containers:`. Eneru still parses it and treats it as Docker-only container config:
+
+```yaml
+docker:
+  enabled: true
+  stop_timeout: 60
+  compose_files:
+    - "/opt/app/docker-compose.yml"
+  shutdown_all_remaining_containers: true
+```
+
+For new configs, use `containers:`. The legacy `docker:` alias is not used for multi-UPS entries.
+
+## Filesystems
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `sync_enabled` | `true` | Run `os.sync()` to flush buffers before unmount |
-| `unmount.enabled` | `false` | Enable filesystem unmounting |
-| `unmount.timeout` | `15` | Seconds before per-mount `umount` times out |
-| `unmount.mounts` | `[]` | List of mount points to unmount |
+| `sync_enabled` | `true` | Run `os.sync()` before shutdown |
+| `unmount.enabled` | `false` | Enable unmount phase |
+| `unmount.timeout` | `15` | Timeout per mount point |
+| `unmount.mounts` | `[]` | Mount paths to unmount |
 
-Mount points can be specified as strings or objects with options:
+Mounts can be strings or objects:
 
 ```yaml
 mounts:
-  - "/mnt/simple"              # simple path
-  - path: "/mnt/stubborn"      # path with options
-    options: "-l"              # lazy unmount
-  - path: "/mnt/force"
-    options: "-f"              # force unmount
+  - "/mnt/media"
+  - path: "/mnt/nas"
+    options: "-l"
 ```
 
-### Remote servers section
-
-Per-UPS in multi-UPS mode. Top-level in single-UPS mode.
+## Remote servers
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `name` | (required) | Display name for logging |
-| `enabled` | `false` | Enable this server |
-| `host` | (required) | Hostname or IP address |
-| `user` | (required) | SSH username |
-| `connect_timeout` | `10` | SSH connection timeout in seconds |
-| `command_timeout` | `30` | Default timeout for commands in seconds |
+| `name` | required | Display name |
+| `enabled` | `false` | Enable this remote server |
+| `host` | required | Hostname or IP |
+| `user` | required | SSH username |
+| `connect_timeout` | `10` | SSH connection timeout |
+| `command_timeout` | `30` | Default timeout for remote commands |
 | `shutdown_command` | `sudo shutdown -h now` | Final shutdown command |
-| `ssh_options` | `[]` | Additional SSH options |
-| `pre_shutdown_commands` | `[]` | Commands to run before shutdown (see below) |
-| `parallel` | (unset) | Legacy two-group flag. `true` = parallel batch, `false` = sequential before parallel batch. **Mutually exclusive with `shutdown_order`** |
-| `shutdown_order` | (unset) | Phase number (≥ 1). Same order = parallel, ascending = sequential. **Mutually exclusive with `parallel`** |
-| `shutdown_safety_margin` | `60` | Seconds added to the per-server timeout budget when waiting for the parallel-shutdown thread. Set `0` to opt out |
+| `ssh_options` | `[]` | Extra SSH options. Avoid disabling host-key checks in production |
+| `pre_shutdown_commands` | `[]` | Pre-shutdown actions or commands |
+| `shutdown_order` | unset | Explicit phase. Same value runs in parallel; higher values run later |
+| `parallel` | unset | Legacy mode. `false` runs before the default parallel batch. Mutually exclusive with `shutdown_order` |
+| `shutdown_safety_margin` | `60` | Extra wait budget for parallel server threads |
 
-#### Pre-shutdown commands
+See [Remote servers](remote-servers.md) for SSH keys, sudoers, predefined actions, and ordering examples.
 
-Commands to run on remote servers before the final shutdown:
-
-```yaml
-pre_shutdown_commands:
-  # Predefined actions
-  - action: "stop_proxmox_vms"
-    timeout: 180
-  - action: "sync"
-
-  # Custom commands
-  - command: "systemctl stop my-service"
-    timeout: 30
-```
-
-**Predefined actions:**
-
-| Action | Description |
-|--------|-------------|
-| `stop_containers` | Stop all Docker/Podman containers |
-| `stop_vms` | Gracefully shutdown libvirt/KVM VMs |
-| `stop_proxmox_vms` | Gracefully shutdown Proxmox QEMU VMs (runs via `sudo`) |
-| `stop_proxmox_cts` | Gracefully shutdown Proxmox LXC containers (runs via `sudo`) |
-| `stop_xcpng_vms` | Gracefully shutdown XCP-ng / XenServer VMs |
-| `stop_esxi_vms` | Gracefully shutdown VMware ESXi VMs |
-| `stop_compose` | Stop a compose stack (requires `path` parameter) |
-| `sync` | Sync filesystems |
-
-#### Shutdown ordering
-
-Use `shutdown_order` to define multi-phase shutdown. Servers with the same order run in parallel; different orders run sequentially (ascending). For simple setups, `parallel: false` still works. The two flags are **mutually exclusive** — setting both on the same server is rejected at config load.
-
-See [Remote Servers](remote-servers.md) for SSH setup, sudoers configuration, and `shutdown_safety_margin` tuning guidance.
-
-### Local shutdown section
-
-Global.
+## Local shutdown
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `enabled` | `true` | Enable local shutdown of the Eneru host |
-| `command` | `shutdown -h now` | Shutdown command to execute |
-| `message` | `UPS battery critical - emergency shutdown` | Optional message for `shutdown -h` |
-| `drain_on_local_shutdown` | `false` | Multi-UPS only. When the local UPS goes critical, also shut down every other group's resources before powering off the host. `false` (default) = only the local group's resources are touched |
-| `trigger_on` | `any` | Multi-UPS only. `any` = any group's shutdown triggers local shutdown (default). `none` = local shutdown is opt-in per group; useful when the host is on its own dedicated UPS that never participates in cascades |
-| `wall` | `false` | Broadcast shutdown warnings to every logged-in tty via `wall(1)`. Off by default since v5.2 — Apprise covers the modern path. Flip to `true` if you still want the tty blast on top (legacy from the v2 ups-monitor era) |
+| `enabled` | `true` | Power off the Eneru host when its policy fires |
+| `command` | `shutdown -h now` | Local shutdown command |
+| `message` | `UPS battery critical - emergency shutdown` | Message passed to shutdown where supported |
+| `drain_on_local_shutdown` | `false` | Multi-UPS. Drain all groups before powering off the local host |
+| `trigger_on` | `any` | Multi-UPS. `any` means any group can trigger local shutdown; `none` disables cross-group local shutdown |
+| `wall` | `false` | Broadcast shutdown warnings to logged-in TTYs |
 
-### Redundancy groups section
-
-Top-level. List of groups; each entry shares the resource surface of `UPSGroupConfig` plus quorum policy.
+## Redundancy groups
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `name` | (required) | Group label, used in logs and the dry-run flag-file path |
-| `ups_sources` | (required) | List of UPS `name`s that protect this group. Each must appear in the top-level `ups:` list |
-| `min_healthy` | `1` | Quorum threshold. Shutdown fires when `healthy_count < min_healthy` |
-| `degraded_counts_as` | `healthy` | How a `DEGRADED` member counts: `healthy` (tolerant of voltage warnings, default) or `critical` (strict) |
-| `unknown_counts_as` | `critical` | How an `UNKNOWN` member (stale NUT data) counts: `critical` (fail-safe, default), `degraded` (counted via `degraded_counts_as`), or `healthy` (risky — assumes best on missing data) |
-| `is_local` | `false` | Marks a redundancy group whose shutdown also powers off the Eneru host (mirror of UPS-group `is_local`). At most one `is_local: true` across all groups |
-| `triggers` | inherits | Per-group `triggers:` block (same shape as the per-UPS one). Members run with their per-UPS triggers in advisory mode |
-| `remote_servers` / `virtual_machines` / `containers` / `filesystems` | (empty) | Same shape as `UPSGroupConfig`. Resources owned by the group, shut down by the evaluator when quorum is lost |
-
-See [Redundancy Groups](redundancy-groups.md) for the full lifecycle: advisory triggers on member UPSes, cross-group cascades, validator ownership rules, and the dry-run flag-file path.
-
----
+| `name` | required | Unique group label |
+| `ups_sources` | required | UPS `name` values from the top-level `ups:` list |
+| `min_healthy` | `1` | Shutdown fires when healthy member count drops below this number |
+| `degraded_counts_as` | `healthy` | Count DEGRADED members as `healthy` or `critical` |
+| `unknown_counts_as` | `critical` | Count UNKNOWN members as `critical`, `degraded`, or `healthy` |
+| `is_local` | `false` | This redundancy group powers the Eneru host. At most one local group is allowed across all groups |
+| `triggers` | inherits | Per-group trigger overrides |
+| Resource sections | empty | Same resource surface as a UPS group |
 
 ## File locations
 
-| File | Purpose |
+| Path | Purpose |
 |------|---------|
-| `/opt/ups-monitor/eneru.py` | Main script (deb/rpm install) |
-| `/etc/ups-monitor/config.yaml` | Configuration file |
-| `/etc/systemd/system/eneru.service` | Systemd service |
-| `/var/log/ups-monitor.log` | Log file |
-| `/var/run/ups-monitor.state` | Current UPS state (read by `eneru monitor`) |
-| `/var/run/ups-shutdown-scheduled` | Shutdown in progress flag |
-| `/var/run/ups-battery-history` | Battery depletion history |
-| `/var/lib/eneru/*.db` | Per-UPS SQLite statistics store (one file per UPS) |
+| `eneru` | Package command on `PATH` |
+| `/opt/ups-monitor/eneru.py` | Package wrapper used internally by the native install |
+| `/etc/ups-monitor/config.yaml` | Default configuration file |
+| `/etc/systemd/system/eneru.service` | Packaged systemd service |
+| `/var/log/ups-monitor.log` | Default file log |
+| `/var/run/ups-monitor.state` | Current state for the TUI |
+| `/var/run/ups-shutdown-scheduled` | Single-UPS shutdown flag |
+| `/var/run/ups-shutdown-redundancy-*` | Redundancy group shutdown flags |
+| `/var/run/ups-battery-history` | Battery history file |
+| `/var/lib/eneru/*.db` | Per-UPS SQLite history |
 
----
+## CLI reference
 
-## Command-line options
+| Command | Purpose |
+|---------|---------|
+| `run` | Start the monitoring daemon |
+| `validate` | Validate config and print the shutdown plan |
+| `monitor` | Open the TUI dashboard |
+| `tui` | Alias for `monitor` |
+| `test-notifications` | Send one test notification |
+| `completion {bash,zsh,fish}` | Print a shell completion script |
+| `version` | Print version |
 
-| Subcommand | Description |
-|------------|-------------|
-| `eneru run` | Start the monitoring daemon |
-| `eneru validate` | Validate configuration and show overview |
-| `eneru monitor` | Launch real-time TUI dashboard |
-| `eneru tui` | Alias for `monitor` |
-| `eneru test-notifications` | Send a test notification and exit |
-| `eneru completion {bash,zsh,fish}` | Print shell completion script (source the output) |
-| `eneru version` | Show version information |
+Common flags:
 
-Running bare `eneru` without a subcommand shows help.
+| Command | Flag | Purpose |
+|---------|------|---------|
+| `run`, `validate`, `monitor`, `test-notifications` | `-c`, `--config` | Config path |
+| `run` | `--dry-run` | Override config and do not execute shutdown actions |
+| `run` | `--exit-after-shutdown` | Exit after a shutdown sequence finishes |
+| `monitor` | `--once` | Print one status snapshot |
+| `monitor` | `--interval` | TUI refresh interval |
+| `monitor` | `--graph {charge,load,voltage,runtime}` | Render a graph with `--once` |
+| `monitor` | `--time {1h,6h,24h,7d,30d}` | Graph or event window |
+| `monitor` | `--events-only` | Print recent events only |
 
-**Flags for `eneru run`:**
-
-| Flag | Description |
-|------|-------------|
-| `-c`, `--config` | Path to configuration file |
-| `--dry-run` | Run in dry-run mode (overrides config) |
-| `--exit-after-shutdown` | Exit after the shutdown sequence completes (used by E2E tests) |
-
-**Flags for `eneru monitor` / `eneru tui`:**
-
-| Flag | Description |
-|------|-------------|
-| `-c`, `--config` | Path to configuration file |
-| `--once` | Print one snapshot and exit (no curses TUI) |
-| `--interval` | Refresh interval in seconds (default: 5) |
-| `--graph {charge,load,voltage,runtime}` | With `--once`: render an ASCII / Braille graph for the metric |
-| `--time {1h,6h,24h,7d,30d}` | With `--once --graph`: time range to plot |
-| `--events-only` | With `--once`: print only the events list (reads from SQLite, falls back to log-tail when no DB exists) |
-
-### Examples
+Example package commands:
 
 ```bash
-# Validate configuration
-eneru validate --config /etc/ups-monitor/config.yaml
-
-# Start monitoring
-eneru run --config /etc/ups-monitor/config.yaml
-
-# Test in dry-run mode
-eneru run --dry-run --config /etc/ups-monitor/config.yaml
-
-# Real-time dashboard
-eneru monitor --config /etc/ups-monitor/config.yaml
-
-# One-shot status snapshot for scripts
-eneru monitor --once --config /etc/ups-monitor/config.yaml
-
-# 24h voltage graph for the dashboard's main UPS
-eneru monitor --once --graph voltage --time 24h --config /etc/ups-monitor/config.yaml
-
-# Recent events only (uses SQLite)
-eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
-
-# Send a test notification
-eneru test-notifications --config /etc/ups-monitor/config.yaml
-
-# Enable shell completion (bash; zsh / fish work the same way)
-source <(eneru completion bash)
+sudo eneru validate --config /etc/ups-monitor/config.yaml
+sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
+sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
 ```
-
----
-
-## Validating configuration
-
-Validate your configuration before starting the service:
-
-```bash
-eneru validate --config /etc/ups-monitor/config.yaml
-```
-
-This checks for:
-
-- YAML syntax errors
-- Required fields and valid value ranges
-- Strict-enum fields (`local_shutdown.trigger_on`, `triggers.voltage_sensitivity`, `notifications.suppress` event names, redundancy `degraded_counts_as` / `unknown_counts_as`)
-- Multi-UPS ownership rules (only `is_local` group can manage VMs / containers / filesystems)
-- `is_local` uniqueness across the combined set of UPS groups + redundancy groups
-- Redundancy-group rules: `min_healthy` bounds, unknown UPS references, duplicate sources, missing names, duplicate names, cross-tier remote-server conflicts. See [Redundancy Groups](redundancy-groups.md)
-- `notifications.voltage_hysteresis_seconds` non-negative; warns above 600s
-- `notifications.suppress` accepts only documented suppressible event names; rejects safety-critical names
-- Notification service availability (Apprise installed?)
-- Reachable UPS (optional connectivity test)
-
-For the per-UPS metrics store (`statistics:` section), see [Statistics](statistics.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,198 +1,148 @@
 # Getting started
 
+This page gets one UPS monitoring safely. Add VMs, containers, remote servers, and multi-UPS policy after the basic loop works.
+
 ## Prerequisites
 
-Before installing Eneru, you need:
+- Linux with Python 3.9 or newer.
+- A working NUT server that answers `upsc` for your UPS.
+- Root access on the Eneru host. Shutdown, filesystem, VM, and container actions need host privileges.
+- SSH client access if Eneru will shut down remote servers.
 
-- **Python 3.9 or higher**
-- **NUT (Network UPS Tools) client** - Your UPS must already be configured with NUT
-- **SSH client** - For remote server shutdown (optional)
-- **Root privileges** - Required for system shutdown operations
-
-!!! note "Eneru monitors NUT, it doesn't replace it"
-    Eneru connects to an existing NUT server to read UPS status. You need a working NUT installation with your UPS already configured before using Eneru.
-
----
-
-## Package installation (recommended)
-
-Native `.deb` and `.rpm` packages are available.
-
-### Option 1: APT/DNF repository (recommended)
-
-Add the repository to get automatic updates:
-
-=== "Debian/Ubuntu"
-
-    ```bash
-    # Import GPG key
-    curl -fsSL https://m4r1k.github.io/Eneru/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/eneru.gpg
-
-    # Add repository
-    echo "deb [arch=all signed-by=/usr/share/keyrings/eneru.gpg] https://m4r1k.github.io/Eneru/deb stable main" | sudo tee /etc/apt/sources.list.d/eneru.list
-
-    # Install
-    sudo apt update
-    sudo apt install eneru
-    ```
-
-=== "RHEL/Fedora"
-
-    ```bash
-    # RHEL 8/9: Enable EPEL first (required for apprise dependency)
-    sudo dnf install -y epel-release
-
-    # Add repository
-    sudo curl -o /etc/yum.repos.d/eneru.repo https://m4r1k.github.io/Eneru/rpm/eneru.repo
-
-    # Install
-    sudo dnf install eneru
-    ```
-
-### Option 2: PyPI (pip)
-
-Install from PyPI:
+Check NUT first:
 
 ```bash
-pip install eneru
-
-# With notification support (recommended)
-pip install eneru[notifications]
+upsc -l 192.168.1.100
+upsc UPS@192.168.1.100
 ```
 
-!!! note "System packages still recommended for production"
-    The pip installation doesn't include the systemd service file. For production deployments, use the native packages which set up the service automatically.
+If those commands fail, fix NUT before installing Eneru.
 
-After pip install, you'll need to:
+## Install
 
-1. Create the config directory: `sudo mkdir -p /etc/ups-monitor`
-2. Create a config file: `sudo nano /etc/ups-monitor/config.yaml`
-3. Run manually or set up your own service: `eneru run --config /etc/ups-monitor/config.yaml`
-
-### Option 3: Direct download from GitHub releases
-
-Download the latest package from [GitHub Releases](https://github.com/m4r1k/Eneru/releases):
-
-=== "Debian/Ubuntu"
-
-    ```bash
-    sudo dpkg -i eneru_*.deb
-    sudo apt install -f  # Install dependencies if needed
-    ```
-
-=== "RHEL/Fedora"
-
-    ```bash
-    # RHEL 8/9: Enable EPEL first (required for apprise dependency)
-    sudo dnf install -y epel-release
-
-    sudo dnf install ./eneru-*.noarch.rpm
-    ```
-
----
-
-## After installation
-
-The package installs but does **not** auto-enable or auto-start the service. You must complete configuration first:
+### Debian or Ubuntu package
 
 ```bash
-# 1. Edit configuration
-sudo nano /etc/ups-monitor/config.yaml
+curl -fsSL https://m4r1k.github.io/Eneru/KEY.gpg \
+  | sudo gpg --dearmor -o /usr/share/keyrings/eneru.gpg
 
-# 2. Validate configuration
-eneru validate --config /etc/ups-monitor/config.yaml
+echo "deb [arch=all signed-by=/usr/share/keyrings/eneru.gpg] https://m4r1k.github.io/Eneru/deb stable main" \
+  | sudo tee /etc/apt/sources.list.d/eneru.list
 
-# 3. Enable and start the service
-sudo systemctl enable eneru.service
-sudo systemctl start eneru.service
+sudo apt update
+sudo apt install eneru
 ```
 
----
+### RHEL or Fedora package
 
-## Minimal configuration
+```bash
+sudo dnf install -y epel-release
+sudo curl -o /etc/yum.repos.d/eneru.repo https://m4r1k.github.io/Eneru/rpm/eneru.repo
+sudo dnf install eneru
+```
 
-The simplest working configuration:
+### PyPI
+
+```bash
+python3 -m venv ~/.venv/eneru
+source ~/.venv/eneru/bin/activate
+pip install "eneru[notifications]"
+```
+
+The PyPI install is useful for development or user-managed services. Native packages are recommended for production because they install the wrapper, config directory, systemd unit, shell completions, and package-managed dependencies.
+
+## Create the first config
+
+Edit `/etc/ups-monitor/config.yaml`:
 
 ```yaml
-# /etc/ups-monitor/config.yaml
-
-# UPS connection (required)
 ups:
   name: "UPS@192.168.1.100"
 
-# Shutdown triggers
 triggers:
   low_battery_threshold: 20
   critical_runtime_threshold: 600
 
-# Enable local shutdown
 local_shutdown:
   enabled: true
 ```
 
-This will:
+This connects to `UPS` on `192.168.1.100`, starts shutdown at 20% battery or 10 minutes estimated runtime, and powers off the local host with `shutdown -h now`.
 
-- Connect to NUT server at `192.168.1.100` and monitor the UPS named `UPS`
-- Trigger shutdown when battery drops below 20% or runtime below 10 minutes
-- Execute `shutdown -h now` on the local system
+## Validate
 
-For full configuration options, see [Configuration](configuration.md).
-
----
-
-## Verify installation
-
-After starting the service, verify it's working:
+Package install:
 
 ```bash
-# Check service status
-sudo systemctl status eneru.service
-
-# View logs
-sudo journalctl -u eneru.service -f
-
-# Check current UPS state
-cat /var/run/ups-monitor.state
+sudo eneru validate --config /etc/ups-monitor/config.yaml
 ```
 
----
+PyPI install:
 
-## Upgrading
+```bash
+eneru validate --config /etc/ups-monitor/config.yaml
+```
 
-When upgrading via APT/DNF, your configuration file is preserved. The package manager will not overwrite `/etc/ups-monitor/config.yaml`.
+Validation prints the UPS groups, enabled resources, remote shutdown phases, notification status, and configuration errors. Do not start the service until validation passes.
 
-If new configuration options are added in a release, check the [Changelog](changelog.md) for details on new features.
+## Test in dry-run mode
 
----
+Dry-run logs every action but does not stop VMs, containers, remote servers, filesystems, or the host.
 
-## Uninstalling
+Package install:
 
-=== "Debian/Ubuntu"
+```bash
+sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
+```
 
-    ```bash
-    sudo apt remove eneru
-    # To also remove configuration:
-    sudo apt purge eneru
-    ```
+PyPI install:
 
-=== "RHEL/Fedora"
+```bash
+eneru run --dry-run --config /etc/ups-monitor/config.yaml
+```
 
-    ```bash
-    sudo dnf remove eneru
-    ```
+Use a real power event only when you can recover the machine locally. For early tests, lower `extended_time.threshold` in the config and keep `behavior.dry_run: true`.
 
-=== "pip"
+## Start the service
 
-    ```bash
-    pip uninstall eneru
-    ```
+The package does not enable the service automatically. Enable it only after validation and dry-run testing.
 
-Configuration files in `/etc/ups-monitor/` may be preserved after uninstall. Remove them manually if desired.
+```bash
+sudo systemctl enable --now eneru.service
+sudo systemctl status eneru.service
+sudo journalctl -u eneru.service -f
+```
 
----
+The packaged service runs the same command through systemd:
 
-## Next steps
+```bash
+sudo eneru run --config /etc/ups-monitor/config.yaml
+```
 
-- [Configuration](configuration.md) - Full configuration reference
-- [Shutdown triggers](triggers.md) - How shutdown decisions work
-- [Notifications](notifications.md) - Set up Discord, Slack, Telegram, and more
+## Watch status
+
+Use the TUI on a terminal session:
+
+```bash
+sudo eneru monitor --config /etc/ups-monitor/config.yaml
+```
+
+For scripts or SSH sessions that should not open curses:
+
+```bash
+sudo eneru monitor --once --config /etc/ups-monitor/config.yaml
+sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
+```
+
+## Add features one at a time
+
+Do not add every feature at once. Add one section, validate, run dry-run, then move on.
+
+| Next step | Page |
+|-----------|------|
+| Full config keys and defaults | [Configuration reference](configuration.md) |
+| Battery, runtime, depletion, and voltage policy | [Shutdown triggers](triggers.md) |
+| Discord, Slack, Telegram, ntfy, email | [Notifications](notifications.md) |
+| NAS, Proxmox, ESXi, XCP-ng, Docker hosts | [Remote servers](remote-servers.md) |
+| Multiple independent UPSes | [Configuration reference](configuration.md#multi-ups-example) |
+| Dual-PSU A+B power | [Redundancy groups](redundancy-groups.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,168 +1,94 @@
 # Eneru
 
 <p align="center">
-  <img src="images/eneru-diagram.svg" alt="Eneru Architecture" width="600">
+  <img src="images/eneru-diagram.svg" alt="Eneru architecture" width="640">
 </p>
 
-**UPS monitoring and shutdown orchestration for NUT**
-
-A Python-based UPS monitoring daemon for [Network UPS Tools (NUT)](https://networkupstools.org/). Monitors one or more UPSes, orchestrates shutdown of VMs, containers, and remote servers during power events.
+Eneru monitors UPSes through [Network UPS Tools](https://networkupstools.org/) and coordinates shutdown before the batteries are exhausted. It is built for hosts that run more than one thing: VMs, containers, NAS mounts, remote servers, and multiple UPS groups.
 
 <p align="center">
-  <img src="images/eneru-mon.gif" alt="Eneru Monitor Dashboard" width="700">
+  <img src="images/eneru-mon.gif" alt="Eneru monitor dashboard" width="700">
 </p>
 
----
+## What Eneru does
 
-## Why Eneru?
+Eneru is the layer above NUT. NUT talks to the UPS hardware. Eneru decides what to do with that information.
 
-Most UPS shutdown tools handle one machine. If you have more than one, things get complicated fast:
+| Area | What Eneru adds |
+|------|-----------------|
+| Shutdown decisions | Battery level, runtime, depletion rate, extended time on battery, FSD, and failsafe connection loss |
+| Local resources | Libvirt VMs, Docker or Podman containers, compose stacks, filesystem sync, and unmounts |
+| Remote systems | SSH shutdown with ordered phases and pre-shutdown actions for Proxmox, ESXi, XCP-ng, Docker, and custom commands |
+| Multiple UPSes | Independent UPS groups, shared configuration defaults, and one local-shutdown owner |
+| Redundant power | Quorum-based redundancy groups for dual-PSU servers and A+B power feeds |
+| Operators | TUI dashboard, one-shot status output, SQLite history, graphs, and Apprise notifications |
 
-| Challenge | Eneru Solution |
-|-----------|----------------|
-| Multiple UPSes powering different servers | ✅ Multi-UPS monitoring from a single instance |
-| Multiple servers need coordinated shutdown | ✅ Orchestrated multi-server shutdown via SSH |
-| VMs and containers need graceful stop | ✅ Libvirt VM and Docker/Podman container handling |
-| Network mounts hang during power loss | ✅ Timeout-protected unmounting |
-| No visibility during power events | ✅ Real-time TUI dashboard + notifications via 100+ services |
-| Different systems need different commands | ✅ Per-server custom shutdown commands |
-| Hypervisors need graceful VM shutdown | ✅ Pre-shutdown actions (Proxmox, ESXi, XCP-ng, libvirt) |
-| Battery estimates are unreliable | ✅ Multi-vector shutdown triggers |
-| Network down during outage might block/slow down shutdown | ✅ Non-blocking notifications with persistent retry |
-| Firmware recalibrates battery silently | ✅ Battery anomaly detection and alerts |
+!!! note "Eneru does not replace NUT"
+    NUT still owns UPS drivers, hardware communication, and the `upsc` data model. Eneru consumes that data and runs the shutdown policy.
 
----
+## When to use it
 
-## Built for
+Use Eneru when a basic `upsmon` script is no longer enough:
 
-- **Homelabs** - Protect your self-hosted infrastructure
-- **Virtualization hosts** - Graceful VM shutdown before power loss
-- **Container hosts** - Stop Docker/Podman containers safely
-- **NAS systems** - Coordinate shutdown of Synology, QNAP, TrueNAS
-- **Small business** - Multi-UPS environments with multiple server groups
-- **Hybrid setups** - Mix of physical and virtual infrastructure
+- One UPS protects a host with VMs, containers, and mounted storage.
+- Several servers need to shut down in a specific order.
+- A NAS should shut down after compute nodes release NFS or SMB mounts.
+- Multiple UPSes protect different racks from one monitoring host.
+- Dual-PSU servers should remain online while at least one UPS feed is healthy.
+- You want alerts and historical data during power problems.
 
----
+For a single workstation with one UPS and no dependencies, NUT's built-in `upsmon` may be simpler.
 
-## How Eneru compares
+## Shutdown model
 
-Eneru builds on NUT's protocol layer and adds shutdown orchestration on top:
+Every shutdown phase is optional. A typical sequence looks like this:
+
+```text
+Power event detected
+  -> evaluate triggers
+  -> stop local VMs
+  -> stop compose stacks
+  -> stop remaining containers
+  -> sync and unmount filesystems
+  -> shut down remote servers by phase
+  -> power off the local host
+```
+
+Multi-UPS mode runs the same sequence per UPS group. Redundancy groups use the same resource model, but they fire only when the group loses quorum.
+
+## How it compares
 
 | Capability | NUT upsmon | apcupsd | PeaNUT | Eneru |
-|------------|-----------|---------|--------|-------|
-| **Shutdown triggers** | 2 (LOWBATT, FSD) | Timer + event scripts | None (dashboard only) | 6 independent triggers including depletion rate and extended time |
-| **Shutdown orchestration** | Runs a single script | Runs event scripts | None | Ordered sequence: VMs → compose → containers → remote servers → filesystems → local |
-| **Multi-UPS** | Monitor multiple, shut down one host | One UPS per instance | Display multiple | Coordinated groups with per-UPS triggers, `is_local` ownership, and `trigger_on` policies |
-| **Battery intelligence** | None | None | None | Depletion rate from observed data, anomaly detection with firmware jitter filtering |
-| **Remote server shutdown** | Via custom script | Via custom script | None | SSH-based with pre-shutdown commands (Proxmox, ESXi, XCP-ng), parallel/sequential modes |
-| **Container handling** | None | None | None | Docker/Podman with compose ordering, rootless Podman, auto-detection |
-| **Notifications** | Email/pager via script | Event scripts | None | 100+ services via Apprise, non-blocking with persistent retry |
-| **Dashboard** | CGI (1990s era) | CGI multimon | Modern web (React) | Real-time TUI with color-coded status |
-| **Connection resilience** | Retry + failsafe | Retry | N/A | Grace period with flap detection, failsafe on battery |
+|------------|------------|---------|--------|-------|
+| Hardware support | NUT drivers | APC only | NUT data | NUT data |
+| Shutdown triggers | LOWBATT, FSD | Timer and scripts | None | Six trigger paths plus failsafe |
+| VM/container handling | Script yourself | Script yourself | None | Built in |
+| Remote shutdown | Script yourself | Script yourself | None | SSH phases and predefined actions |
+| Multiple UPS groups | Host-level | One UPS per instance | Display only | Per-group orchestration |
+| Redundant A+B feeds | No | No | No | Quorum evaluator |
+| Notifications | Script yourself | Event scripts | No | Apprise with persistent retry |
+| Dashboard and history | Limited | Limited | Dashboard | TUI, graphs, SQLite events |
 
-!!! note "Eneru complements NUT, it doesn't replace it"
-    NUT handles the hard problem of talking to 170+ manufacturers' hardware via 250+ drivers. Eneru handles what happens *after* NUT delivers the data: when to shut down, what to shut down, and in what order.
+## Start here
 
----
+1. Install Eneru and create a minimal config: [Getting started](getting-started.md).
+2. Choose your shutdown policy: [Configuration reference](configuration.md).
+3. Tune the shutdown thresholds: [Shutdown triggers](triggers.md).
+4. Add remote systems if needed: [Remote servers](remote-servers.md).
+5. Test in dry-run mode before relying on it: [Troubleshooting](troubleshooting.md#safe-dry-run-test).
 
-## Features
+## Installation style in these docs
 
-### Monitoring
+Native packages install Eneru under `/opt/ups-monitor/`, but expose `eneru` on `PATH`. The systemd service runs the package wrapper internally; operators can use:
 
-- **Multi-UPS support:** Monitor one or more UPSes from a single instance, each with its own shutdown group
-- **TUI dashboard:** `eneru monitor` shows live UPS status with color-coded badges
-- **Single-call polling:** One `upsc` call per cycle, all processing in memory
-- **Input validation:** Prevents failures from corrupted or transient data
-- **Atomic state updates:** Uses atomic file operations for data integrity
-- **Connection recovery:** Automatic reconnection with stale data detection and [grace period](configuration.md#connection-loss-grace-period) to suppress notification storms from flaky NUT servers
+```bash
+sudo eneru run --config /etc/ups-monitor/config.yaml
+```
 
-### Shutdown triggers
+PyPI installs expose the `eneru` command:
 
-Multiple shutdown conditions with configurable thresholds:
+```bash
+eneru run --config /etc/ups-monitor/config.yaml
+```
 
-1. **FSD flag:** UPS signals forced shutdown (highest priority)
-2. **Critical battery level:** Battery percentage below threshold (default: 20%)
-3. **Critical runtime:** Estimated runtime below threshold (default: 10 minutes)
-4. **Dangerous depletion rate:** Battery draining faster than threshold (default: 15%/min)
-5. **Extended time on battery:** Safety net for aged batteries (default: 15 minutes)
-6. **Failsafe (FSB):** Connection lost while on battery triggers immediate shutdown
-
-See [Shutdown triggers](triggers.md) for details.
-
-### Shutdown sequence
-
-All components are optional and independently configurable:
-
-1. **Virtual machines (libvirt/KVM):** Graceful shutdown with force-destroy fallback
-2. **Containers (Docker/Podman):** Stop all running containers with auto-detection
-3. **Filesystem sync:** Flush buffers to disk
-4. **Filesystem unmount:** Hang-proof unmounting with per-mount options
-5. **Remote servers:** SSH-based shutdown of multiple remote systems
-6. **Local shutdown:** Configurable shutdown command
-
-### Notifications (via Apprise)
-
-- **100+ services:** Discord, Slack, Telegram, ntfy, Pushover, email, and [many more](https://github.com/caronc/apprise/wiki)
-- **Non-blocking with persistent retry:** Notifications never delay shutdown, retried until delivered
-- **Power event alerts:** Color-coded notifications for all power events
-- **Service lifecycle:** Notifications when service starts/stops
-
-See [Notifications](notifications.md) for setup.
-
-### Power quality monitoring
-
-- **Voltage monitoring:** Brownout and over-voltage detection
-- **AVR tracking:** Boost/Trim mode detection
-- **Bypass detection:** Alerts when UPS protection is inactive
-- **Overload detection:** Load threshold monitoring
-
-### Tested on every commit
-
-Every commit triggers the full test suite:
-
-- **190 unit tests** across 7 Python versions (3.9-3.14, plus 3.15-dev)
-- **Integration tests** verifying package installation on 7 Linux distributions (Debian, Ubuntu, RHEL)
-- **End-to-end tests** with real NUT server, SSH target, and Docker containers in CI
-
-The E2E test suite simulates 8 UPS scenarios (online, low-battery, FSD, brownout, etc.) and validates the complete shutdown workflow, from power failure detection to SSH remote shutdown. Before each release, Eneru is also validated on real hardware with actual UPS units and simulated power events. See [Testing](testing.md) for details.
-
-### Modular architecture (v4.10+)
-
-9 focused modules:
-
-- `config.py` - Configuration dataclasses and YAML loader
-- `monitor.py` - Core UPS monitoring logic
-- `notifications.py` - Non-blocking notification worker
-- `cli.py` - Command-line interface
-- Plus: `version.py`, `state.py`, `logger.py`, `utils.py`, `actions.py`
-
----
-
-## Why a systemd daemon? (No Docker)
-
-Eneru runs as a systemd service, not a container. This is intentional.
-
-Eneru's job is to shut down Docker/Podman containers during power events. If Eneru itself ran inside a container, it would be stopped during its own shutdown sequence, potentially stalling the process and leaving the host in an undefined state.
-
-Running as a systemd daemon means:
-
-- **Survives container shutdown** - It can orchestrate the full sequence without being killed
-- **Direct host access** - Native access to systemd, virsh, SSH, and filesystem operations
-- **No runtime dependency** - The container runtime itself could fail during a power event
-- **Less complexity** - Running inside a container would require self-exclusion logic during shutdown, adding complexity and failure modes
-
-NUT itself runs as a system daemon for the same reasons.
-
----
-
-## The name
-
-<img src="images/eneru.jpg" alt="Eneru from One Piece" width="120" align="right">
-
-Named after [Eneru (エネル)](https://onepiece.fandom.com/wiki/Enel) from *One Piece*, the self-proclaimed God of Skypiea who ate the Goro Goro no Mi (Rumble-Rumble Fruit) and can control electricity. When the power from the grid fails, this tool takes over and shuts everything down safely. *Unlimited power... management!*
-
----
-
-## Quick start
-
-See [Getting started](getting-started.md) for installation instructions.
+Package commands in these docs use the package path where root/systemd behavior matters. PyPI examples use `eneru` when the context is developer or user-managed execution.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -213,17 +213,20 @@ This is the common "power came back fast, internet came back slowly" case. Coale
 
 ## Lifecycle notifications
 
-Eneru classifies daemon starts instead of blindly sending "stopped" and "started" every time.
+Eneru classifies daemon starts instead of blindly sending "stopped" and "started" every time. The classifier picks one of eight messages based on the on-disk shutdown marker and the previous-version metadata in the stats DB. Logic lives in `src/eneru/lifecycle.py`.
 
-| Event | How Eneru recognizes it |
-|-------|-------------------------|
-| Package upgrade | Package marker from install scripts or a stored version change |
-| Restart | Previous shutdown marker with short downtime |
-| Recovery after UPS-triggered shutdown | Shutdown-state marker with sequence-complete reason |
-| Crash recovery | Missing or fatal shutdown marker |
-| First start | No previous lifecycle metadata |
+| Notification | When it fires | How Eneru recognizes it |
+|--------------|---------------|-------------------------|
+| `📦 Eneru Upgraded vX → vY` | deb/rpm package upgrade | `.upgrade_marker.json` written by `packaging/scripts/postinstall.sh`; old version captured by `preinstall.sh` |
+| `📦 Eneru Upgraded vX → vY` (pip path) | `pip install --upgrade eneru` followed by restart | `meta.last_seen_version` in the stats DB differs from the current `__version__` |
+| `📊 Eneru Recovered` | Daemon back after a power-loss-triggered shutdown | Shutdown marker with `reason: sequence_complete`. Folds the prior shutdown headline and summary into one richer message |
+| `🔄 Eneru Restarted (downtime: Ns)` | `systemctl restart eneru` within 30 seconds | Shutdown marker with `reason: signal` and downtime under 30 s |
+| `🚀 Eneru Restarted` (after fatal exit) | Daemon back after a crash that wrote a `fatal` marker | Shutdown marker with `reason: fatal` |
+| `🚀 Eneru Started (last seen Nh ago)` | Daemon started after a long graceful gap | Shutdown marker present with downtime ≥ 30 s |
+| `🚀 Eneru vX Started (after crash)` | Daemon back without ever writing a marker | No shutdown marker but `meta.last_seen_version` is set |
+| `🚀 Eneru vX Started` | First-ever start | No markers and no `last_seen_version` |
 
-The goal is one useful lifecycle message per transition.
+The goal is one useful lifecycle message per transition. The `📊 Recovered` path also absorbs the prior instance's pending `🚨 EMERGENCY SHUTDOWN INITIATED!` and `✅ Shutdown Sequence Complete` rows so an outage produces a single combined message rather than three.
 
 ### Restart classification timeline
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,351 +1,268 @@
 # Notifications
 
-Eneru uses [Apprise](https://github.com/caronc/apprise) to send notifications to 100+ services: Discord, Slack, Telegram, ntfy, Pushover, Email, and others.
+Eneru sends notifications through [Apprise](https://github.com/caronc/apprise), so one config format covers Discord, Slack, Telegram, ntfy, Pushover, email, Matrix, Gotify, Home Assistant, and many more services.
 
----
+Notifications are not on the shutdown critical path. Eneru queues the message and continues shutting things down.
 
-## Configuration
+## Basic config
 
 ```yaml
 notifications:
-  # Optional title for notifications
-  title: "⚡ Homelab UPS"
-
-  # Avatar/icon URL (supported by Discord, Slack, and others)
+  title: "Homelab UPS"
   avatar_url: "https://raw.githubusercontent.com/m4r1k/Eneru/main/docs/images/eneru-avatar.png"
-
-  # Timeout for notification delivery (seconds)
   timeout: 10
-
-  # Initial retry wait for failed sends. Doubles on each failure up to
-  # retry_backoff_max (see below). Default: 5
-  retry_interval: 5
-
-  # v5.2 persistent-queue knobs. Defaults are sized for "long weekend
-  # with the internet down" — the queue survives process death and
-  # prolonged outages, then drains once the endpoint returns.
-  retention_days: 7         # keep sent/cancelled rows for forensics
-  max_attempts: 0           # 0 = unlimited (default, see below)
-  max_age_days: 30          # only TTL on pending rows
-  max_pending: 10000        # backlog overflow cap
-  retry_backoff_max: 300    # 5-min ceiling on the exponential backoff
-
-  # Notification service URLs
   urls:
     - "discord://webhook_id/webhook_token"
-    - "slack://token_a/token_b/token_c/#channel"
-    - "telegram://bot_token/chat_id"
+    - "ntfy://ntfy.sh/my-ups-topic"
 ```
 
-`max_attempts` defaults to `0` (unlimited) on purpose: Apprise's
-success/fail signal is a single bool — Eneru cannot tell "bad URL" from
-"internet down". Capping attempts risks dropping legitimate messages
-during a long outage. Use this only as a poison-message kill switch.
+If `urls` is empty, notifications are disabled.
 
----
+## Test delivery
 
-## Popular services
+Package install:
+
+```bash
+sudo eneru test-notifications --config /etc/ups-monitor/config.yaml
+```
+
+PyPI install:
+
+```bash
+eneru test-notifications --config /etc/ups-monitor/config.yaml
+```
+
+Also run validation. It catches missing Apprise support and malformed config values:
+
+```bash
+sudo eneru validate --config /etc/ups-monitor/config.yaml
+```
+
+## Common service URLs
 
 ### Discord
 
-1. In your Discord server, go to **Server Settings → Integrations → Webhooks**
-2. Click **New Webhook** and copy the webhook URL
-3. Extract the ID and token from the URL:
-   ```
-   https://discord.com/api/webhooks/1234567890/abcdefghijk...
-                                    └─ ID ─┘   └─ Token ─┘
-   ```
-4. Add to config:
-   ```yaml
-   urls:
-     - "discord://1234567890/abcdefghijk..."
-   ```
+Create a webhook in Discord under Server Settings, Integrations, Webhooks. Convert the webhook URL:
+
+```text
+https://discord.com/api/webhooks/1234567890/abcdefghijklmnopqrstuvwxyz
+                                 webhook id / webhook token
+```
+
+```yaml
+notifications:
+  urls:
+    - "discord://1234567890/abcdefghijklmnopqrstuvwxyz"
+```
 
 ### Slack
 
-1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps)
-2. Add **Incoming Webhooks** feature
-3. Create a webhook for your channel
-4. Use the webhook URL format:
-   ```yaml
-   urls:
-     - "slack://TokenA/TokenB/TokenC/#channel"
-   ```
+Create an incoming webhook in a Slack app and use the token components from the webhook URL.
+
+```yaml
+notifications:
+  urls:
+    - "slack://TokenA/TokenB/TokenC/#channel"
+```
 
 ### Telegram
 
-1. Create a bot via [@BotFather](https://t.me/botfather) and get the token
-2. Get your chat ID by messaging the bot and checking:
-   ```
-   https://api.telegram.org/bot<TOKEN>/getUpdates
-   ```
-3. Add to config:
-   ```yaml
-   urls:
-     - "telegram://bot_token/chat_id"
-   ```
+Create a bot with BotFather, message it once, then get your chat ID with `getUpdates`.
+
+```yaml
+notifications:
+  urls:
+    - "telegram://bot_token/chat_id"
+```
 
 ### ntfy
 
-[ntfy](https://ntfy.sh/) is a simple pub-sub notification service:
-
 ```yaml
-urls:
-  - "ntfy://ntfy.sh/your-topic-name"
-  # Or self-hosted:
-  - "ntfy://your-server.com/your-topic"
+notifications:
+  urls:
+    - "ntfy://ntfy.sh/my-topic"
+    - "ntfy://user:password@ntfy.example.com/my-topic"
 ```
 
 ### Pushover
 
 ```yaml
-urls:
-  - "pover://user_key@app_token"
+notifications:
+  urls:
+    - "pover://user_key@app_token"
 ```
 
-### Email (SMTP)
-
-```yaml
-urls:
-  - "mailto://user:password@smtp.gmail.com:587?to=recipient@example.com"
-```
-
-### More services
-
-Apprise supports 100+ notification services. See the [Apprise Wiki](https://github.com/caronc/apprise/wiki) for the complete list and URL formats.
-
----
-
-## Testing notifications
-
-Test notifications before relying on them during a power event:
-
-```bash
-# Send a test notification
-eneru test-notifications --config /etc/ups-monitor/config.yaml
-
-# Validate configuration
-eneru validate --config /etc/ups-monitor/config.yaml
-```
-
----
-
-## Persistent retry architecture
-
-Network connectivity is often temporarily down during power outages, and the daemon process itself may stop and restart mid-incident (`systemctl restart`, package upgrade, host reboot). Eneru's notification queue is **SQLite-backed and lossless across process death**: the main thread inserts a `pending` row in the per-UPS stats DB and returns immediately; a worker thread reads pending rows and ships them via Apprise; failed sends stay `pending` and retry with **per-message exponential backoff** (starts at `retry_interval`, doubles up to `retry_backoff_max`).
-
-If the daemon dies while rows are still pending, the next start picks them up and continues delivery — nothing is lost in process memory. Only `pending` rows are subject to a TTL (`max_age_days`, default 30 days); `sent` and `cancelled` rows are kept for `retention_days` (default 7) for forensic inspection via `sqlite3`.
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                  ENERU v5.2 NOTIFICATION ARCHITECTURE                       │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│   MAIN THREAD (Critical Path)         WORKER THREAD (Persistent Retry)      │
-│   ═══════════════════════════         ═════════════════════════════════     │
-│                                                                             │
-│   ┌─────────────────────┐                                                   │
-│   │  Event happens      │                                                   │
-│   │  (power, lifecycle) │                                                   │
-│   └──────────┬──────────┘                                                   │
-│              │                                                              │
-│              ▼                                                              │
-│   ┌─────────────────────┐         ┌──────────────────────────────┐          │
-│   │ Insert pending row  │────────▶│   Per-UPS SQLite stats DB    │          │
-│   │ (non-blocking)      │         │   notifications table:       │          │
-│   └──────────┬──────────┘         │   id │ ts │ body │ status   │          │
-│              │                    │   ──┴────┴──────┴──────────  │          │
-│              │ continues          │   pending → sent / cancelled │          │
-│              │ immediately        └──────────┬───────────────────┘          │
-│              ▼                               │                              │
-│   ┌─────────────────────┐                    ▼                              │
-│   │ Stop VMs            │         ┌──────────────────────────────┐          │
-│   └──────────┬──────────┘         │ Read oldest `pending` row    │          │
-│              ▼                    │ Try Apprise send             │          │
-│   ┌─────────────────────┐         └──────────┬───────────────────┘          │
-│   │ Stop Containers     │                    │                              │
-│   └──────────┬──────────┘               YES ┌┴┐ NO                          │
-│              ▼                              │ │                             │
-│   ┌─────────────────────┐         ┌─────────┘ └──────────┐                  │
-│   │ Unmount Filesystems │         │ Mark `sent`           │ Increment       │
-│   └──────────┬──────────┘         │ Move to next pending  │ attempts        │
-│              ▼                    │                       │ Wait `interval` │
-│   ┌─────────────────────┐         └───────────────────────┘ × 2^N           │
-│   │ Shutdown Remote     │                                  (cap = 300s)     │
-│   │ Servers             │                                                   │
-│   └──────────┬──────────┘                                                   │
-│              ▼                                                              │
-│   ┌─────────────────────┐         ┌──────────────────────────────┐          │
-│   │ flush(timeout=5)    │         │       KEY GUARANTEES          │         │
-│   │ wait for pending=0  │         ├──────────────────────────────┤          │
-│   │ OR 5s, whichever    │         │ ✓ Survives process death     │          │
-│   │ comes first         │         │ ✓ Survives long outages      │          │
-│   └──────────┬──────────┘         │ ✓ FIFO within UPS            │          │
-│              ▼                    │ ✓ Per-message backoff        │          │
-│   ┌─────────────────────┐         │ ✓ No flush burns the CPU on  │          │
-│   │ shutdown -h now     │         │   an unreachable endpoint    │          │
-│   └─────────────────────┘         └──────────────────────────────┘          │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
-
-### Comparison with prior architectures
-
-| Scenario | Fire-and-Forget (v4.6) | Persistent Retry (v4.7+) | Stateful, Lossless (v5.2+) |
-|----------|------------------------|--------------------------|-----------------------------|
-| 30-second network blip | Notifications lost | Retried and delivered | Retried and delivered |
-| Router reboot during outage | Notifications lost | Retried and delivered | Retried and delivered |
-| Transient DNS failure | Notifications lost | Retried and delivered | Retried and delivered |
-| Daemon crashes mid-outage | Messages lost at exit | Messages lost at exit | Pending rows survive in SQLite; next start resumes |
-| `systemctl restart` mid-outage | Messages lost at exit | Messages lost at exit | Resumed transparently |
-| Multi-day internet outage | All retries hammer the network | Same | Per-message exponential backoff, capped at `retry_backoff_max` (default 5 min) |
-| `systemctl restart` (no event) | Stop + Start (2 unrelated messages) | Stop + Start (2 unrelated messages) | Single `🔄 Restarted (downtime: Ns)` (classifier cancels the pending stop) |
-| Package upgrade (deb/rpm) | Stop + Start (2 messages, no version) | Stop + Start (2 messages, no version) | Single `📦 Upgraded vX → vY` (postinstall marker + classifier) |
-| Power-loss recovery | Stop + Start (2 messages, no context) | Stop + Start (2 messages, no context) | Single `📊 Recovered` (folds the prior shutdown headline + downtime + reason) |
-| Brief power blip | 2 messages (`Power Lost` + `Power Restored`) | Same | Coalesced into 1 `📊 Brief Power Outage: Ns on battery` summary |
-| Backlog growth on runaway events | Unbounded queue (OOM risk) | Unbounded queue (OOM risk) | Bounded by `max_pending` (default 10000); oldest cancelled with `backlog_overflow` |
-| Stale pending TTL | N/A (no queue) | N/A (memory-only) | `max_age_days` (default 30) ages out pending rows as `too_old` |
-
-### Shutdown drain: `flush(timeout=5)`
-
-When the daemon is exiting (signal, sequence-complete, or `systemctl stop`), the worker is given up to 5 seconds to drain any pending rows before the process exits. The call returns as soon as `pending` hits 0, so a fast network adds zero latency. Whatever doesn't drain stays in SQLite — the next start replays it, so the only real failure mode is "endpoint still unreachable when the system finally powers off", which Eneru flags in `journalctl` rather than dropping silently.
-
-### 30-second power blip
-
-During a brief power blip, power may return within seconds, well before any shutdown triggers fire. But the public Internet often stays unreachable for several minutes while local network equipment reboots (router, modem, switches, WiFi APs).
-
-Notifications insert as `pending` immediately and the worker retries with exponential backoff. Once the network is back, queued messages drain in age order. With v5.2, an `ON_BATTERY` + `POWER_RESTORED` pair from the same outage that's still pending when delivery resumes is **coalesced into one `📊 Brief Power Outage: Ns on battery` summary** rather than shipping as two separate messages.
-
-```
-Timeline (brief power blip, network slow to recover):
-─────────────────────────────────────────────────────────────────
-0s     │ Power lost, ON_BATTERY row inserted (pending)
-5s     │ Worker retry #1 — network down (attempts=1, wait=5s)
-10s    │ Worker retry #2 — still failing  (attempts=2, wait=10s)
-20s    │ Worker retry #3 — still failing  (attempts=3, wait=20s)
-28s    │ Power restored, POWER_RESTORED row inserted (pending)
-40s    │ Worker retry #4 — still failing  (attempts=4, wait=40s)
-60s    │ Network is back!
-60s    │ Coalescer folds ON_BATTERY + POWER_RESTORED into one row
-60s    │ ✓ "📊 Brief Power Outage: 28s on battery" delivered
-─────────────────────────────────────────────────────────────────
-       1 message delivered (instead of 2) despite a 60-second outage
-```
-
----
-
-## Lifecycle notifications
-
-v5.2 replaces the unconditional `🚀 Started` / `🛑 Stopped` pair with a **stateful classifier** that picks one of eight messages based on two on-disk markers and the previous-version metadata in the stats DB. The result is exactly one notification per lifecycle transition rather than one per process start.
-
-| Classification | Trigger | Driven by |
-|----------------|---------|-----------|
-| `📦 Eneru Upgraded vX → vY` | deb/rpm package upgrade | `.upgrade_marker.json` written by `packaging/scripts/postinstall.sh`; old version captured by `preinstall.sh` (`rpm -q eneru` / `dpkg-query`) |
-| `📦 Eneru Upgraded vX → vY` (pip path) | `pip install --upgrade eneru` followed by restart | `meta.last_seen_version` in the stats DB differs from current `__version__` |
-| `📊 Eneru Recovered` | Daemon coming back after a power-loss-triggered shutdown | `.shutdown_state.json` with `reason: sequence_complete`; folds the prior shutdown headline + summary into one richer message |
-| `🔄 Eneru Restarted (downtime: Ns)` | `systemctl restart eneru` within 30 seconds | `.shutdown_state.json` with `reason: signal` and downtime under 30 s |
-| `🚀 Eneru Restarted` (fatal) | Daemon came back after a crash that wrote a `fatal` marker | `.shutdown_state.json` with `reason: fatal` |
-| `🚀 Eneru Started (last seen Nh ago)` | Daemon started after a long graceful gap | `.shutdown_state.json` present with downtime ≥ 30 s |
-| `🚀 Eneru Started (after crash)` | Daemon came back without ever writing a marker | No shutdown marker but `meta.last_seen_version` is set |
-| `🚀 Eneru vX Started` | First-ever start | No markers, no `last_seen_version` |
-
-The mechanism that delivers "exactly one message" picks the cheapest correct path based on systemd intent:
-
-1. **`systemctl stop eneru`** (systemd `Job=stop` queued): the old daemon ships `🛑 Service Stopped` synchronously via Apprise and exits. Single message, instant — no waiting around.
-2. **`systemctl restart eneru` / package upgrade**: the old daemon enqueues `🛑 Service Stopped` as a `pending` row, stops its worker, and schedules a transient `systemd-run` timer that re-invokes `eneru _deliver-stop` ~15 s later. The timer lives **outside** `eneru.service`'s cgroup so it survives our exit and doesn't gate the systemd restart cycle. The new daemon's classifier cancels the pending row with `cancel_reason='superseded'` before the timer fires → single `🔄 Restarted` / `📦 Upgraded` / `📊 Recovered`. (Package-upgrade also short-circuits via the upgrade marker in the old daemon's `_cleanup_and_exit`, skipping the enqueue entirely.)
-3. **Crash, kill, manual SIGTERM (no systemd job queued)**: defensive — same systemd-run timer as case 2. If a replacement comes up within 15 s the row is cancelled; otherwise the timer ships.
-4. **Not under systemd** (Docker, K8s, foreground `eneru run`): the defer-then-ship dance only makes sense when there's a service manager that will or won't restart us. The old daemon ships eagerly via Apprise, identical to case 1. Single message, instant.
-
-The systemd intent is detected by querying `systemctl show -p Job eneru.service` at SIGTERM time — systemd has the job queued before it sends the signal, so by the time we read this we see whether it's a stop, a restart, or nothing (crash/kill).
-
----
-
-## Coalescing
-
-Two related events that reach the queue close together get folded into one richer message before delivery, so the user sees the *story* rather than the individual signals.
-
-**Brief power outage.** When a `POWER_RESTORED` notification is being enqueued and an `ON_BATTERY` notification from the same outage is still `pending` (i.e. the network was down during the outage and only came back after recovery), both rows are cancelled with reason `coalesced` and replaced by a single `📊 Brief Power Outage: Ns on battery` summary. If either row already shipped, no fold-in happens — the user still gets two messages, which is the right behaviour because the first one already left the building.
-
-**Power-loss recovery fold-in.** When the daemon classifies a startup as `📊 Recovered` (sequence_complete shutdown marker on disk), it absorbs the prior instance's pending shutdown *headline* (the `🚨 EMERGENCY SHUTDOWN INITIATED!` line) and the pending shutdown *summary* (`✅ Shutdown Sequence Complete`) into one message that carries the trigger reason and the total downtime. The fold is bounded to the current outage (`shutdown_at - 60 s` floor) so an unrelated older pending shutdown row from a previous outage isn't accidentally cancelled.
-
----
-
-## Notification events
-
-| Event | `event_type` (stats DB) | Category | Notes |
-|-------|-------------------------|----------|-------|
-| Power lost | `ON_BATTERY` | `power_event_on_battery` | Sub-typed category lets the coalescer pair it with `power_event_on_line` by exact match |
-| Power restored | `POWER_RESTORED` | `power_event_on_line` | Suppressible via `notifications.suppress` |
-| Brief power outage (coalesced) | `BRIEF_POWER_OUTAGE` | `power_event` | v5.2 summary row that replaces an `ON_BATTERY` + `POWER_RESTORED` pair |
-| Connection lost / restored | `CONNECTION_LOST` / `CONNECTION_RESTORED` | `power_event` | Restored is suppressible |
-| Emergency shutdown initiated | `EMERGENCY_SHUTDOWN_INITIATED` | `shutdown` | Safety-critical (cannot be suppressed) |
-| Shutdown sequence complete | `SHUTDOWN_SEQUENCE_COMPLETE` | `shutdown_summary` | One per shutdown |
-| Voltage: brownout / over-voltage | `BROWNOUT_DETECTED` / `OVER_VOLTAGE_DETECTED` | `power_event` | Hysteresis-debounced; severe deviations bypass the dwell |
-| Voltage normalized | `VOLTAGE_NORMALIZED` | `power_event` | Suppressible |
-| AVR boost / trim / inactive | `AVR_BOOST_ACTIVE` / `AVR_TRIM_ACTIVE` / `AVR_INACTIVE` | `power_event` | All three suppressible |
-| Bypass active / inactive | `BYPASS_MODE_ACTIVE` / `BYPASS_MODE_INACTIVE` | `power_event` | Active is safety-critical |
-| Overload active / resolved | `OVERLOAD_ACTIVE` / `OVERLOAD_RESOLVED` | `power_event` | Active is safety-critical |
-| Battery anomaly | `BATTERY_ANOMALY_DETECTED` | `health` | Charge dropped > 20% while on line power; sustained-reading filter (3 polls) for APC / CyberPower / UniFi firmware jitter |
-| Lifecycle: started / restarted / recovered / upgraded | `DAEMON_START` / `DAEMON_RESTARTED` / `DAEMON_RECOVERED` / `DAEMON_UPGRADED` | `lifecycle` | One per lifecycle transition (see "Lifecycle notifications") |
-| Lifecycle: restarted after fatal | `DAEMON_RESTARTED_AFTER_FATAL` | `lifecycle` | |
-| Lifecycle: started after crash | `DAEMON_AFTER_CRASH` | `lifecycle` | Marker-less restart with prior `last_seen_version` |
-| Lifecycle: stopped | `DAEMON_STOP` | `lifecycle` | Pending row gets superseded if a new daemon comes up within the restart window |
-
----
-
-## Tuning alert noise
-
-Issue [#27](https://github.com/m4r1k/Eneru/issues/27) reported "a lot
-of email" from chatty UPS firmware on a US 120V grid. Eneru ships
-two knobs to tune notification volume — both designed so a
-misconfiguration cannot silence a real safety-critical event.
-
-### `voltage_hysteresis_seconds` — debounce transient flaps
+### Email
 
 ```yaml
 notifications:
-  voltage_hysteresis_seconds: 30   # default; 0 = legacy immediate
+  urls:
+    - "mailto://user:password@smtp.example.com:587?to=admin@example.com"
 ```
 
-When `voltage_state` transitions to HIGH or LOW, the
-`OVER_VOLTAGE_DETECTED` / `BROWNOUT_DETECTED` log line and SQLite
-event row are written **immediately** (operational record is
-sacred). The notification dispatch is held for
-`voltage_hysteresis_seconds`. If the condition reverts inside the
-window, no notification fires and a `VOLTAGE_FLAP_SUPPRESSED` event
-is recorded for visibility:
+Apprise documents the full URL catalog in its [service wiki](https://github.com/caronc/apprise/wiki).
 
-```bash
-sqlite3 /var/lib/eneru/<UPS>.db \
-  "SELECT ts, event_type, detail FROM events
-   WHERE event_type='VOLTAGE_FLAP_SUPPRESSED'
-   ORDER BY ts DESC LIMIT 10;"
+## Persistent retry
+
+Eneru stores pending notifications in the per-UPS SQLite database. If the network is down, the worker retries with exponential backoff. If Eneru restarts before delivery, the next process resumes the queue.
+
+```text
+ENERU NOTIFICATION PATH
+
+ +----------------------+      insert pending       +----------------------+
+ | Main monitor thread  +-------------------------->| Per-UPS SQLite DB    |
+ | power/lifecycle      |                           | notifications table  |
+ | event occurs         |                           | status = pending     |
+ +----------+-----------+                           +----------+-----------+
+            |                                                  ^
+            | continue safety work                             |
+            v                                                  | update row
+ +----------+-----------+                                      |
+ | Shutdown sequence    |                           +----------+-----------+
+ | VMs, containers, SSH |                           | Worker thread       |
+ | filesystems, local   |                           | oldest due row      |
+ | poweroff             |                           | Apprise delivery    |
+ +----------------------+                           +----------+-----------+
+                                                               |
+                                                +--------------+--------------+
+                                                |                             |
+                                                v                             v
+                                      +---------+----------+       +----------+---------+
+                                      | success            |       | failure            |
+                                      | mark sent          |       | attempts += 1      |
+                                      +--------------------+       | schedule backoff   |
+                                                                   +--------------------+
 ```
 
-If the condition persists past the dwell, the notification fires
-with a `Persisted Ns.` annotation so you can see it was held.
+```yaml
+notifications:
+  retry_interval: 5
+  retry_backoff_max: 300
+  max_attempts: 0
+  max_age_days: 30
+  max_pending: 10000
+  retention_days: 7
+```
 
-**Severity bypass (rc9, 5.1.0).** Non-severe voltage warnings (up
-to and including ±15% from nominal) go through the dwell as
-described above. **Severe deviations** (greater than ±15% from
-nominal) bypass the dwell entirely and notify immediately, with a
-`(severe, X.X% below/above nominal)` tag and an
-`Approaching UPS battery-switch threshold` callout when NUT
-exposes the UPS's transfer points. The reasoning:
-- Non-severe events are usually flap from neighbour appliances
-  cycling — the 30s filter is the right call. Note that with
-  narrow UPS transfer points the warning thresholds may be tighter
-  than ±10%, so the "non-severe" band can fire at less than 10%
-  deviation; the dwell still applies.
-- Severe deviations indicate real grid trouble (utility fault,
-  generator instability, site wiring issue) — the operator wants
-  to know immediately, not 30s later.
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `retry_interval` | `5` | First retry delay in seconds |
+| `retry_backoff_max` | `300` | Maximum delay after exponential backoff |
+| `max_attempts` | `0` | Attempt cap. `0` means unlimited until age/backlog policy cancels the row |
+| `max_age_days` | `30` | Pending rows older than this are cancelled as `too_old` |
+| `max_pending` | `10000` | Pending backlog cap. Oldest rows are cancelled as `backlog_overflow` |
+| `retention_days` | `7` | Sent and cancelled row retention |
 
-The bypass threshold (15%) is hard-coded — there's deliberately no
-config knob for it, same reasoning as the warning thresholds: a
-misconfiguration there would mask real over-voltage events.
+`max_attempts` defaults to unlimited because Apprise returns one boolean for success or failure. Eneru cannot reliably tell a bad URL from a temporary internet outage.
 
-### `notifications.suppress` — mute specific event types
+### Notification architecture history
+
+| Scenario | Fire-and-forget (v4.6) | Memory retry (v4.7+) | SQLite queue (v5.2+) |
+|----------|------------------------|----------------------|----------------------|
+| Short network blip | Message could be lost | Retried while process stayed alive | Retried until delivered |
+| Router reboot during outage | Message could be lost | Retried while process stayed alive | Retried after network returns |
+| Daemon restart mid-outage | In-memory message lost | In-memory message lost | Pending row survives restart |
+| Host powers off before delivery | Message lost | Message lost | Row remains for next boot if disk survives |
+| Multi-day endpoint outage | No queue | Repeated retries in memory | Per-message backoff capped by `retry_backoff_max` |
+| Brief power outage with delayed internet | Separate messages or losses | Separate messages if delivered | Pending `ON_BATTERY` + `POWER_RESTORED` can coalesce |
+| `systemctl restart eneru` | Stop/start noise | Stop/start noise | Single restart notification when classified |
+| Package upgrade | Stop/start noise | Stop/start noise | Single upgraded notification when classified |
+| Backlog growth | Not applicable | Process memory growth | Bounded by `max_pending` |
+| Stale pending messages | Not applicable | Lost on process exit | Aged out by `max_age_days` |
+
+The v5.2 queue is intentionally boring: SQLite row first, network later. Shutdown code should not block on Discord, email, DNS, or a phone push service during a power event.
+
+### Retry timeline
+
+The retry timer is per message. A failed send does not block newer shutdown work, and it does not spin in a tight loop while the network is down. The first attempt is due immediately because a newly inserted row has no backoff entry. After a failure, `retry_interval * 2^(attempts-1)` is used, capped by `retry_backoff_max`.
+
+| Time | Worker action | Row state |
+|------|---------------|-----------|
+| 0s | Event inserts notification | `pending`, `attempts=0`; worker is woken |
+| Immediately or next 1s worker tick | First delivery attempt fails | `attempts=1`, next attempt in 5s by default |
+| About 5s later | Second attempt fails | `attempts=2`, next attempt in 10s |
+| About 10s later | Third attempt fails | `attempts=3`, next attempt in 20s |
+| About 20s later | Fourth attempt fails | Backoff continues, capped by `retry_backoff_max` |
+| Network returns | Next due attempt succeeds | Row becomes `sent` |
+| `max_age_days` reached and prune runs | Message is too old | Row becomes `cancelled`, reason `too_old` |
+
+## Coalescing
+
+Eneru folds related pending events before delivery when doing so gives the operator a clearer message.
+
+| Pattern | Result |
+|---------|--------|
+| Power lost and restored while both messages are still pending | One brief-outage summary |
+| Shutdown summary pending when the daemon starts after power recovery | One recovery notification with downtime and reason |
+| Stop message pending and a new daemon starts quickly | One restarted, upgraded, or recovered notification |
+
+Already-delivered messages are not rewritten.
+
+### Brief outage coalescing timeline
+
+This is the common "power came back fast, internet came back slowly" case. Coalescing only happens if both rows are still `pending` when the worker sees them; already-sent rows are left alone.
+
+| Time | Event | Notification result |
+|------|-------|---------------------|
+| 0s | UPS goes on battery | `ON_BATTERY` row is inserted as pending |
+| 5s | Worker tries delivery | Network is still down, so the row remains pending |
+| 28s | Power returns | `POWER_RESTORED` row is inserted as pending |
+| Later worker pass | Network or endpoint is usable again | Worker sees both rows still pending |
+| Same pass | Coalescer runs before delivery | Original rows are cancelled as `coalesced` and a summary row is inserted |
+| Same or next pass | Summary row is due | One brief-outage notification is delivered |
+
+## Lifecycle notifications
+
+Eneru classifies daemon starts instead of blindly sending "stopped" and "started" every time.
+
+| Event | How Eneru recognizes it |
+|-------|-------------------------|
+| Package upgrade | Package marker from install scripts or a stored version change |
+| Restart | Previous shutdown marker with short downtime |
+| Recovery after UPS-triggered shutdown | Shutdown-state marker with sequence-complete reason |
+| Crash recovery | Missing or fatal shutdown marker |
+| First start | No previous lifecycle metadata |
+
+The goal is one useful lifecycle message per transition.
+
+### Restart classification timeline
+
+This is the systemd restart path. The deferred timer delay is `DEFAULT_DEFER_SECS = 15` in `src/eneru/deferred_delivery.py`; plain `systemctl stop` and non-systemd foreground runs send the stop notification eagerly instead.
+
+| Time | Event | Notification behavior |
+|------|-------|-----------------------|
+| 0s | Old daemon exits under systemd restart or unknown intent | Stop row is queued and a 15s `systemd-run` delivery timer is scheduled |
+| Before 15s | Replacement daemon starts | Startup classifier reads the previous shutdown marker |
+| Before 15s | Classifier recognizes restart, upgrade, or recovery | Pending stop row is cancelled as `superseded` |
+| Before 15s | Replacement notification is queued | A single restarted, upgraded, or recovered message is sent |
+| 15s | No replacement cancelled the original row | Deferred delivery timer fires and the stopped message is sent |
+
+## Alert noise tuning
+
+### Voltage hysteresis
+
+```yaml
+notifications:
+  voltage_hysteresis_seconds: 30
+```
+
+Voltage events are logged immediately. The notification waits until the condition has persisted for the configured number of seconds. If voltage returns to normal before the dwell expires, Eneru records `VOLTAGE_FLAP_SUPPRESSED` and sends no alert.
+
+Severe deviations beyond +/- 15% of nominal bypass the dwell and notify immediately.
+
+### Voltage hysteresis timeline
+
+The default dwell is 30 seconds. The log and `events` table are immediate; only notification delivery waits.
+
+| Time | Voltage state | Notification behavior |
+|------|---------------|-----------------------|
+| 0s | Input crosses warning threshold | Log and SQLite event are written immediately |
+| 10s | Voltage returns to normal | No notification is sent; `VOLTAGE_FLAP_SUPPRESSED` is recorded |
+| 0s | Input crosses warning threshold again | New dwell window starts |
+| 30s | Still outside threshold | Notification is sent with a persisted-duration note |
+| Any time | Severe deviation exceeds +/- 15% nominal | Notification bypasses dwell and sends immediately |
+
+### Suppression list
 
 ```yaml
 notifications:
@@ -355,80 +272,57 @@ notifications:
     - AVR_INACTIVE
 ```
 
-Mutes notifications for the listed event types. The events still
-land in the log file and the SQLite `events` table — only the
-notification dispatch is gated. The events table records
-`notification_sent=0` for muted events so you can audit later:
+Suppression mutes notifications only. The log and SQLite `events` table still record the event with `notification_sent=0`.
+
+Allowed event names:
+
+| Event |
+|-------|
+| `POWER_RESTORED` |
+| `VOLTAGE_NORMALIZED` |
+| `AVR_BOOST_ACTIVE` |
+| `AVR_TRIM_ACTIVE` |
+| `AVR_INACTIVE` |
+| `BYPASS_MODE_INACTIVE` |
+| `OVERLOAD_RESOLVED` |
+| `CONNECTION_RESTORED` |
+| `VOLTAGE_AUTODETECT_MISMATCH` |
+| `VOLTAGE_FLAP_SUPPRESSED` |
+
+Safety-critical events cannot be suppressed. Validation rejects them:
+
+| Blocked event |
+|---------------|
+| `OVER_VOLTAGE_DETECTED` |
+| `BROWNOUT_DETECTED` |
+| `OVERLOAD_ACTIVE` |
+| `BYPASS_MODE_ACTIVE` |
+| `ON_BATTERY` |
+| `CONNECTION_LOST` |
+| Any event starting with `SHUTDOWN_` |
+
+## Inspect notification history
+
+Each UPS database contains notification rows. The exact file name is the sanitized UPS label.
 
 ```bash
-sqlite3 /var/lib/eneru/<UPS>.db \
-  "SELECT event_type, COUNT(*) FROM events
-   WHERE notification_sent = 0
-   GROUP BY event_type;"
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT ts, status, attempts, cancel_reason, title FROM notifications ORDER BY ts DESC LIMIT 20;"
 ```
 
-**Suppressible event names** (any combination is accepted; case-
-insensitive):
+Muted events are in the `events` table:
 
-- `POWER_RESTORED`
-- `VOLTAGE_NORMALIZED`
-- `AVR_BOOST_ACTIVE`, `AVR_TRIM_ACTIVE`, `AVR_INACTIVE`
-- `BYPASS_MODE_INACTIVE`
-- `OVERLOAD_RESOLVED`
-- `CONNECTION_RESTORED`
-- `VOLTAGE_AUTODETECT_MISMATCH`
-- `VOLTAGE_FLAP_SUPPRESSED`
-
-### Safety-critical blocklist
-
-The following event names **cannot** appear in
-`notifications.suppress`. The config validator rejects them with a
-clear error pointing at `voltage_hysteresis_seconds` for
-flap-debounce:
-
-- `OVER_VOLTAGE_DETECTED`
-- `BROWNOUT_DETECTED`
-- `OVERLOAD_ACTIVE`
-- `BYPASS_MODE_ACTIVE`
-- `ON_BATTERY`
-- `CONNECTION_LOST`
-- Anything starting with `SHUTDOWN_`
-
-These exist to alert you to potential hardware damage or imminent
-service loss; silencing them defeats the safety contract. If you're
-seeing frequent over-voltage warnings on a US grid, the right fix
-is the auto-detect re-snap (see
-[Triggers → Voltage thresholds](triggers.md#voltage-thresholds-preset-driven-raw-thresholds-not-user-configurable)),
-not muting the alert.
-
----
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT event_type, COUNT(*) FROM events WHERE notification_sent = 0 GROUP BY event_type;"
+```
 
 ## Troubleshooting
 
-### Notifications not arriving
-
-Test Apprise directly:
-
-```bash
-python3 -c "
-import apprise
-ap = apprise.Apprise()
-ap.add('discord://webhook_id/webhook_token')
-result = ap.notify(body='Test from Apprise', title='Test')
-print('Success' if result else 'Failed')
-"
-```
-
-Check that the URL format matches the service. Each service has its own format documented in the [Apprise Wiki](https://github.com/caronc/apprise/wiki).
-
-Verify the server can reach the notification service:
-
-```bash
-curl -I https://discord.com
-```
-
-Notification errors are logged to `/var/log/ups-monitor.log`.
-
-### Rate limiting
-
-Some services (especially Discord) have rate limits. If you're testing frequently, you may hit these limits. In production, power events are infrequent enough that this shouldn't be an issue.
+| Symptom | Check |
+|---------|-------|
+| Test command says Apprise is missing | Install the native package with notification dependencies, or use `eneru[notifications]` for PyPI |
+| URL rejected | Compare the URL against the Apprise wiki for that service |
+| Test sends but production events do not arrive | Check `notifications.suppress`, service rate limits, and outbound HTTPS/DNS |
+| Messages arrive late | Check network recovery during outages and pending rows in SQLite |
+| Duplicate lifecycle messages | Check whether multiple Eneru instances are running against the same config |

--- a/docs/redundancy-groups.md
+++ b/docs/redundancy-groups.md
@@ -1,23 +1,21 @@
 # Redundancy groups
 
-A redundancy group ties a set of resources to two or more UPS sources.
-Eneru only acts when the group's quorum is lost. Use this for dual-PSU
-servers, redundant rack feeds, and A+B data-centre power.
+A redundancy group protects one set of resources with two or more UPS sources. Eneru shuts the group down only when the configured quorum is lost.
+
+Use this for dual-PSU servers, A+B rack feeds, and other setups where losing one UPS does not mean the protected system has lost power.
 
 ## When to use one
 
 | Situation | Use a redundancy group? |
-|---|---|
-| Single UPS feeding a single PSU server | No, use `ups:` only. |
-| Two UPSes, each feeding a different server | No, use two independent UPS groups. |
-| Two UPSes feeding redundant PSUs on the same server or rack | Yes. |
-| A+B feeds across a chassis row, with cross-cabling | Yes. |
+|-----------|-------------------------|
+| One UPS feeds one server | No. Use a normal UPS group |
+| Two UPSes feed two independent racks | No. Use multi-UPS groups |
+| Two UPSes feed both PSUs on the same server | Yes |
+| Two UPSes feed a shared A+B rack | Yes |
 
-The rule of thumb: if losing one UPS does not mean losing the resource,
-the resource belongs in a redundancy group. Eneru should only shut it
-down when the redundancy itself is gone.
+The practical test is simple: if a resource can survive one UPS failure, put it in a redundancy group instead of assigning it directly to a single UPS group.
 
-## Quick example
+## Example
 
 ```yaml
 ups:
@@ -30,6 +28,8 @@ redundancy_groups:
       - "UPS-A@10.0.0.10"
       - "UPS-B@10.0.0.11"
     min_healthy: 1
+    degraded_counts_as: healthy
+    unknown_counts_as: critical
     remote_servers:
       - name: "Compute Node 1"
         enabled: true
@@ -37,191 +37,160 @@ redundancy_groups:
         user: "root"
 ```
 
-`min_healthy: 1` shuts down only when fewer than 1 member UPS is
-healthy, i.e. when both UPSes have failed. With two UPSes and
-`min_healthy: 1` the rack tolerates a single UPS outage indefinitely.
+With two UPSes and `min_healthy: 1`, the group tolerates one failed UPS. It shuts down only when the healthy count drops below 1.
 
-## Field reference
+## Fields
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `name` | required | Unique group label |
+| `ups_sources` | required | Two or more UPS names from the top-level `ups:` list |
+| `min_healthy` | `1` | Shutdown fires when healthy member count is below this number |
+| `degraded_counts_as` | `healthy` | Count DEGRADED members as `healthy` or `critical` |
+| `unknown_counts_as` | `critical` | Count UNKNOWN members as `critical`, `degraded`, or `healthy` |
+| `is_local` | `false` | This group powers the Eneru host and may own local resources |
+| `triggers` | inherits | Trigger overrides for this group |
+| `remote_servers` | `[]` | Remote resources owned by the group |
+| `virtual_machines`, `containers`, `filesystems` | disabled | Local resources. Valid only when `is_local: true` |
+
+## Quorum
+
+The group fires when:
+
+```text
+healthy_count < min_healthy
+```
+
+For a two-UPS dual-PSU server:
+
+| `min_healthy` | Behavior |
+|---------------|----------|
+| `1` | Shut down when both UPSes fail. This is the usual choice |
+| `2` | Shut down when either UPS fails. This removes practical redundancy |
+
+For a three-UPS group:
+
+| `min_healthy` | Behavior |
+|---------------|----------|
+| `1` | Tolerate two failed members |
+| `2` | Tolerate one failed member |
+| `3` | Shut down when any member fails |
+
+`min_healthy: 0` is invalid because the group would never shut down.
+
+## Member states
+
+Each UPS member is classified on every evaluator tick.
+
+| State | Meaning |
+|-------|---------|
+| `HEALTHY` | UPS reports usable data and no active problem |
+| `DEGRADED` | UPS is visible but in a warning state, such as on battery or voltage warning |
+| `CRITICAL` | UPS hit a shutdown trigger, FSD, overload-critical path, or explicit advisory condition |
+| `UNKNOWN` | Snapshot is stale, NUT connection is lost, or the monitor cannot provide current data |
+
+`degraded_counts_as` controls whether warning states still contribute to quorum. `unknown_counts_as` controls how missing data is counted. The default is tolerant of degraded power but fail-safe on missing visibility.
+
+## Advisory triggers
+
+Member UPS triggers still run. In a redundancy group they do not directly run the shutdown sequence. They mark the member as advisory-critical, then the group evaluator decides whether quorum is gone.
+
+You will see log lines like:
+
+```text
+Trigger condition met (advisory, redundancy group): battery below threshold
+```
+
+For `min_healthy: 1`, that advisory condition only shuts down the protected resource if every other member has also stopped counting as healthy.
+
+## Local ownership
+
+At most one group across the whole config can be `is_local: true`. That group may own local VMs, containers, filesystems, and local shutdown behavior.
+
+This is valid:
 
 ```yaml
 redundancy_groups:
-  - name: "<unique-name>"             # required, used in logs / shutdown flag files
-    ups_sources:                       # required, 2+ UPS names from the top-level `ups:` section
-      - "UPS-A@host"
-      - "UPS-B@host"
-    min_healthy: 1                     # quorum: shutdown when healthy_count < min_healthy
-    degraded_counts_as: "healthy"      # "healthy" | "critical"
-    unknown_counts_as: "critical"      # "healthy" | "degraded" | "critical"
-    is_local: false                    # at most one group across the config can be is_local
-    triggers:                          # optional; inherits from top-level triggers
-      low_battery_threshold: 20
-    remote_servers: [...]              # owned by this group
-    virtual_machines: { enabled: ... } # only valid when is_local: true
-    containers: { enabled: ... }       # only valid when is_local: true
-    filesystems: { ... }               # only valid when is_local: true
+  - name: "local-dual-feed"
+    is_local: true
+    virtual_machines:
+      enabled: true
 ```
 
-### `min_healthy`
+This is not valid if another UPS group already has `is_local: true`.
 
-The quorum threshold. Shutdown fires when:
+## Remote-server ownership
 
-```
-healthy_count(group) < min_healthy
-```
+A remote server, identified by `host` and `user`, can belong to only one place:
 
-For a 2-UPS group, the practical choices are:
+- One UPS group's `remote_servers` list.
+- One redundancy group's `remote_servers` list.
 
-| `min_healthy` | Behaviour |
-|---|---|
-| `1` | Shut down only when both UPSes fail (recommended). |
-| `2` | Shut down when either UPS fails (no redundancy; flagged with a warning during validation). |
+Validation rejects duplicate ownership so Eneru cannot shut down the same server through two paths.
 
-For a 3-UPS group:
-
-| `min_healthy` | Behaviour |
-|---|---|
-| `1` | Tolerate any 2 simultaneous failures. |
-| `2` | Tolerate any 1 failure; shut down on the second. |
-| `3` | No redundancy (warning). |
-
-`min_healthy: 0` is rejected. A group that never triggers a shutdown
-serves no purpose; remove the group instead.
-
-### `degraded_counts_as`
-
-A degraded member UPS reports valid data but in a warning state:
-voltage outside thresholds, AVR active, on battery but above all
-triggers. `degraded_counts_as` controls how that contributes to
-`healthy_count`:
-
-| Value | Effect |
-|---|---|
-| `healthy` | (default) Degraded UPSes still count as healthy. Tolerant; fits homelab and most production sites. |
-| `critical` | Degraded UPSes count as failed. Strict; fits sites where any voltage warning means the protective margin is gone, so shut down pre-emptively. |
-
-### `unknown_counts_as`
-
-A member UPS becomes unknown when the snapshot is stale (no successful
-poll for `5 * check_interval` seconds), the NUT connection has dropped,
-or the per-UPS monitor thread is mid-recovery from a connection failure.
-
-| Value | Effect |
-|---|---|
-| `critical` | (default) Unknown counts as failed. Fail-safe: if you cannot see the UPS, assume the worst. |
-| `degraded` | Unknown counts as degraded; then `degraded_counts_as` decides whether that maps to healthy or critical. Useful when you have flaky NUT servers and want a controlled escalation. |
-| `healthy` | Unknown counts as healthy. Risky; only use when your UPSes are genuinely independent and a transient NUT outage is more likely than a real power event. |
-
-`critical` is the right default for almost everyone. Consider
-`degraded` only after you have hardened your NUT setup and verified
-flap behaviour with the connection-loss grace period.
-
-### `is_local`
-
-`is_local: true` declares that this redundancy group powers the Eneru
-host itself, allowing the group to declare local resources
-(`virtual_machines`, `containers`, `filesystems`).
-
-At most one group across the entire configuration, UPS group or
-redundancy group, can be `is_local: true`. Validation rejects configs
-that declare two `is_local` groups.
-
-### Resource ownership rules
-
-A remote server, identified by `host` + `user`, must belong to exactly
-one tier:
-
-- A single `ups_groups[*].remote_servers` entry, or
-- A single `redundancy_groups[*].remote_servers` entry.
-
-Listing the same `host` + `user` in both tiers is rejected at
-validation time. Otherwise, Eneru would shut the same server down
-through two different code paths.
-
-## Validating your config
+## Validate
 
 ```bash
-eneru validate --config /etc/ups-monitor/config.yaml
+sudo eneru validate --config /etc/ups-monitor/config.yaml
 ```
 
-The output gains a "Redundancy groups" section when any are configured:
+Validation prints configured redundancy groups:
 
-```
-  Redundancy groups (1):
-    1. rack-1-dual-psu
-       Sources (2): UPS-A@10.0.0.10, UPS-B@10.0.0.11
-       Quorum: min_healthy=1 (degraded→healthy, unknown→critical)
-       Remote servers (2): Compute Node 1, Compute Node 2
-```
-
-Invalid configs exit non-zero with the specific rule that failed
-(`min_healthy must be >= 1`, `references unknown UPS name(s)`,
-`Multiple groups marked as is_local`, etc.).
-
-## Working example
-
-A complete dual-PSU config is shipped at
-[`examples/config-redundancy.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-redundancy.yaml).
-Copy it as a starting point and adjust the `ups_sources`, `host`s, and
-SSH user names for your environment.
-
-## How it actually fires
-
-Each member UPS keeps polling on its own thread at its
-`check_interval`. When a per-UPS trigger condition is met (low battery,
-low runtime, depletion rate, extended time on battery, FSD, or
-FAILSAFE), the member does not run a local shutdown. It sets an
-advisory flag in its state snapshot and emits a log line:
-
-```
-⚠️ Trigger condition met (advisory, redundancy group): <reason>
+```text
+Redundancy groups (1):
+  1. rack-1-dual-psu
+     Sources (2): UPS-A@10.0.0.10, UPS-B@10.0.0.11
+     Quorum: min_healthy=1 (degraded->healthy, unknown->critical)
+     Remote servers (1): Compute Node 1
 ```
 
-A separate `RedundancyGroupEvaluator` thread (one per group, ~1s tick)
-reads every member's snapshot under a lock, classifies each into
-`HEALTHY` / `DEGRADED` / `CRITICAL` / `UNKNOWN`, applies the group's
-`degraded_counts_as` / `unknown_counts_as` policy, and only fires the
-group's shutdown when:
+Common validation failures:
 
+| Error class | Cause |
+|-------------|-------|
+| Unknown UPS source | `ups_sources` does not exactly match a top-level `ups[].name` |
+| Duplicate UPS source | Same member listed twice |
+| Duplicate group name | Two redundancy groups share a name |
+| Multiple local groups | More than one UPS or redundancy group has `is_local: true` |
+| Duplicate remote ownership | Same `host` and `user` assigned to more than one group |
+
+## Failure timeline
+
+For a dual-UPS group with `min_healthy: 1` and default counting:
+
+| Time | Event | Group result |
+|------|-------|--------------|
+| 0s | UPS-A loses input power | UPS-A is `DEGRADED`, UPS-B is `HEALTHY`. Quorum holds |
+| 60s | UPS-A hits low battery | UPS-A is `CRITICAL`, UPS-B is `HEALTHY`. Quorum still holds |
+| 90s | UPS-B also loses input power | UPS-B is `DEGRADED` and counts as healthy by default. Quorum holds |
+| 120s | UPS-B hits low battery | Both members are `CRITICAL`. Quorum is lost and shutdown starts |
+
+If you want the group to shut down as soon as a member is merely degraded, set `degraded_counts_as: critical`.
+
+## Sizing warning
+
+Redundancy only works if the remaining feed can carry the load. For A+B power, verify that each UPS can carry the full protected load during single-feed operation.
+
+Good targets:
+
+- Normal operation: each UPS at or below about 50% load.
+- Single-feed degraded operation: surviving UPS below about 80% load.
+- Extra headroom for inrush, battery age, and generator transitions.
+
+If the surviving UPS overloads, software cannot save the rack. Fix the load or UPS sizing.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| One UPS failed but nothing shut down | Quorum still holds. Check `min_healthy` and member states |
+| On-battery member still counts healthy | `degraded_counts_as: healthy` is the default |
+| Advisory log appears but no shutdown | Another member still satisfies quorum |
+| Group never starts | `ups_sources` names do not match exactly |
+| Repeated tests do not fire | A previous dry-run or killed process left `/var/run/ups-shutdown-redundancy-*` |
+
+Clear stale redundancy flags only after confirming no real shutdown is in progress:
+
+```bash
+sudo rm -f /var/run/ups-shutdown-redundancy-*
 ```
-healthy_count(group) < min_healthy
-```
-
-When the group fires, the executor reuses the same shutdown mixins as
-the per-UPS path. Multi-phase ordering (`shutdown_order`),
-`shutdown_safety_margin`, and deadline-based join behave identically.
-The group's flag file lives at
-`/var/run/ups-shutdown-redundancy-{sanitized-group-name}` and makes
-the shutdown idempotent across signals or restarts mid-flow.
-
-### Cascade timeline (dual-PSU, `min_healthy: 1`)
-
-| Time | Event | Group state |
-|---|---|---|
-| t = 0 | UPS-A loses input power → on battery | UPS-A=DEGRADED, UPS-B=HEALTHY → quorum holds |
-| t = 30 | UPS-A battery drops below threshold | UPS-A advisory trigger set; CRITICAL. UPS-B=HEALTHY → quorum still holds |
-| t = 90 | UPS-B also loses input power | UPS-B=DEGRADED → still 1 healthy via DEGRADED→healthy → quorum holds |
-| t = 95 | UPS-B battery also drops below threshold | both CRITICAL → quorum LOST → executor fires |
-
-### Load redistribution
-
-When one UPS in the group loses input power, the other UPS picks up the
-full rack load. Rack-level UPSes are normally sized for the peak load
-on a single feed, so this is fine, but verify your sizing:
-
-- Peak load per UPS during normal operation (both feeds up) ≤ 50% of rated output.
-- Peak load per UPS during single-feed degraded mode ≤ 80% of rated output.
-- Reserve 20% margin for inrush and boot transients.
-
-If the surviving UPS is overloaded (the `OVERLOAD` flag flips to
-ACTIVE), that UPS will likely flip to bypass or drop the load
-entirely. There is no software workaround; fix the load.
-
-## See also
-
-- [Configuration reference](configuration.md). Every field, with defaults.
-- [Shutdown triggers](triggers.md). Per-UPS triggers stay active in
-  advisory mode for redundancy-group members.
-- [Remote servers](remote-servers.md). SSH and pre-shutdown command
-  semantics. Identical between independent and redundancy-group servers.
-- [Troubleshooting](troubleshooting.md). "Why isn't my redundancy
-  shutdown firing?"

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -1,14 +1,26 @@
-# Remote server setup
+# Remote servers
 
-Eneru can shut down remote servers via SSH during a power event: NAS devices (Synology, QNAP, TrueNAS), additional servers sharing the same UPS, network equipment with SSH access, or any system that needs coordinated shutdown.
+Eneru can shut down other systems over SSH before the local host powers off. Use this for NAS devices, hypervisors, Docker hosts, storage nodes, and network equipment that must leave cleanly during an outage.
 
----
-
-## Configuration
+## Minimal remote server
 
 ```yaml
 remote_servers:
-  # Proxmox hypervisor - stop VMs/CTs before shutdown
+  - name: "NAS"
+    enabled: true
+    host: "192.168.1.50"
+    user: "admin"
+    shutdown_command: "sudo -i synoshutdown -s"
+```
+
+Eneru connects as `admin@192.168.1.50` and runs the final shutdown command.
+
+## Pre-shutdown actions
+
+Run cleanup commands before the final shutdown:
+
+```yaml
+remote_servers:
   - name: "Proxmox Host"
     enabled: true
     host: "192.168.1.60"
@@ -21,287 +33,191 @@ remote_servers:
         timeout: 60
       - action: "sync"
     shutdown_command: "shutdown -h now"
-
-  # NAS - shutdown LAST since other servers mount its storage
-  - name: "Synology NAS"
-    enabled: true
-    host: "192.168.1.50"
-    user: "admin"
-    parallel: false  # Shutdown after all parallel servers
-    shutdown_command: "sudo -i synoshutdown -s"
-    ssh_options:
-      - "-o StrictHostKeyChecking=no"
 ```
 
-### Configuration options
+Pre-shutdown commands are best effort. Eneru logs failures and continues to the final shutdown command.
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `name` | (required) | Display name for logging |
-| `enabled` | `false` | Enable this server |
-| `host` | (required) | Hostname or IP address |
-| `user` | (required) | SSH username |
-| `connect_timeout` | `10` | SSH connection timeout in seconds |
-| `command_timeout` | `30` | Default timeout for commands in seconds |
-| `shutdown_command` | `sudo shutdown -h now` | Final shutdown command |
-| `ssh_options` | `[]` | Additional SSH options |
-| `pre_shutdown_commands` | `[]` | Commands to run before shutdown |
-| `parallel` | `true` | Shutdown concurrently with other parallel servers |
+| Action | What it does |
+|--------|--------------|
+| `stop_containers` | Stop all Docker or Podman containers |
+| `stop_vms` | Stop libvirt/KVM VMs through `virsh` |
+| `stop_proxmox_vms` | Stop Proxmox QEMU VMs through `qm` |
+| `stop_proxmox_cts` | Stop Proxmox LXC containers through `pct` |
+| `stop_xcpng_vms` | Stop XCP-ng or XenServer VMs |
+| `stop_esxi_vms` | Stop VMware ESXi VMs |
+| `stop_compose` | Stop a compose stack. Requires `path` |
+| `sync` | Flush remote filesystems |
 
----
-
-## Pre-shutdown commands
-
-Eneru can run a sequence of commands on remote servers before the final shutdown command.
-
-### Predefined actions
-
-| Action | Description |
-|--------|-------------|
-| `stop_containers` | Stop all Docker/Podman containers |
-| `stop_vms` | Gracefully shutdown libvirt/KVM VMs (then force-destroy remaining) |
-| `stop_proxmox_vms` | Gracefully shutdown Proxmox QEMU VMs, then force-stop remaining (runs via `sudo`) |
-| `stop_proxmox_cts` | Gracefully shutdown Proxmox LXC containers, then force-stop remaining (runs via `sudo`) |
-| `stop_xcpng_vms` | Gracefully shutdown XCP-ng/XenServer VMs (then force-shutdown remaining) |
-| `stop_esxi_vms` | Gracefully shutdown VMware ESXi VMs (then force-off remaining) |
-| `stop_compose` | Stop a compose stack (requires `path` parameter) |
-| `sync` | Sync filesystems before shutdown |
-
-### Example: Proxmox server
+Custom commands are also allowed:
 
 ```yaml
-- name: "Proxmox Host"
-  enabled: true
-  host: "192.168.1.60"
-  user: "root"
-  pre_shutdown_commands:
-    - action: "stop_proxmox_vms"
-      timeout: 180  # Give VMs 3 minutes for graceful shutdown
-    - action: "stop_proxmox_cts"
-      timeout: 60
-    - action: "sync"
-  shutdown_command: "shutdown -h now"
+pre_shutdown_commands:
+  - action: "stop_compose"
+    path: "/opt/app/docker-compose.yml"
+    timeout: 120
+  - command: "systemctl stop my-critical-service"
+    timeout: 30
+  - action: "sync"
 ```
 
-### Example: Docker server with custom commands
+## Ordering
 
-```yaml
-- name: "Docker Server"
-  enabled: true
-  host: "192.168.1.70"
-  user: "root"
-  command_timeout: 30  # Default timeout for commands
-  pre_shutdown_commands:
-    - action: "stop_compose"
-      path: "/opt/myapp/docker-compose.yml"
-      timeout: 120
-    - action: "stop_containers"
-      timeout: 60
-    - command: "systemctl stop my-critical-service"  # Custom command
-      timeout: 30
-    - action: "sync"
-  shutdown_command: "shutdown -h now"
-```
-
-### Error handling
-
-Pre-shutdown commands are **best-effort**:
-
-- Errors are logged but don't prevent the shutdown sequence from continuing
-- Timeouts are logged with a warning, then the next command runs
-- The final shutdown command always runs (unless SSH connection fails entirely)
-
----
-
-## Shutdown ordering
-
-By default, all enabled remote servers shut down concurrently using threads, so one slow or unreachable server does not block others.
-
-### Multi-phase shutdown with `shutdown_order`
-
-Use `shutdown_order` to define phases when servers have dependencies. Servers with the same `shutdown_order` run in parallel; different orders run sequentially (ascending). A server alone in its order effectively runs sequentially.
+Use `shutdown_order` for dependencies. Servers with the same order run in parallel. Lower orders run first.
 
 ```yaml
 remote_servers:
-  # Phase 1: Compute servers shutdown in parallel
   - name: "App Server 1"
     enabled: true
     host: "192.168.1.10"
     user: "root"
     shutdown_order: 1
-    shutdown_command: "shutdown -h now"
 
   - name: "App Server 2"
     enabled: true
     host: "192.168.1.11"
     user: "root"
     shutdown_order: 1
-    shutdown_command: "shutdown -h now"
 
-  # Phase 2: Storage shuts down alone (after compute releases NFS mounts)
   - name: "NAS"
     enabled: true
     host: "192.168.1.50"
     user: "admin"
     shutdown_order: 2
     shutdown_command: "sudo -i synoshutdown -s"
-
-  # Phase 3: Network infrastructure shuts down last
-  - name: "Router"
-    enabled: true
-    host: "192.168.1.254"
-    user: "admin"
-    shutdown_order: 3
-    shutdown_command: "shutdown -h now"
-
-  - name: "Switch"
-    enabled: true
-    host: "192.168.1.253"
-    user: "admin"
-    shutdown_order: 3
-    shutdown_command: "shutdown -h now"
 ```
 
-`shutdown_order` must be a positive integer (>= 1). Gaps are allowed (e.g., 1, 5, 10) — only relative order matters.
+This shuts down both app servers first, then the NAS.
 
-### Legacy `parallel` flag
+### Remote phase timeline
 
-For simple two-group setups, the `parallel` flag still works:
+| Time | Phase | What happens |
+|------|-------|--------------|
+| 0s | Shutdown sequence reaches remote servers | Eneru groups enabled servers by `shutdown_order` |
+| 0s | Phase 1 starts | App Server 1 and App Server 2 run in parallel |
+| During phase 1 | Per-server pre-shutdown | Each server uses its own `pre_shutdown_commands` list, with each command bounded by its configured timeout |
+| During phase 1 | Final shutdown command | Each server runs `shutdown_command`, bounded by `command_timeout` |
+| Phase deadline reached or all threads finish | Join window closes | Eneru moves on when all phase-1 threads finish or the phase deadline expires |
+| Next | Phase 2 starts | NAS runs after clients have released storage |
+| Phase 2 done | Remote phase complete | Shutdown sequence continues to remaining local steps |
 
-```yaml
-remote_servers:
-  - name: "App Server"
-    enabled: true
-    host: "192.168.1.10"
-    user: "root"
-    shutdown_command: "shutdown -h now"
-    # parallel: true is the default
-
-  - name: "NAS"
-    enabled: true
-    host: "192.168.1.50"
-    user: "admin"
-    parallel: false  # Shuts down before the parallel batch
-    shutdown_command: "sudo -i synoshutdown -s"
-```
-
-### Behavior summary
+The legacy `parallel` flag still exists for old configs:
 
 | Config | Behavior |
 |--------|----------|
-| No `shutdown_order`, no `parallel` | Default: runs in the parallel batch |
-| No `shutdown_order`, `parallel: true` | Runs in the parallel batch |
-| No `shutdown_order`, `parallel: false` | Runs sequentially before the parallel batch |
-| `shutdown_order: N` (no `parallel`) | Grouped with other order-N servers, all in parallel |
-| `shutdown_order` + `parallel: true` or `false` | **Hard validation error** — pick one model |
+| No `shutdown_order`, no `parallel` | Default parallel batch |
+| `parallel: true` | Default parallel batch |
+| `parallel: false` | Sequential phase before the default parallel batch |
+| `shutdown_order: N` | Explicit phase. Same N runs in parallel |
+| Both `shutdown_order` and `parallel` | Validation error |
 
-!!! warning "shutdown_order and parallel are mutually exclusive"
-    Setting both `shutdown_order` and `parallel` on the same server is rejected at config load time. Use `shutdown_order` for multi-phase ordering, or `parallel` for the legacy two-group behavior — never both.
+Do not use `parallel: false` to make a NAS run last. Use `shutdown_order` for that.
 
-!!! tip "Use `eneru validate` to preview"
-    Run `eneru validate --config your-config.yaml` to see the shutdown sequence tree, including remote server phases.
+## Safety margin
 
-### Tuning `shutdown_safety_margin`
+```yaml
+remote_servers:
+  - name: "Storage"
+    shutdown_safety_margin: 120
+```
 
-Each remote server has a `shutdown_safety_margin` (seconds, default `60`) added on top of `pre_shutdown_commands + command_timeout + connect_timeout` when waiting for its parallel-shutdown thread to finish. The margin covers SSH session setup, OS scheduling jitter, and the brief window between the remote shutdown command starting and SSH closing the channel.
+Eneru waits for remote shutdown threads using the command timeouts plus `shutdown_safety_margin`. The default is 60 seconds. Raise it for slow storage servers or battery-backed RAID. Lower it for fast, stateless VMs. Set `0` to use only explicit command timeouts.
 
-| When to tune | Suggested value |
-|--------------|-----------------|
-| Servers with battery-backed RAID, large write-back caches, or known slow shutdown paths | Raise (e.g. `120`–`300`) |
-| Fast VMs or stateless containers where shutdown completes immediately | Lower (e.g. `10`–`30`) |
-| Opt out of the buffer entirely (use only the explicit timeouts) | `0` |
+### Safety-margin timeline
 
-The phase-wide join window uses the **maximum** `shutdown_safety_margin` across the servers in that phase, so tuning one slow server up does not penalise the others' actual execution time — it only extends the worst-case wait before Eneru moves to the next phase.
+| Step | Timeout contribution |
+|------|----------------------|
+| SSH connection budget in phase calculation | `connect_timeout` is added once per server budget |
+| Each pre-shutdown command | Command-specific `timeout`, or `command_timeout` when no per-command timeout is set |
+| Final shutdown command | `command_timeout` |
+| OS and SSH close delay | `shutdown_safety_margin` |
+| Phase deadline | Worst-case server budget in that phase |
 
----
+One slow server can extend the phase deadline, but it does not make other servers run sequentially. Servers in the same phase still start together. Individual SSH command execution also gets a 30-second subprocess buffer in `_run_remote_command`; the phase deadline calculation uses the configured command timeouts plus `connect_timeout` and `shutdown_safety_margin`.
 
 ## SSH key setup
 
-Passwordless SSH keys are required for unattended operation.
-
-### 1. Generate SSH key
-
-As root on the Eneru server (since Eneru runs as root):
+Eneru normally runs as root, so create and test the key as root on the Eneru host.
 
 ```bash
-sudo su
-ssh-keygen -t ed25519 -f ~/.ssh/id_ups_shutdown -C "ups-monitor@$(hostname)"
+sudo install -d -m 700 /root/.ssh
+sudo ssh-keygen -t ed25519 -f /root/.ssh/id_ups_shutdown -C "ups-monitor@$(hostname)"
+sudo ssh-copy-id -i /root/.ssh/id_ups_shutdown.pub user@remote-server
+sudo ssh -i /root/.ssh/id_ups_shutdown user@remote-server "echo OK"
 ```
 
-Press Enter for no passphrase (required for unattended operation).
+Leave the key without a passphrase. A passphrase-protected key cannot be used unattended during a power event.
 
-### 2. Copy key to remote server
+If you use a non-default key, add SSH options:
+
+```yaml
+ssh_options:
+  - "-i"
+  - "/root/.ssh/id_ups_shutdown"
+```
+
+## Host-key verification
+
+Accept host keys deliberately before relying on shutdown:
 
 ```bash
-ssh-copy-id -i ~/.ssh/id_ups_shutdown.pub user@remote-server
+sudo ssh user@remote-server "echo OK"
 ```
 
-### 3. Test connection
-
-```bash
-# Should connect without password prompt
-sudo ssh -i ~/.ssh/id_ups_shutdown user@remote-server "echo OK"
-```
-
----
+Do not leave `StrictHostKeyChecking=no` in production. If a host key changes unexpectedly, SSH should fail closed instead of sending shutdown commands to an untrusted host.
 
 ## Passwordless sudo
 
-The shutdown command requires root privileges. Configure passwordless sudo for the specific command:
+The SSH user needs passwordless access to the exact commands Eneru runs.
 
-### Standard linux
-
-On the remote server:
+### Standard Linux
 
 ```bash
-echo "username ALL=(ALL) NOPASSWD: /sbin/shutdown" | sudo tee /etc/sudoers.d/ups_shutdown
+echo "username ALL=(ALL) NOPASSWD: /sbin/shutdown, /usr/bin/systemctl, /bin/sync" \
+  | sudo tee /etc/sudoers.d/ups_shutdown
 sudo chmod 0440 /etc/sudoers.d/ups_shutdown
+sudo visudo -c
 ```
 
 ### Synology DSM
 
 ```bash
-echo "username ALL=(ALL) NOPASSWD: /usr/syno/sbin/synoshutdown -s" | sudo tee /etc/sudoers.d/ups_shutdown
+echo "username ALL=(ALL) NOPASSWD: /usr/syno/sbin/synoshutdown -s" \
+  | sudo tee /etc/sudoers.d/ups_shutdown
 sudo chmod 0440 /etc/sudoers.d/ups_shutdown
 ```
 
-!!! warning "Synology note"
-    Synology DSM resets `/etc/sudoers.d/` on updates. You may need to re-apply this after DSM updates, or use a scheduled task to maintain it.
-
-### QNAP QTS
-
-```bash
-echo "username ALL=(ALL) NOPASSWD: /sbin/poweroff" | sudo tee /etc/sudoers.d/ups_shutdown
-sudo chmod 0440 /etc/sudoers.d/ups_shutdown
-```
+DSM updates can reset sudoers changes. Re-check after DSM upgrades.
 
 ### Proxmox VE
 
-`stop_proxmox_vms` and `stop_proxmox_cts` invoke `qm` and `pct`, which require root regardless of PVE-level ACLs (`vm.audit` + `vm.powermgmt` are not sufficient). Required only if the SSH user is non-root — root logins work unchanged.
+`qm` and `pct` need root. If the SSH user is not root:
 
 ```bash
-echo "username ALL=(ALL) NOPASSWD: /usr/sbin/qm, /usr/sbin/pct" | sudo tee /etc/sudoers.d/ups_proxmox
+echo "username ALL=(ALL) NOPASSWD: /usr/sbin/qm, /usr/sbin/pct, /sbin/shutdown" \
+  | sudo tee /etc/sudoers.d/ups_proxmox
 sudo chmod 0440 /etc/sudoers.d/ups_proxmox
+sudo visudo -c
 ```
-
-If you also want the same user to run the final `shutdown -h now`, add `/sbin/shutdown` to the same NOPASSWD line.
 
 ### TrueNAS SCALE
 
-TrueNAS rebuilds `/etc/sudoers` from the middleware database on boot, so do not edit `/etc/sudoers.d/` by hand. Instead:
+Use the Web UI. Go to Credentials, Local Users, edit the SSH user, and allow the exact sudo command you plan to run. For current SCALE releases, use:
 
-1. Go to **Credentials → Local Users**, edit the SSH user
-2. In **Allowed sudo commands**, add the full path: `/usr/bin/midclt`
-3. Tick **Allow all sudo commands with no password** *or* leave it unchecked and the user will use the explicit allowed-commands list above
-4. Use the SCALE shutdown form from the table below (`sudo /usr/bin/midclt call system.shutdown "ups_event"` for 25.04+)
+```text
+/usr/bin/midclt call system.shutdown "ups_event"
+```
 
-### TrueNAS CORE
+### TrueNAS CORE and FreeBSD appliances
 
-CORE is FreeBSD; the orchestrated `shutdown -p now` runs the rc.d teardown sequence cleanly. Configure sudo via **Accounts → Users → Edit → Permit Sudo** in the WebUI; do not hand-edit sudoers.
+Use the platform's user or sudo configuration UI where available. The shutdown command is usually:
 
----
+```text
+sudo shutdown -p now
+```
 
 ## Common shutdown commands
+
+These commands match the previously documented, validated shutdown forms. Keep platform-specific forms unless you have tested an alternative on that device.
 
 | System | Command | Notes |
 |--------|---------|-------|
@@ -312,101 +228,34 @@ CORE is FreeBSD; the orchestrated `shutdown -p now` runs the rc.d teardown seque
 | TrueNAS CORE | `sudo shutdown -p now` | `-p` cuts power on FreeBSD; `-h` only halts |
 | TrueNAS SCALE (>= 25.04) | `sudo /usr/bin/midclt call system.shutdown "ups_event"` | Vendor-recommended; orchestrates app/VM teardown. `reason` arg required since Fangtooth |
 | TrueNAS SCALE (< 25.04) | `sudo /usr/bin/midclt call system.shutdown` | Same as above without the mandatory reason arg |
-| VMware ESXi 7.x/8.x | `esxcli system shutdown poweroff --reason="UPS power event"` | No `sudo` on ESXi (SSH login is root). Reason logged to vmkernel.log |
-| Proxmox VE | `sudo shutdown -h now` | Stop guests first via `stop_proxmox_vms` / `stop_proxmox_cts` pre-shutdown actions |
+| VMware ESXi 7.x/8.x | `esxcli system shutdown poweroff --reason="UPS power event"` | No `sudo` on ESXi when SSH login is root. Reason is logged to vmkernel.log |
+| Proxmox VE | `sudo shutdown -h now` | Stop guests first with `stop_proxmox_vms` and `stop_proxmox_cts` pre-shutdown actions |
 | pfSense / OPNsense | `sudo /sbin/shutdown -p now` | FreeBSD `-p` for ACPI power-off |
 
----
+## Safe test checklist
 
-## Testing remote shutdown
-
-!!! danger "This will actually shut down the server!"
-    Only run this when you're prepared for the server to go offline.
+Run these before relying on remote shutdown:
 
 ```bash
-# Test the full command as root
+sudo ssh user@remote-server "echo OK"
+sudo ssh user@remote-server "sudo -n true && echo sudo OK"
+sudo eneru validate --config /etc/ups-monitor/config.yaml
+sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
+```
+
+Only test the final shutdown command when you are prepared for the remote server to power off:
+
+```bash
 sudo ssh user@remote-server "sudo shutdown -h now"
 ```
 
-For a safer test, use a command that doesn't shut down:
-
-```bash
-# Verify SSH and sudo work
-sudo ssh user@remote-server "sudo whoami"
-# Should output: root
-```
-
----
-
-## Security considerations
-
-### Host key verification
-
-The example config includes `-o StrictHostKeyChecking=no` for initial setup. For production:
-
-1. **Manually accept host keys once:**
-   ```bash
-   sudo ssh user@remote-server
-   # Type 'yes' when prompted for host key
-   ```
-
-2. **Remove StrictHostKeyChecking from config:**
-   ```yaml
-   ssh_options: []  # or remove the line entirely
-   ```
-
-If a server's host key changes unexpectedly (potential MITM attack), the connection will fail rather than proceeding silently.
-
-### Limiting sudo access
-
-The sudoers rules above grant access only to the specific shutdown command.
-
-### SSH key security
-
-- Store keys in `/root/.ssh/` with permissions `600`
-- Use a dedicated key (`id_ups_shutdown`) rather than the default key
-- The key has no passphrase (required for unattended operation), so protect access to the Eneru server
-
----
-
 ## Troubleshooting
 
-### Connection timeout
-
-```
-ERROR: SSH connection to 192.168.178.229 timed out
-```
-
-- Verify network connectivity: `ping 192.168.178.229`
-- Check SSH service is running on remote server
-- Verify firewall allows SSH (port 22)
-- Increase `connect_timeout` if network is slow
-
-### Permission denied
-
-```
-ERROR: Permission denied (publickey,password)
-```
-
-- Verify SSH key is copied: `ssh-copy-id -i ~/.ssh/id_ups_shutdown.pub user@host`
-- Check key permissions: `ls -la ~/.ssh/id_ups_shutdown` (should be 600)
-- Ensure you're running as root: `sudo ssh ...`
-
-### Sudo password required
-
-```
-sudo: a password is required
-```
-
-- Verify sudoers rule is in place on remote server
-- Check rule syntax: `sudo visudo -c`
-- Ensure the command in sudoers matches exactly what Eneru runs
-
-### Command not found
-
-```
-synoshutdown: command not found
-```
-
-- Use full path in shutdown command: `/usr/syno/sbin/synoshutdown`
-- Or use `sudo -i` to get a login shell with full PATH
+| Symptom | Check |
+|---------|-------|
+| `Permission denied (publickey,password)` | Copy the key for the same user Eneru uses, and test as root from the Eneru host |
+| SSH timeout | Network path, firewall, SSH service, `connect_timeout` |
+| `sudo: a password is required` | Add or fix the sudoers rule. Use `sudo -n` in tests |
+| `command not found` | Use full command paths or a login shell where the platform requires one |
+| NAS shuts down too early | Use `shutdown_order` instead of legacy `parallel: false` |
+| Host key verification fails | Re-check the host identity before accepting the new key |

--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -1,249 +1,187 @@
 # Statistics
 
-Eneru records every UPS poll into a per-UPS SQLite database. The TUI
-graph view reads from it and you can run `sqlite3` (or DataGrip /
-Grafana / a script) for offline analysis. The store is on by default
-with no opt-in flag. The hot path is in-memory only; a background
-thread does the disk writes.
+Eneru writes UPS history to SQLite. The TUI graphs, event panel, notification retry queue, and offline troubleshooting all use the same per-UPS database files.
 
-## Architecture
+Statistics are always enabled. If the database cannot be opened or written, Eneru logs the problem and keeps monitoring.
 
-```
-poll cycle (1 Hz)        StatsWriter thread (~10 s)        SQLite store
-─────────────────        ────────────────────────         ──────────────
-buffer_sample()  ─────►  flush() executemany()  ────►    samples table
-                         aggregate() every 5 min ───►    agg_5min table
-                         purge() every 5 min     ───►    agg_hourly table
-log_event()      ──────────────── direct INSERT ───►    events table
-```
-
-- The poll cycle calls `buffer_sample()`, a constant-time append to an
-  in-memory deque. No I/O on the hot path.
-- A background `StatsWriter` thread drains the deque to SQLite every
-  10s with a single `executemany` transaction.
-- Every 5 min the writer rolls samples into 5-minute buckets, then
-  5-minute buckets into hourly buckets, and applies retention.
-- SQLite errors are caught, logged once with rate-limit, and swallowed.
-  Stats can never crash the monitor.
-
-## Schema
-
-The `samples` table carries 13 metrics per row: 10 raw NUT vars (per
-spec 2.12) plus 3 Eneru-derived state fields. The 4 columns flagged
-"v2" were added in v5.1.0-rc6 and arrive automatically on existing
-databases via additive `ALTER TABLE` migration -- see
-[Schema versioning](#schema-versioning) below.
-
-```sql
-samples (
-    ts INTEGER NOT NULL,             -- epoch seconds
-    status TEXT,                     -- e.g. "OL CHRG", "OB DISCHRG"
-    battery_charge REAL,             -- %
-    battery_runtime REAL,            -- seconds
-    ups_load REAL,                   -- %
-    input_voltage REAL,              -- V
-    output_voltage REAL,             -- V
-    depletion_rate REAL,             -- %/min       (Eneru-derived)
-    time_on_battery INTEGER,         -- seconds since OB start (Eneru-derived)
-    connection_state TEXT,           -- OK / GRACE_PERIOD / FAILED  (Eneru-derived)
-    battery_voltage REAL,            -- V           (v2)
-    ups_temperature REAL,            -- °C          (v2)
-    input_frequency REAL,            -- Hz          (v2)
-    output_frequency REAL            -- Hz          (v2)
-)
-
-agg_5min, agg_hourly (
-    ts INTEGER PRIMARY KEY,          -- bucket start, epoch seconds
-    battery_charge_avg REAL,
-    battery_charge_min REAL,
-    battery_charge_max REAL,
-    battery_runtime_avg REAL,
-    ups_load_avg REAL,
-    ups_load_max REAL,
-    input_voltage_avg REAL,
-    input_voltage_min REAL,
-    input_voltage_max REAL,
-    samples_count INTEGER,
-    output_voltage_avg REAL,         -- (v2 -- closes the long-standing gap)
-    battery_voltage_avg REAL,        -- (v2)
-    ups_temperature_avg REAL,        -- (v2)
-    ups_temperature_min REAL,        -- (v2)
-    ups_temperature_max REAL,        -- (v2)
-    input_frequency_avg REAL,        -- (v2)
-    output_frequency_avg REAL        -- (v2)
-)
-
-events (
-    ts INTEGER NOT NULL,             -- epoch seconds
-    event_type TEXT NOT NULL,        -- ON_BATTERY, POWER_RESTORED, ...
-    detail TEXT,
-    notification_sent INTEGER DEFAULT 1   -- (v3) 1=delivered, 0=muted
-)
-
-meta (
-    key TEXT PRIMARY KEY,
-    value TEXT                       -- e.g. schema_version=3
-)
-```
-
-### `events.notification_sent` (v3)
-
-Added in v5.1.0-rc7 alongside the [issue #27](https://github.com/m4r1k/Eneru/issues/27)
-notification suppression work. Records whether the daemon dispatched
-a notification for an event:
-
-- `1` (default for backfilled rows from v2 DBs) — event was logged
-  AND a notification was dispatched.
-- `0` — event was logged but the notification was muted, either
-  because it was in `notifications.suppress`, the voltage
-  hysteresis dwell hadn't elapsed, or the event is in the always-
-  silent set (`VOLTAGE_NORMALIZED`, `AVR_INACTIVE`,
-  `VOLTAGE_FLAP_SUPPRESSED`, `VOLTAGE_AUTODETECT_MISMATCH`).
-
-Audit query:
-
-```bash
-sqlite3 /var/lib/eneru/<UPS>.db \
-  "SELECT event_type, COUNT(*) FROM events
-   WHERE notification_sent = 0
-   GROUP BY event_type
-   ORDER BY 2 DESC;"
-```
-
-### New event types in v3
-
-| Event | When |
-|-------|------|
-| `VOLTAGE_AUTODETECT_MISMATCH` | NUT's `input.voltage.nominal` disagreed with the observed `input.voltage` median by > 25V at startup. The `detail` carries `nut={N}V, observed median={M}V, re-snapped to {S}V`. |
-| `VOLTAGE_FLAP_SUPPRESSED` | A voltage state transition (NORMAL→HIGH/LOW) reverted within `notifications.voltage_hysteresis_seconds`. The `detail` carries `state={LOW|HIGH} duration=Ns peak={V}V`. |
-
-The 3 Eneru-derived columns (`depletion_rate`, `time_on_battery`,
-`connection_state`) intentionally have no `*_avg` companion in the agg
-tables: they're state-shaped, not signal-shaped, so an average over a
-5-minute bucket is meaningless. The TUI graph panel only offers the 9
-signal-shaped metrics in its `<G>` cycle.
-
-## Schema versioning
-
-`meta.schema_version` records the schema generation. New deployments
-land at the current version (currently `2`). Daemons upgraded from an
-older version run idempotent `ALTER TABLE ADD COLUMN` migrations on
-first start; existing rows are preserved with `NULL` for the new
-columns until the next sample. The migration is wrapped in try/except
-so a duplicate-column error is benign and `meta.schema_version` is
-bumped *after* the migrations succeed -- a crash mid-migration is
-replayed safely on next start.
-
-When a future feature adds new columns or tables, follow the pattern
-documented in `src/eneru/CLAUDE.md` ("Stats schema evolution"):
-
-```bash
-sqlite3 /var/lib/eneru/UPS-host-3493.db \
-  "SELECT key, value FROM meta WHERE key='schema_version';"
-```
-
-## Configuration
+## Storage path
 
 ```yaml
 statistics:
-  # Directory holding one .db per UPS, named after the sanitized UPS name.
   db_directory: "/var/lib/eneru"
   retention:
-    raw_hours: 24                    # raw samples retained 1 day
-    agg_5min_days: 30                # 5-min aggregations retained 30 days
-    agg_hourly_days: 1825            # hourly aggregations retained 5 years
+    raw_hours: 24
+    agg_5min_days: 30
+    agg_hourly_days: 1825
 ```
 
-Retention windows are independent per tier. Samples older than
-`raw_hours` are deleted from `samples`; their aggregations live on in
-`agg_5min` / `agg_hourly` until those tiers' own windows expire.
+The package creates `/var/lib/eneru`. PyPI installs create it on first daemon start if permissions allow.
 
-The deb / rpm package creates `/var/lib/eneru` on install (mode 0755,
-owner root). Pip installs create the directory on first start.
+Each UPS gets its own `.db` file named from the sanitized UPS label.
 
-## Storage on small devices (Raspberry Pi / SD card)
+## Write path
 
-Per-UPS database, steady state at 1 Hz polling (v2 schema, 13 metrics):
+```text
+UPS poll loop
+    |
+    v
+append sample to in-memory buffer
+    |
+    v
+StatsWriter flushes every ~10 seconds
+    |
+    v
+SQLite samples table
+    |
+    v
+5-minute and hourly aggregates
+```
 
-- Raw samples: ~135 bytes × 86,400 polls/day ≈ 11.7 MB/day. Older
-  samples are aggregated and deleted after 24 h.
-- 5-min aggregations: ~135 bytes × 288 buckets/day × 30 days ≈ 1.1 MB.
-- Hourly aggregations: ~135 bytes × 24 buckets/day × 5 years ≈ 5.5 MB.
-- Events table: a few hundred bytes per power event, normally negligible.
+Polls do not wait on SQLite writes. The writer batches rows in the background. Event rows are inserted directly, but failures are isolated from the safety-critical monitor path.
 
-Steady-state footprint per UPS ≈ 17 MB (24 h raw + 30 d 5-min + 5 y
-hourly). For a 4-UPS site that's ~70 MB. Still trivial on the
-smallest SD cards.
+### Stats write timeline
 
-Disk I/O profile per UPS: one `executemany` transaction every 10s,
-batching 10 inserts. That is roughly equivalent to a busy systemd
-journald write. Meaningful on an SD card, but not enough to wear it
-out faster than journald already does.
+These intervals come from `StatsWriter` defaults in `src/eneru/stats.py`: `flush_interval=10.0` and `maintenance_interval=300.0`.
 
-If your device has slow or wear-sensitive storage, relocate the
-databases to an attached SSD or USB stick:
+| Time | Action | Result |
+|------|--------|--------|
+| Every poll | Monitor appends sample to memory | No SQLite work runs on the hot path |
+| About every 10s | Writer flushes buffered samples | One batched SQLite transaction persists recent samples |
+| Every 300s | Writer aggregates raw rows | `agg_5min` receives new buckets |
+| Every 300s | Writer rolls 5-minute buckets | `agg_hourly` receives hourly buckets |
+| Every 300s | Retention runs | Old raw and aggregate rows are purged by tier |
+| Any SQLite failure | Error is logged and rate-limited | Monitoring continues without stats persistence |
+
+## Tables
+
+| Table | Purpose |
+|-------|---------|
+| `samples` | Raw poll samples, typically 1 Hz |
+| `agg_5min` | Five-minute aggregate buckets |
+| `agg_hourly` | Hourly aggregate buckets |
+| `events` | Power, health, lifecycle, and shutdown events |
+| `notifications` | Persistent notification queue and delivery history |
+| `meta` | Schema version and lifecycle metadata |
+
+The main sample metrics include status, battery charge, runtime, load, input/output voltage, battery voltage, temperature, frequency, depletion rate, time on battery, and connection state.
+
+## Retention
+
+| Tier | Default retention | Use |
+|------|-------------------|-----|
+| Raw samples | 24 hours | Detailed incident review |
+| Five-minute aggregates | 30 days | Recent trends |
+| Hourly aggregates | 5 years | Long-term battery and load history |
+
+Raw rows are deleted after they have been aggregated. Aggregates have their own retention windows.
+
+## Disk usage
+
+At a 1-second poll interval, expect roughly 15 to 20 MB per UPS at the default retention settings, plus small growth from events and notification rows.
+
+For SD-card systems, the write pattern is a small transaction about every 10 seconds per UPS. That is usually less write pressure than normal system logging, but you can move the database to better storage:
 
 ```yaml
 statistics:
   db_directory: "/mnt/ssd/eneru-stats"
 ```
 
-The directory must be writable by the user the daemon runs as (root
-for deb/rpm installs).
+Make sure the daemon user can write there.
 
-## Inspecting a database
+## Inspect data
+
+List databases:
 
 ```bash
-# Schema + table sizes
-sqlite3 /var/lib/eneru/UPS-host-3493.db ".schema"
-sqlite3 /var/lib/eneru/UPS-host-3493.db ".tables"
-sqlite3 /var/lib/eneru/UPS-host-3493.db "SELECT COUNT(*) FROM samples"
-
-# Last-hour battery charge trend
-sqlite3 /var/lib/eneru/UPS-host-3493.db <<'SQL'
-.mode column
-.headers on
-SELECT datetime(ts, 'unixepoch') AS time, battery_charge, ups_load, status
-FROM samples
-WHERE ts > strftime('%s', 'now', '-1 hour')
-ORDER BY ts ASC;
-SQL
-
-# Recent power events
-sqlite3 /var/lib/eneru/UPS-host-3493.db \
-    "SELECT datetime(ts, 'unixepoch'), event_type, detail FROM events ORDER BY ts DESC LIMIT 20"
+sudo ls -lh /var/lib/eneru/
 ```
+
+Show tables:
+
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db ".tables"
+```
+
+Recent samples:
+
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db <<'SQL'
+.headers on
+.mode column
+SELECT datetime(ts, 'unixepoch') AS time,
+       status,
+       battery_charge,
+       battery_runtime,
+       ups_load,
+       input_voltage
+FROM samples
+ORDER BY ts DESC
+LIMIT 20;
+SQL
+```
+
+Recent events:
+
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT datetime(ts, 'unixepoch'), event_type, detail FROM events ORDER BY ts DESC LIMIT 20;"
+```
+
+Muted events:
+
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT event_type, COUNT(*) FROM events WHERE notification_sent = 0 GROUP BY event_type;"
+```
+
+Pending notifications:
+
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT id, attempts, next_attempt_at, title FROM notifications WHERE status='pending';"
+```
+
+## TUI graphs
+
+`eneru monitor` reads the stats database read-only. Graphs select the smallest table that covers the requested time range:
+
+| Window | Table | Resolution |
+|--------|-------|------------|
+| Up to 24 hours | `samples` | Per poll |
+| Up to 30 days | `agg_5min` | Five-minute buckets |
+| More than 30 days | `agg_hourly` | Hourly buckets |
+
+See [Monitor and graphs](tui-graphs.md) for TUI usage.
 
 ## Backup
 
-Each `.db` is a self-contained SQLite file. Use `.backup` for an
-online hot backup that does not block the writer:
+SQLite supports online backup without stopping Eneru:
 
 ```bash
-sqlite3 /var/lib/eneru/UPS-host-3493.db ".backup '/srv/backups/UPS-host-3493.db'"
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  ".backup '/srv/backups/UPS-192-168-1-100.db'"
 ```
 
-## Failure isolation
+## Schema migrations
 
-If `/var/lib/eneru` becomes read-only, runs out of space, or the
-SQLite file gets corrupted, the daemon logs one warning and keeps
-polling without stats persistence. You will see lines like:
+Eneru stores the schema version in `meta.schema_version`. New releases migrate existing databases with additive `ALTER TABLE` statements and preserve old rows.
 
+Check the version:
+
+```bash
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT key, value FROM meta WHERE key='schema_version';"
 ```
-⚠️ WARNING: stats store open failed at /var/lib/eneru/UPS-host.db: ...
-```
 
-or
+Migrations are designed to be replay-safe. If a daemon crashes mid-migration, the next start retries before bumping the schema version.
 
-```
+## Failure behavior
+
+Stats failures do not stop monitoring or shutdown. You may see logs like:
+
+```text
+stats store open failed at /var/lib/eneru/UPS.db: ...
 stats: flush failed: disk I/O error
 ```
 
-Restart the daemon after fixing the underlying storage problem. The
-daemon will reopen the database (or create a fresh one) and continue.
-
-## See also
-
-- [Configuration reference](configuration.md). Full `statistics:` field
-  reference.
-- [Troubleshooting](troubleshooting.md). Disk-related failure modes.
+Fix the storage problem, then restart Eneru so it can reopen the database.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -153,7 +153,7 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 36 numb
 | 36 | UPS Multi | Multi-UPS coordinator applies the same single-restart-notification contract across per-UPS stores |
 | E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |
 
-This coverage gives confidence that code quality is not only measured by isolated Python assertions. Each commit that enters the protected workflow must also prove that Eneru can talk to real NUT sockets, run against Dockerized SSH targets, write and query SQLite, render monitor output, validate production-shaped configs, and execute shutdown orchestration without depending on local developer state.
+Every commit on the protected workflow has to prove the daemon works against real services, not just isolated Python assertions: real NUT sockets, Dockerized SSH targets, a live SQLite database, rendered TUI output, validated production-shaped configs, and a full shutdown orchestration run. None of it depends on local developer state.
 
 ## Run E2E locally
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,12 +1,8 @@
 # Testing
 
-Every commit runs unit tests, integration tests across 9 Linux distributions, end-to-end tests with real NUT/SSH/Docker services, and configuration validation.
+Eneru uses unit tests, package-install tests, and end-to-end tests with real NUT, SSH, and Docker services. The goal is to catch both Python logic bugs and packaging/runtime failures.
 
----
-
-## Testing strategy
-
-```
+```text
                           ▲
                          ╱ ╲
                         ╱   ╲
@@ -19,11 +15,11 @@ Every commit runs unit tests, integration tests across 9 Linux distributions, en
                  ╱─────────────────╲
                 ╱    Integration    ╲
                ╱Package & Pip Install╲
-              ╱    7 Linux Distros    ╲
+              ╱  on key Linux Distros ╲
              ╱─────────────────────────╲
             ╱         Unit Tests        ╲
-           ╱   pytest + Coverage (410)   ╲
-          ╱      7 Python Versions        ╲
+           ╱       pytest + Coverage     ╲
+          ╱        3.9 -> 3.15 Python     ╲
          ╱─────────────────────────────────╲
         ╱          Static Analysis          ╲
        ╱   Syntax Check + Config Validation  ╲
@@ -33,339 +29,176 @@ Every commit runs unit tests, integration tests across 9 Linux distributions, en
    ╱─────────────────────────────────────────────╲
 ```
 
-| Layer | Frequency | What It Tests |
-|-------|-----------|---------------|
-| **AI-Assisted Dev** | Continuous | Code review, implementation guidance |
-| **Static Analysis** | Every commit | Python syntax, config validation |
-| **Unit Tests** | Every commit | Logic, state machine, edge cases (813 tests) |
-| **Integration** | Every commit | Package install on 7 Linux distros |
-| **E2E Tests** | Every commit | Full workflow with real NUT, SSH, Docker |
-| **Real UPS** | Pre-release | Actual hardware, power events |
+The pyramid is intentionally bottom-heavy. Most behavior is covered by fast pytest tests. E2E tests are fewer, but they exercise the real service boundaries where packaging, NUT, SSH, Docker, filesystem, and CLI assumptions meet.
 
----
+## CI layout
 
-## Automated testing
+| Workflow | File | What it checks |
+|----------|------|----------------|
+| Validate | `.github/workflows/validate.yml` | Unit tests, coverage, example config validation |
+| Integration | `.github/workflows/integration.yml` | Wheel install, `.deb`, `.rpm`, and package layout |
+| E2E Tests | `.github/workflows/e2e.yml` | Real NUT/SSH/Docker behavior across grouped scenarios |
+| Release | `.github/workflows/release.yml` | Release package build |
+| PyPI | `.github/workflows/pypi.yml` | PyPI publish from release tags |
 
-All automated tests run via GitHub Actions on every commit and pull request.
+The protected `main` branch requires the validate matrix and five E2E matrix jobs.
 
-### Validate workflow
+## Local test environment
 
-The **Validate** workflow runs on every push and pull request to `main`:
-
-| Check | Description |
-|-------|-------------|
-| **Python Syntax** | Verifies the code compiles correctly |
-| **Unit Tests** | Runs the full pytest test suite with coverage |
-| **Configuration Validation** | Validates the default and example configs |
-
-**Python versions tested:** 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.15-dev
-
-### Integration workflow
-
-The **Integration** workflow tests package installation on real distributions:
-
-#### Package installation testing
-
-Tests `.deb` and `.rpm` package installation:
-
-| Distribution | Version | Package |
-|--------------|---------|---------|
-| Debian | 11 (Bullseye) | .deb |
-| Debian | 12 (Bookworm) | .deb |
-| Debian | 13 (Trixie) | .deb |
-| Ubuntu | 22.04 (Jammy) | .deb |
-| Ubuntu | 24.04 (Noble) | .deb |
-| Ubuntu | 26.04 (Resolute) | .deb |
-| RHEL | 8 (Ootpa) | .rpm |
-| RHEL | 9 (Plow) | .rpm |
-| RHEL | 10 (Coughlan) | .rpm |
-
-Each test:
-
-1. Installs the package using the native package manager
-2. Verifies files are installed in the correct locations
-3. Runs `--version` to confirm the script executes
-4. Validates the default and example configurations
-
-!!! note "Debian 11 and PyYAML"
-    Debian 11 ships PyYAML 5.3.1, which is below the `>=5.4.1` requirement in `pyproject.toml`. The `.deb` package does not enforce a PyYAML version, and Eneru only uses `yaml.safe_load()` which is identical across both versions, so CI passes. However, all real-world testing and production deployments have used PyYAML 5.4.1 or newer. If you run into YAML parsing issues on Debian 11, upgrade PyYAML first: `pip install --upgrade PyYAML`.
-
-#### Pip installation testing
-
-Tests `pip install .` to ensure `pyproject.toml` is valid:
-
-| Environment | Python Versions |
-|-------------|-----------------|
-| Ubuntu runner | 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.15-dev |
-| Debian 11 container | System Python (3.9) |
-| Debian 13 container | System Python |
-| Ubuntu 26.04 container | System Python |
-| RHEL 10 container | System Python |
-
-!!! note "Ubuntu 22.04 not tested with pip"
-    Ubuntu 22.04 ships pip 22.0.2, which has a known regression with `pyproject.toml` dynamic version metadata. `pip install eneru` produces an `UNKNOWN-0.0.0` package and no `eneru` entry point. Upgrading pip fixes it, but that no longer tests the real system environment, so Ubuntu 22.04 is excluded from pip-in-container tests. It is still tested with `.deb` package installation. If you need pip install on Ubuntu 22.04, upgrade pip first (`pip install --upgrade pip`) or use a virtualenv.
-
----
-
-## Test coverage
-
-813 tests across 28 files:
-
-- Configuration parsing (142 tests across 6 files): YAML options, defaults, multi-UPS detection, trigger inheritance, ownership validation, `trigger_on` enum validation, `shutdown_order` parsing and validation (YAML type coercion edge cases, mutual-exclusion error with `parallel`), `shutdown_safety_margin` parsing and validation, `voltage_sensitivity` strict-enum + per-UPS-group + explicit-flag round-trip + redundancy-group symmetry. Adds the redundancy-group dataclass (parsing, defaults, inheritance, multi-group, malformed-entry handling) and 24 validation rules (`min_healthy` bounds, unknown UPS references, duplicate sources, missing names, duplicate names, enum checks, local-resource ownership, cross-tier server conflicts, `is_local` uniqueness). Files: `test_config_loading.py` (20), `test_config_notifications.py` (9), `test_config_filesystems.py` (3), `test_config_vm_containers.py` (7), `test_config_remote.py` (29), `test_config_validation.py` (74).
-- Multi-UPS coordination (65 tests): coordinator routing, `is_local` / drain / `trigger_on`, defense-in-depth lock, battery anomaly with jitter filtering, notification prefixing, runtime `is_local` enforcement, `exit_after_shutdown` in coordinator, ownership rejection (VMs / containers / filesystems), and the full `MultiUPSCoordinator` lifecycle (`initialize`, `start_monitors`, `run_monitor` crash path, `handle_signal`, `wait_for_completion`, real local-shutdown command path, drain edge cases, log fallback). 6 new tests cover redundancy-group wiring inside the coordinator: `in_redundancy` set computation, `in_redundancy_group` flag passed to monitors, evaluator + executor instantiation, signal-handler join of evaluator threads.
-- Core monitor logic (57 tests): OL / OB / FSD state machine, all four shutdown triggers, failsafe, shutdown sequence ordering, multi-phase shutdown (`compute_effective_order`, phased execution, thread verification, backward compat, deadline-based join, per-server safety margin). 12 new tests cover the advisory-mode branches at the three trigger sites (T1-T4, FSD, FAILSAFE) under `in_redundancy_group=True`, plus regression tests that verify the legacy single-UPS and independent-group paths stay byte-identical.
-- Health model (32 tests): pure-function classification of `HealthSnapshot` into `HEALTHY` / `DEGRADED` / `CRITICAL` / `UNKNOWN` with the documented priority (FAILED beats `trigger_active` beats FSD beats OB), `5 * check_interval` staleness rule, parametrised `ups.status` and `connection_state` table.
-- Redundancy runtime (28 tests): evaluator counting and policy translation for `degraded_counts_as` / `unknown_counts_as`, executor synthetic Config wiring, flag-file namespace and sanitisation, dry-run cleanup, idempotency (in-process and against a pre-existing flag), local-resource gating on `is_local`, log-prefix and `@`-escape behaviour, evaluator thread lifecycle and exception swallowing, cross-group cascade regression.
-- Shutdown phase mixins (46 tests across 3 files): per-mixin coverage. `test_shutdown_vms.py` (7) covers libvirt graceful shutdown, force-destroy on timeout, dry-run, missing virsh, no running VMs. `test_shutdown_containers.py` (26) covers runtime detection (docker / podman / auto), compose subcommand availability, compose-stack shutdown with per-file timeouts, container shutdown (dry-run and real-stop paths), `ps` failure handling. `test_shutdown_filesystems.py` (13) covers sync (real, dry-run, disabled), unmount with options, timeout (exit 124), busy-mount handling, already-unmounted detection, multi-mount independence.
-- Remote commands (29 tests): SSH execution, pre-shutdown actions, parallel and sequential modes.
-- Connection grace period (26 tests): OK / GRACE_PERIOD / FAILED transitions, flap detection, stale data.
-- TUI dashboard (50 tests): state file parsing, log filtering, human-readable status, `--once` output. Graph integration: `cycle()` keybinding helper, per-UPS stats DB path that mirrors the daemon's sanitization, `render_graph_text` (no-data, with-samples, unknown-metric paths), `run_once --graph` block. Events-panel: `query_events_for_display` for single-UPS (no label prefix) and multi-UPS (with `[label]` prefix and timestamp interleave), time-window exclusion, `max_events` cap. `run_once --events-only` SQLite path with log-tail fallback and "(no events)" placeholder. Width-helper regression: `display_width` counts emoji and CJK as 2 cells, `truncate_to_width` clips before a partial double-width char, `render_logs_panel` no longer overflows the gold-panel right edge with emoji-heavy lines.
-- BrailleGraph (24 tests): code-point arithmetic against hand-computed glyphs (top-left, top-right, bottom row), `supported()` detection (`LANG=C`, UTF-8 vs ISO-8859-1), `plot()` geometry (height / width match request, empty data, zero dims), auto-scale (max at top, min at bottom, zero-range padding), explicit bounds clipping (above and below, NULL skipped), fallback character path, `render_to_window` curses helper.
-- CLI (20 tests): subcommands, bare invocation, multi-UPS validate.
-- Calculations (17 tests): depletion rate, battery history.
-- Notifications (16 tests): formatting, retry, Apprise.
-- State (23 tests): transition tests, plus the new lock/snapshot/concurrent-write infrastructure (8) used by the redundancy evaluator.
-- SQLite statistics (42 tests): schema and WAL / synchronous pragmas, hot-path `buffer_sample` (no I/O), thread-safe buffering, single-transaction flush, 5-min and hourly aggregation, retention purge, tier-aware `query_range`, events round-trip, read-only TUI connection, concurrent reader and writer, failure-isolation contract (every method swallows `sqlite3.Error` / `OSError`), `StatsConfig` YAML round-trip, `StatsWriter` thread lifecycle.
-- Packaging structural guard (3 tests): every `src/eneru/**/*.py` is referenced in `nfpm.yaml`. No dangling `src:` references. `/var/lib/eneru` directory entry present. Catches the PR #23 class of bug where a new module file fails at deb/rpm install with `ModuleNotFoundError` while pip CI passes silently.
-- Voltage health (78 tests): grid-snap helper across STANDARD_GRIDS, autodetect re-snap (NUT-mis-reports-nominal path + per-UPS sensitivity preserved across re-snap), single-formula thresholds at every standard grid × every preset, Chris's repro (issue #4: 120V/106/127 → 108/132, no false alarm at 122.4V, brownout at 107V), notification-text framing under any preset, hysteresis dwell + flap suppression, severity bypass at ±15%, severity-escalation refresh inside same state, migration-warning matrix (fires/suppresses + per-side delta + acknowledgement-via-explicit), legacy-band recompute helpers preserved for the migration comparison.
-- Triggers, integration, command execution (31 tests combined).
-
-To run tests locally:
+All Python development commands must run inside a `uv` virtualenv. Do not run `pip`, `python`, or `pytest` against the system Python while working in this repo.
 
 ```bash
-# Install dev dependencies
-pip install ".[dev]"
-
-# Run tests with coverage
-pytest --cov=src/eneru --cov-report=term -v
-
-# Run specific test file
-pytest tests/test_config_loading.py -v
+uv venv /tmp/eneru-venv
+source /tmp/eneru-venv/bin/activate
+uv pip install -e ".[dev,notifications,docs]"
 ```
 
----
-
-## End-to-end (E2E) testing
-
-The E2E tests run the full monitoring and shutdown workflow using real services.
-
-### E2E test environment
-
-The E2E tests spin up a test environment with Docker Compose:
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Test Environment                         │
-│                                                             │
-│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐   │
-│  │  NUT Server  │    │  SSH Target  │    │   Target     │   │
-│  │  (dummy-ups) │    │   (sshd)     │    │  Containers  │   │
-│  │  :3493       │    │   :2222      │    │              │   │
-│  └──────────────┘    └──────────────┘    └──────────────┘   │
-│         │                   │                   │           │
-│         └───────────────────┼───────────────────┘           │
-│                             │                               │
-│                     ┌───────▼───────┐                       │
-│                     │    Eneru      │                       │
-│                     │  (under test) │                       │
-│                     └───────────────┘                       │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-- NUT server with dummy driver, simulating UPS states without real hardware
-- SSH target container that receives and logs shutdown commands
-- Target containers that Eneru can shut down
-- tmpfs mount for testing filesystem unmount operations
-
-### UPS scenarios
-
-The E2E tests use scenario files to simulate different UPS states:
-
-| Scenario | Description | Triggers Shutdown? |
-|----------|-------------|-------------------|
-| `online-charging.dev` | Normal operation, fully charged | No |
-| `on-battery.dev` | On battery, battery OK | No |
-| `low-battery.dev` | Battery below 20% threshold | Yes |
-| `critical-runtime.dev` | Runtime below 600s threshold | Yes |
-| `fsd.dev` | UPS signals Forced Shutdown | Yes |
-| `avr-boost.dev` | AVR boosting low voltage | No |
-| `brownout.dev` | Voltage below warning threshold | No |
-| `overload.dev` | UPS overloaded | No |
-
-### E2E test cases
-
-The E2E workflow (`.github/workflows/e2e.yml`) runs 36 tests on every push and PR.
-Tests are partitioned into five parallel matrix jobs (`E2E CLI`,
-`E2E UPS Single`, `E2E UPS Multi`, `E2E Redundancy`, `E2E Stats`) so the
-total wall-clock is bounded by the slowest group rather than the sum of
-all 36 tests. v5.1.2 split the previous `Redundancy and Stats` group
-in two so the heaviest job no longer gates the matrix on its own.
-
-| Test | Group | Description |
-|------|-------|-------------|
-| **Test 1** | CLI | Validate E2E config against real NUT server |
-| **Test 2** | UPS Single | Monitor normal state - verify no false shutdown triggers |
-| **Test 3** | UPS Single | Detect power failure in dry-run mode |
-| **Test 4** | UPS Single | SSH remote shutdown with real command execution |
-| **Test 5** | UPS Single | FSD (Forced Shutdown) flag triggers immediate shutdown |
-| **Test 6** | UPS Single | Voltage event detection (brownout, AVR) |
-| **Test 7** | UPS Single | Notification delivery (if `E2E_NOTIFICATION_URL` secret configured) |
-| **Test 8** | CLI | Multi-UPS config validation against real NUT (both UPS1 and UPS2) |
-| **Test 9** | UPS Multi | Multi-UPS isolation: UPS1 fails, UPS2 unaffected |
-| **Test 10** | UPS Multi | Multi-UPS both online: no false shutdown triggers |
-| **Test 11** | CLI | Ownership validation: non-local group with containers rejected |
-| **Test 12** | CLI | CLI safety: bare `eneru` shows help, does not start daemon |
-| **Test 13** | CLI | TUI `--once` snapshot outputs UPS status |
-| **Test 14** | UPS Multi | Multi-UPS concurrent failure: both UPSes fail, both groups shut down |
-| **Test 15** | UPS Multi | Non-local failure: UPS2 fails, UPS1 and local resources unaffected |
-| **Test 16** | UPS Multi | Local drain (`drain_on_local_shutdown=true`): all groups drain before local shutdown |
-| **Test 17** | UPS Multi | Local no-drain (`drain_on_local_shutdown=false`): only local group shuts down |
-| **Test 18** | UPS Multi | Power recovery: OB then power restored, no shutdown triggered |
-| **Test 19** | UPS Multi | Multi-phase shutdown ordering: 3 SSH targets across 2 phases (`shutdown_order: 1, 1, 2`) — verifies all received shutdown, "Phase N/M (order=X)" log lines, and timestamp ordering across phases |
-| **Test 20** | CLI | Redundancy-group config validation: valid config passes (with `Redundancy groups (1):` summary); `min_healthy: 0` exits non-zero with the documented error |
-| **Test 21** | Redundancy | Redundancy quorum *holds* when 1 of 2 members healthy (`min_healthy: 1`) — no shutdown |
-| **Test 22** | Redundancy | Redundancy quorum *exhausted* (both critical) — `quorum LOST` log + `REDUNDANCY GROUP SHUTDOWN` sequence |
-| **Test 23** | Redundancy | UNKNOWN handling under default `unknown_counts_as: critical` — evaluator startup line confirmed |
-| **Test 24** | Redundancy | Both UPSes critical → fail-safe redundancy shutdown fires |
-| **Test 25** | Redundancy | Cross-group cascade: a UPS shared between an independent group and a redundancy group does not falsely fire the redundancy shutdown when the other member is healthy |
-| **Test 26** | Redundancy | Advisory-mode log signature: `Trigger condition met (advisory, redundancy group): ...` appears for redundancy members; `Triggering immediate shutdown` does *not* |
-| **Test 27** | Redundancy | Separate-Eneru-UPS topology: TestUPS protects the host (`is_local: true`), the redundancy group protects a remote rack — rack shutdown fires, host UPS unaffected |
-| **Test 28** | Stats | SQLite stats DB created at `db_directory`, `samples` table populated, `events` table contains the `DAEMON_START` row |
-| **Test 29** | Stats | Stats writer failure isolation: a broken `db_directory` (file where a directory was expected) logs the warning but does *not* crash the daemon |
-| **Test 30** | Stats | `eneru monitor --once --graph charge --time 1h` renders the ASCII / Braille graph header and y-axis label with seeded sample data |
-| **Test 31** | Stats | `eneru monitor --once --events-only` reads from the SQLite events table — verified by injecting a known event row into the DB and asserting the line surfaces in the output |
-| **Test 32** | Stats | Voltage auto-detect re-snaps NUT mis-reported nominal — scenario `us-grid-misreport.dev` reports `input.voltage.nominal=230V` while actual `input.voltage=120V`; daemon detects the mismatch, logs `auto-detect re-snap`, records a `VOLTAGE_AUTODETECT_MISMATCH` event with `notification_sent=0`, and confirms `meta.schema_version=3` |
-| **Test 33** | UPS Single | Issue #4: voltage_sensitivity preset prevents Chris's false-alarm flood — scenario `us-grid-hot.dev` (120V/106/127, input 122.4V) does NOT fire `OVER_VOLTAGE_DETECTED` on default `normal` (warnings 108/132), startup log says `sensitivity=normal`, the migration warning surfaces for the narrow-firmware UPS, and `us-grid-brownout.dev` at 107V still fires `BROWNOUT_DETECTED` |
-| **Test 34** | Stats | v5.2 panic-attack coalescing: `ON_BATTERY` + `POWER_RESTORED` rows pointed at TEST-NET-1 stay pending; the worker folds them into one `📊 Brief Power Outage` summary with the originals cancelled with `cancel_reason='coalesced'` |
-| **Test 35** | Stats | v5.2.1 single-restart-notification (single-UPS): SIGTERM enqueues `🛑 Service Stopped` AFTER `flush()` so it lands as `pending`; the next daemon's classifier cancels it with `cancel_reason='superseded'` and emits a single `🔄 Restarted` row — proves one notification per restart, never two |
-| **Test 36** | UPS Multi | v5.2.1 single-restart-notification (multi-UPS coordinator): same contract as Test 35 but exercises `MultiUPSCoordinator._cancel_prev_pending_lifecycle_rows` which sweeps each per-UPS store on the next coordinator startup |
-
-### Running E2E tests locally
-
-To run the E2E tests locally:
+Then run tests from inside the activated venv:
 
 ```bash
-# From repository root
-cd tests/e2e
+pytest
+pytest -m unit
+pytest -m integration
+pytest --cov=src/eneru --cov-report=term
+```
 
-# Generate SSH keys for the test
+Validate example configs:
+
+```bash
+for config in examples/*.yaml; do
+  python -m eneru validate --config "$config"
+done
+```
+
+## Test areas
+
+| Area | Coverage |
+|------|----------|
+| Config loading and validation | YAML parsing, defaults, enum validation, multi-UPS inheritance, local ownership, redundancy rules |
+| Monitor state machine | OL/OB transitions, FSD, failsafe, shutdown trigger order, dry-run behavior |
+| Shutdown mixins | VMs, containers, compose files, filesystem sync and unmounts, remote SSH phases |
+| Multi-UPS coordinator | Group routing, `is_local`, drain policy, local shutdown locking, signal handling |
+| Redundancy runtime | Quorum evaluation, advisory triggers, idempotent group execution |
+| Health monitoring | Voltage thresholds, AVR, bypass, overload, battery anomaly filtering |
+| Notifications | Formatting, retry queue, lifecycle classification, coalescing, suppression rules |
+| Statistics and TUI | SQLite schema, aggregation, event queries, graphs, one-shot monitor output |
+| Packaging | nFPM file list, package install paths, wrapper execution |
+
+## End-to-end tests
+
+The E2E suite runs on every pull request to `main` and every push to `main`. It is intentionally heavier than unit testing because it starts the same kinds of services Eneru depends on in production: NUT, SSH, Docker targets, real config files, and SQLite-backed state.
+
+The E2E environment lives under `tests/e2e/` and uses Docker Compose:
+
+```text
+Eneru under test
+  -> NUT dummy server
+  -> SSH target container
+  -> target containers and test mounts
+```
+
+The workflow is split into five parallel matrix groups:
+
+| Group | Focus |
+|-------|-------|
+| CLI | Validation, bare command safety, one-shot output |
+| UPS Single | Single UPS events and shutdown paths |
+| UPS Multi | Independent UPS groups and local-drain policies |
+| Redundancy | Quorum behavior and advisory triggers |
+| Stats | SQLite, graphs, events, notification coalescing |
+
+The scenario files simulate online, on-battery, low-battery, FSD, brownout, overload, hot-grid, and nominal-voltage-mismatch states.
+
+### E2E test inventory
+
+The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 36 numbered tests plus one CLI completion smoke check.
+
+| Test | Group | What it proves |
+|------|-------|----------------|
+| 1 | CLI | Main E2E config validates against the running test environment |
+| 2 | UPS Single | Normal online state keeps the daemon running and does not trigger shutdown |
+| 3 | UPS Single | Low battery triggers the dry-run shutdown sequence and exits cleanly |
+| 4 | UPS Single | Remote SSH shutdown command reaches the target container |
+| 5 | UPS Single | UPS `FSD` flag triggers immediate shutdown handling |
+| 6 | UPS Single | Brownout detection logs the expected voltage event and startup threshold context |
+| 7 | UPS Single | Apprise notification test command can deliver through the configured secret-backed URL when available |
+| 8 | CLI | Multi-UPS config validates while both dummy UPSes are reachable through NUT |
+| 9 | UPS Multi | UPS1 failure is isolated while UPS2 remains online |
+| 10 | UPS Multi | Both UPSes online does not create false multi-UPS shutdowns |
+| 11 | CLI | Validation rejects local-resource ownership on a non-local UPS group |
+| 12 | CLI | Bare `eneru` is safe and shows help instead of starting shutdown behavior |
+| 13 | CLI | `eneru monitor --once` prints a usable one-shot UPS snapshot |
+| 14 | UPS Multi | Concurrent failure of both UPSes triggers grouped shutdown behavior |
+| 15 | UPS Multi | Non-local UPS failure triggers only that UPS group context |
+| 16 | UPS Multi | `drain_on_local_shutdown=true` logs and executes the drain path |
+| 17 | UPS Multi | Default no-drain behavior skips the drain path |
+| 18 | UPS Multi | Power restored before shutdown logs recovery and avoids shutdown |
+| 19 | UPS Multi | `shutdown_order` runs remote targets in ordered phases with parallel servers inside a phase |
+| 20 | CLI | Redundancy-group validation accepts valid quorum config and rejects invalid `min_healthy` |
+| 21 | Redundancy | Quorum holds when one of two UPSes remains healthy |
+| 22 | Redundancy | Both UPSes critical exhaust quorum and fire redundancy shutdown |
+| 23 | Redundancy | Default unknown-state handling is surfaced and does not fire in healthy steady state |
+| 24 | Redundancy | Fail-safe redundancy shutdown fires when the group is effectively unsafe |
+| 25 | Redundancy | Cross-group topology does not cascade into redundancy shutdown while quorum holds |
+| 26 | Redundancy | Redundancy members log advisory trigger mode instead of immediate local shutdown |
+| 27 | Redundancy | Separate Eneru-host UPS plus remote rack redundancy topology fires only the remote rack group |
+| 28 | Stats | SQLite stats DB is created with samples and daemon-start event rows |
+| 29 | Stats | Stats writer failure is non-fatal and does not crash monitoring |
+| 30 | Stats | `monitor --once --graph` renders a graph from persisted stats data |
+| 31 | Stats | `monitor --once --events-only` reads events from SQLite |
+| 32 | Stats | Voltage nominal auto-detect re-snaps misreported NUT nominal voltage and records a silent event |
+| 33 | UPS Single | `voltage_sensitivity` avoids 120 V hot-grid false alarms while preserving real brownout detection |
+| 34 | Stats | Pending on-battery and restored notifications coalesce into one brief-outage summary |
+| 35 | Stats | Single-UPS restart lifecycle sends one restart notification instead of stop/start noise |
+| 36 | UPS Multi | Multi-UPS coordinator applies the same single-restart-notification contract across per-UPS stores |
+| E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |
+
+This coverage gives confidence that code quality is not only measured by isolated Python assertions. Each commit that enters the protected workflow must also prove that Eneru can talk to real NUT sockets, run against Dockerized SSH targets, write and query SQLite, render monitor output, validate production-shaped configs, and execute shutdown orchestration without depending on local developer state.
+
+## Run E2E locally
+
+Use the Python venv for Eneru commands, but Docker Compose provides the services.
+
+```bash
+source /tmp/eneru-venv/bin/activate
+
 ssh-keygen -t ed25519 -f /tmp/e2e-ssh-key -N ""
-cp /tmp/e2e-ssh-key.pub ssh-target/authorized_keys
+cp /tmp/e2e-ssh-key.pub tests/e2e/ssh-target/authorized_keys
 
-# Start the test environment
-docker compose up -d --build
-
-# Wait for services to be ready
+docker compose --project-directory tests/e2e up -d --build
 sleep 10
 
-# Verify NUT is working (single-UPS and multi-UPS)
 upsc TestUPS@localhost:3493
-upsc UPS1@localhost:3493
-upsc UPS2@localhost:3493
+python -m eneru validate --config tests/e2e/config-e2e-dry-run.yaml
+python -m eneru run --config tests/e2e/config-e2e-dry-run.yaml --exit-after-shutdown
 
-# Run Eneru in dry-run mode
-eneru validate --config config-e2e-dry-run.yaml
-
-# Simulate a power failure (single-UPS)
-cp scenarios/low-battery.dev scenarios/apply.dev
-eneru run --config config-e2e-dry-run.yaml --exit-after-shutdown
-
-# Multi-UPS: simulate UPS1 failure while UPS2 stays online
-cp scenarios/low-battery.dev scenarios/apply-UPS1.dev
-eneru run --config config-e2e-multi-ups.yaml --exit-after-shutdown
-
-# Cleanup
-docker compose down -v
+docker compose --project-directory tests/e2e down -v --remove-orphans
 ```
 
-See `tests/e2e/README.md` for more details.
+The GitHub workflow scripts under `tests/e2e/groups/` are the source of truth for exact CI steps.
 
----
+## Documentation build
 
-## Pre-release validation
-
-!!! important "Real hardware testing"
-    Before each official release, Eneru is tested on real hardware with actual UPS units and simulated power events.
-
-### Test environment
-
-The pre-release environment consists of:
-
-- Physical UPS units connected via USB and network
-- NUT server configured and serving UPS data
-- Multiple test systems (physical and virtual)
-- Real power event simulation (unplugging UPS from mains)
-
-### Validation checklist
-
-Before each release:
-
-- [ ] Power loss detection: UPS status correctly transitions to `OB` (on battery)
-- [ ] Trigger thresholds: shutdown initiates at configured battery/runtime levels
-- [ ] Notification delivery: alerts sent to configured services
-- [ ] Remote server shutdown: SSH-based shutdown executes successfully
-- [ ] Container shutdown: Docker/Podman containers stop gracefully
-- [ ] VM shutdown: libvirt VMs shut down before host
-- [ ] Local shutdown: system powers off cleanly
-- [ ] Recovery: service resumes monitoring after power restoration
-
-### Simulating power events
-
-To test without actually losing power:
+Build the ReadTheDocs site locally from the same uv venv:
 
 ```bash
-# On the NUT server, force the UPS into "on battery" mode (if supported)
-upsrw -s ups.status=OB your-ups@localhost
-
-# Or use a test UPS driver
-upsdrvctl -t stop
-
-# Monitor Eneru's response
-journalctl -u eneru.service -f
+source /tmp/eneru-venv/bin/activate
+mkdocs build --strict
 ```
 
-!!! warning "Test responsibly"
-    When testing shutdown sequences, ensure you have console access to the system. Remote SSH sessions may be terminated during the shutdown process.
-
----
-
-## Continuous integration
-
-### Workflow files
-
-| Workflow | File | Trigger |
-|----------|------|---------|
-| Validate | `.github/workflows/validate.yml` | Push, PR |
-| Integration | `.github/workflows/integration.yml` | Push, PR |
-| E2E | `.github/workflows/e2e.yml` | Push, PR |
-| Release | `.github/workflows/release.yml` | Release published |
-| PyPI | `.github/workflows/pypi.yml` | Release published |
-
-### Viewing results
-
-- [Validate Workflow Runs](https://github.com/m4r1k/Eneru/actions/workflows/validate.yml)
-- [Integration Workflow Runs](https://github.com/m4r1k/Eneru/actions/workflows/integration.yml)
-- [E2E Workflow Runs](https://github.com/m4r1k/Eneru/actions/workflows/e2e.yml)
-- [Release Workflow Runs](https://github.com/m4r1k/Eneru/actions/workflows/release.yml)
-- [PyPI Workflow Runs](https://github.com/m4r1k/Eneru/actions/workflows/pypi.yml)
-
----
-
-## Contributing tests
-
-When contributing new features or bug fixes:
-
-1. Add unit tests for new functionality in the `tests/` directory
-2. Update example configs if new configuration options are added
-3. Test locally before submitting a pull request:
+Serve it locally:
 
 ```bash
-# Run the full test suite
-pytest -v
-
-# Validate your config changes
-eneru validate --config /etc/ups-monitor/config.yaml
+mkdocs serve
 ```
 
-See the [GitHub repository](https://github.com/m4r1k/Eneru) for contribution guidelines.
+## Adding tests
+
+For code changes:
+
+- Add focused unit or integration tests under `tests/`.
+- Add or update E2E coverage in `.github/workflows/e2e.yml` and `tests/e2e/groups/` for new features.
+- Update example configs and docs when config keys change.
+- Update this page if test counts, workflow groups, or test responsibilities change materially.
+
+For documentation-only changes, a strict MkDocs build is usually enough.

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -186,7 +186,11 @@ Eneru reads `input.voltage.nominal`, snaps it to a standard grid voltage when po
 
 | Nominal | tight | normal | loose |
 |--------:|------:|-------:|------:|
+| 100 V | 95.0 / 105.0 | 90.0 / 110.0 | 85.0 / 115.0 |
 | 120 V | 114.0 / 126.0 | 108.0 / 132.0 | 102.0 / 138.0 |
+| 127 V | 120.7 / 133.4 | 114.3 / 139.7 | 108.0 / 146.1 |
+| 208 V | 197.6 / 218.4 | 187.2 / 228.8 | 176.8 / 239.2 |
+| 220 V | 209.0 / 231.0 | 198.0 / 242.0 | 187.0 / 253.0 |
 | 230 V | 218.5 / 241.5 | 207.0 / 253.0 | 195.5 / 264.5 |
 | 240 V | 228.0 / 252.0 | 216.0 / 264.0 | 204.0 / 276.0 |
 
@@ -199,6 +203,19 @@ upsc UPS@192.168.1.100 input.voltage.nominal input.transfer.low input.transfer.h
 ```
 
 Transfer points are the UPS firmware's battery-switch thresholds. Eneru includes them in logs and notifications for context, but the warning band comes from `voltage_sensitivity`.
+
+### Common UPS transfer points
+
+These are typical vendor defaults. Always confirm against your own unit with the `upsc` command above. Managed UPSes are often retuned by the operator, and firmware revisions vary.
+
+| UPS family | Grid | Transfer points (low / high) | Notes |
+|------------|------|------------------------------|-------|
+| APC Smart-UPS SUA / SMT / SMC | US 120 V  | ~106 / ~127 V                          | Eneru `normal` warns at 108 / 132 V before the UPS switches. `tight` (114 / 126 V) fires inside the firmware band, which is too aggressive. |
+| APC Smart-UPS (default-wide)  | EU 230 V  | 170 / 280 V                            | Wide factory band. `normal` (207 / 253 V) gives plenty of warning before the UPS switches. |
+| APC SMX / Symmetra (managed)  | EU 230 V  | operator-tightened, often ~207 / ~253  | Use `tight` (218.5 / 241.5 V) for an early signal when the UPS itself is tightened. |
+| Eaton 5P / 9PX                | EU 230 V  | typically narrow defaults              | `tight` is reasonable; `normal` still warns before the UPS acts. |
+| CyberPower CP1500             | US 120 V  | ~95 / ~140 V (wide)                    | `normal` (108 / 132 V) warns well before the UPS switches; `loose` matches the firmware band. |
+| Tripp Lite SMART series       | EU 230 V  | typically narrow                       | `tight` matches the firmware band; `normal` adds warning headroom. |
 
 ### Voltage auto-detect timeline
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,360 +1,113 @@
 # Shutdown triggers
 
-Eneru uses multiple independent triggers to decide when to shut down. This way, if one metric is unreliable (e.g., aged batteries with bad runtime estimates), other triggers can still catch the problem.
+Eneru starts shutdown when any configured trigger says the remaining power is no longer safe. The triggers overlap on purpose. UPS firmware can report bad runtime estimates, old batteries can fall off a cliff, and networked NUT servers can disappear during the event you most need them.
 
-!!! info "Beyond NUT's built-in triggers"
-    NUT's `upsmon` supports two shutdown conditions: `LOWBATT` (UPS hardware signals low battery) and `FSD` (forced shutdown flag). These depend on the UPS firmware's own assessment, which can be unreliable with aged batteries or certain hardware. Eneru adds four more triggers computed from observed data to cover scenarios that firmware-based triggers miss.
+## Decision order
 
----
+When a UPS is on battery, Eneru evaluates these conditions in order. The first matching condition starts shutdown.
 
-## Trigger priority
+| Order | Trigger | Default | Why it exists |
+|-------|---------|---------|---------------|
+| 1 | FSD flag | UPS-provided | The UPS is explicitly telling clients to shut down |
+| 2 | Low battery | `20%` | Hard floor when the battery is nearly empty |
+| 3 | Critical runtime | `600s` | UPS estimate says runtime is too short |
+| 4 | Depletion rate | `15%/min` after `90s` | Observed battery loss is too fast |
+| 5 | Extended time | `900s` | Safety net for long outages or stuck UPS readings |
+| Always | Failsafe battery protection | built in | Connection lost while on battery means shut down now |
 
-When on battery power, triggers are evaluated in this order. The **first** condition met initiates shutdown:
+Only on-battery status activates the shutdown triggers. Voltage, AVR, bypass, overload, and battery anomaly events are health alerts unless they also lead to one of the trigger conditions above.
 
-| Priority | Trigger | Default | Purpose |
-|----------|---------|---------|---------|
-| 1 | FSD Flag | N/A | UPS signals forced shutdown |
-| 2 | Low Battery | 20% | Battery percentage critically low |
-| 3 | Critical Runtime | 10 min | Estimated runtime too short |
-| 4 | Depletion Rate | 15%/min | Battery draining dangerously fast |
-| 5 | Extended Time | 15 min | Safety net for prolonged outages |
+### Power-event evaluation timeline
 
+This shows the normal path for a UPS that goes on battery but does not hit a shutdown trigger immediately. The numbers use the defaults from `src/eneru/config.py`: `check_interval: 1`, depletion `grace_period: 90`, critical runtime `600`, and extended time `900`.
 
----
+| Time | UPS data | Eneru action |
+|------|----------|--------------|
+| 0s | `ups.status` changes from `OL` to `OB` | Logs the transition and records `ON_BATTERY` |
+| Next poll | Fresh NUT snapshot arrives | Checks FSD, battery percentage, runtime, depletion, and extended-time triggers in priority order |
+| About 30 polls | Battery history reaches 30 readings | Depletion rate can now be calculated. With the default 1s `check_interval`, this is roughly 30s, but the 90s depletion grace period can still block shutdown |
+| 90s | Default depletion grace period expires | Depletion rate can trigger if it is above 15%/min |
+| Any poll | Runtime drops below 600s | Critical-runtime trigger fires unless an earlier trigger already started shutdown |
+| First poll after 900s | `time_on_battery > 900s` | Extended-time trigger fires even if battery and runtime still look safe |
+| Any poll | Power returns to `OL` | On-battery timers reset and no shutdown starts |
 
-## Voltage thresholds (preset-driven; raw thresholds not user-configurable)
-
-Issue [#27](https://github.com/m4r1k/Eneru/issues/27) asked for
-user-tunable over-voltage and brownout thresholds. **Raw volt-level
-overrides are deliberately not exposed.** A misconfigured
-`warning_high: 200` on a 120V grid would mask a real damaging
-over-voltage condition — Eneru would sit silent while line voltage took
-out PSUs. The safety contract is non-negotiable.
-
-The bounded escape hatch is the `voltage_sensitivity` preset (added in
-v5.1.2 after issue [#4](https://github.com/m4r1k/Eneru/issues/4)),
-configured per UPS group:
-
-```yaml
-ups:
-  - name: "Tower UPS"
-    triggers:
-      voltage_sensitivity: loose      # noisy utility, dial it back
-  - name: "Main Rack UPS"
-    triggers:
-      voltage_sensitivity: tight      # clean PDU, want early warning
-  - name: "Generator-fed Rack"
-    # voltage_sensitivity omitted -> defaults to `normal`
-```
-
-| Preset  | Band              | When to pick                                                  |
-|---------|-------------------|---------------------------------------------------------------|
-| `tight` | ±5% from nominal  | Clean PDU / managed UPS / lab environment; want early signal  |
-| `normal`| ±10% from nominal | **Default.** Matches the EN 50160 / IEC 60038 envelope        |
-| `loose` | ±15% from nominal | Noisy utility, generator-fed leg, hot-running grid            |
-
-What Eneru does:
-
-1. **Auto-detect at startup.** Read `input.voltage.nominal` from NUT
-   and snap it to the nearest standard grid voltage from
-   `(100, 110, 115, 120, 127, 200, 208, 220, 230, 240)` if within 15V
-   tolerance.
-2. **Derive grid-quality warning thresholds.** `warning_low` /
-   `warning_high` = `nominal × (1 ∓ pct)` where `pct` comes from the
-   `voltage_sensitivity` preset above. NUT's
-   `input.transfer.{low,high}` are **cached for context only** — the
-   daemon surfaces them in the startup log and in every brownout /
-   over-voltage notification so the operator knows when the UPS firmware
-   itself will switch to battery — but they no longer compute the
-   warning band.
-
-   Resolved thresholds across the standard grids (output of `round(nominal × (1 ∓ pct), 1)` —
-   Python's banker's rounding rounds .X5 floats to even, so 109.25 prints as
-   109.2 and 132.25 as 132.2; the daemon log line shows the same values):
-
-   | Nominal | tight (±5%)   | normal (±10%) | loose (±15%)  |
-   |--------:|--------------:|--------------:|--------------:|
-   | 100 V   | 95.0 / 105.0  | 90.0 / 110.0  | 85.0 / 115.0  |
-   | 110 V   | 104.5 / 115.5 | 99.0 / 121.0  | 93.5 / 126.5  |
-   | 115 V   | 109.2 / 120.8 | 103.5 / 126.5 | 97.8 / 132.2  |
-   | 120 V   | 114.0 / 126.0 | 108.0 / 132.0 | 102.0 / 138.0 |
-   | 127 V   | 120.6 / 133.3 | 114.3 / 139.7 | 108.0 / 146.0 |
-   | 200 V   | 190.0 / 210.0 | 180.0 / 220.0 | 170.0 / 230.0 |
-   | 208 V   | 197.6 / 218.4 | 187.2 / 228.8 | 176.8 / 239.2 |
-   | 220 V   | 209.0 / 231.0 | 198.0 / 242.0 | 187.0 / 253.0 |
-   | 230 V   | 218.5 / 241.5 | 207.0 / 253.0 | 195.5 / 264.5 |
-   | 240 V   | 228.0 / 252.0 | 216.0 / 264.0 | 204.0 / 276.0 |
-
-   ### Vendor reference (verify against your unit)
-
-   UPS firmware transfer points vary by family, region, and field
-   tuning. The numbers below are **typical defaults, not contracts** —
-   always verify against your actual hardware before relying on them:
-
-   ```bash
-   upsc <ups@host> input.voltage.nominal input.transfer.low input.transfer.high
-   ```
-
-   | Vendor / family               | Region    | Typical `transfer.low` / `transfer.high` | Behaviour with `normal` (±10%)                                            |
-   |-------------------------------|:---------:|:---------------------------------------:|---------------------------------------------------------------------------|
-   | APC Smart-UPS SUA / SMT / SMC | US 120 V  | ~106 / ~127 V                            | Warnings at 108 / 132 V. UPS won't switch to battery until 106 / 127 V.   |
-   | APC Smart-UPS (default-wide)  | EU 230 V  | 170 / 280 V                              | Warnings at 207 / 253 V. UPS won't switch until ±20% from nominal.        |
-   | APC SMX / Symmetra (managed)  | EU 230 V  | operator-tightened, often ~207 / ~253    | Warnings at 207 / 253 V. Use `tight` for 218.5 / 241.5 V.                 |
-   | Eaton 5P / 9PX                | EU 230 V  | typically narrow defaults                | Warnings at 207 / 253 V. Use `tight` for an early signal.                 |
-   | CyberPower CP1500             | US 120 V  | ~95 / ~140 V (wide)                      | Warnings at 108 / 132 V. UPS won't switch until 95 / 140 V.               |
-   | Tripp Lite SMART series       | EU 230 V  | typically narrow                         | Warnings at 207 / 253 V.                                                   |
-
-3. **Cross-check with observed reality.** Some UPS firmwares (notably
-   on US 120V grids) mis-report `input.voltage.nominal=230`. After
-   ~10 polls Eneru takes the median of observed `input.voltage`
-   readings and re-snaps the nominal if the readings disagree with
-   NUT by more than 25V. The re-snap is logged and recorded as a
-   `VOLTAGE_AUTODETECT_MISMATCH` event in the SQLite events table:
-
-       sqlite3 /var/lib/eneru/<UPS>.db \
-         "SELECT * FROM events WHERE event_type='VOLTAGE_AUTODETECT_MISMATCH';"
-
-   If you see one of these rows, your UPS firmware is mis-reporting
-   nominal — the daemon corrected for you, but it's worth filing a
-   NUT driver bug upstream. The re-snap re-applies the same percentage
-   band against the new nominal (your `voltage_sensitivity` preset
-   carries through).
-
-4. **Severity-aware notification hysteresis.** The state log line for
-   `OVER_VOLTAGE_DETECTED` / `BROWNOUT_DETECTED` is always written
-   immediately on transition. The *notification* dispatch is gated by
-   severity:
-   - **Non-severe voltage warnings** (up to and including ±15% from
-     nominal) go through `notifications.voltage_hysteresis_seconds`
-     (default 30s). A 2-second flap to 105V on a 120V grid (12.5%
-     under nominal — past the warning threshold but not severe) no
-     longer pages you; a sustained event still does, and arrives
-     with a `Persisted Ns.` annotation. With narrow UPS transfer
-     points the warning band can be tighter than ±10%, so non-severe
-     events can fire at less than 10% deviation.
-   - **Severe deviations** (`>±15%` from nominal) bypass the dwell
-     and notify **immediately** with a `(severe, X.X% below/above
-     nominal)` tag. These signal real grid trouble — utility fault,
-     generator instability, site wiring — that the operator wants to
-     know about NOW, not 30 seconds from now.
-
-   See [Notifications → Tuning alert noise](notifications.md#tuning-alert-noise).
-
-5. **Per-event mute, with a safety blocklist.**
-   `notifications.suppress: [...]` mutes specific informational
-   events (AVR cycling, voltage normalized) but rejects safety-
-   critical event names at config-load time. There is no way to
-   silence `OVER_VOLTAGE_DETECTED`, `BROWNOUT_DETECTED`,
-   `OVERLOAD_ACTIVE`, `BYPASS_MODE_ACTIVE`, `ON_BATTERY`,
-   `CONNECTION_LOST`, or any `SHUTDOWN_*` event.
-
-### What you'll see in the log
-
-```text
-📊 Voltage Monitoring Active.
-   Nominal: 230.0V (NUT=230.0).
-   Grid-quality warnings: 207.0V / 253.0V (±10% nominal, sensitivity=normal).
-   UPS battery-switch points: 170.0V / 280.0V (from NUT input.transfer.{low,high}).
-📊 Voltage auto-detect re-snap: NUT=230V disagreed with observed median 120.0V (window=[120.5, 119.0, ...]V). Re-snapped to 120V; new thresholds 108.0V / 132.0V.
-⚡ POWER EVENT: VOLTAGE_AUTODETECT_MISMATCH - NUT nominal=230V, observed median=120.0V, re-snapped to 120V
-```
-
-If you upgraded from v5.1.1 and one of your UPSes had narrow firmware
-transfer points (the `transfer ± 5V` candidate beat ±10% of nominal),
-the daemon emits a one-time startup warning with a per-side delta so
-you don't miss the change:
-
-```text
-⚠️ Voltage warning band changed from v5.1.1 on this UPS: low 220.0V→207.0V
-   (widened); high 240.0V→253.0V (widened). v5.1.2 dropped the
-   tighter-of-percentage-or-transfer clamp in favour of a single percentage-
-   band formula (issue #4). Current band is ±10% nominal (207.0V/253.0V).
-   Set 'voltage_sensitivity: tight' under this UPS's triggers block to
-   restore a tighter band, or set 'voltage_sensitivity: normal' to
-   acknowledge the new default and silence this warning. See
-   https://eneru.readthedocs.io/latest/changelog/ for details.
-```
-
-The warning suppresses once you set `voltage_sensitivity` explicitly
-(any value, even `normal`) — the daemon takes that as your decision and
-stops nagging.
-
-The autodetect-mismatch row lands in the SQLite `events` table with
-`notification_sent=0` so it doesn't ping you (it's startup
-information, not an active power event).
-
-### What you'll see in a brownout notification
-
-**Mild brownout (UPS won't switch):**
-
-```text
-🔻 BROWNOUT_DETECTED: input voltage 200.0V is 13.0% below 230V nominal
-   (warning threshold 207.0V). Persisted 30s.
-   UPS will not switch to battery until 170.0V (firmware setting);
-   this is a grid-quality issue (outside the configured ±10% nominal band),
-   not an imminent power loss.
-```
-
-**Severe brownout (UPS may switch shortly):**
-
-```text
-🔻 BROWNOUT_DETECTED: (severe, 21.7% below nominal): input voltage 180.0V.
-   Notifying immediately (bypassed hysteresis).
-   Approaching UPS battery-switch threshold (170.0V) -- battery may
-   engage shortly.
-```
-
----
-
-## Low battery threshold
+## Low battery
 
 ```yaml
 triggers:
-  low_battery_threshold: 20  # percentage
+  low_battery_threshold: 20
 ```
 
-Triggers shutdown when battery charge falls below the configured percentage.
+Eneru shuts down when `battery.charge` drops below the threshold. This is the simplest and most portable trigger. It works even when runtime estimates are missing or jump around.
 
-**When it helps:**
+### Low-battery timeline
 
-- Available on all UPS devices
-- Works when runtime estimates are unavailable or inaccurate
-- Hard floor regardless of load conditions
+| Time | Battery reading | Eneru action |
+|------|-----------------|--------------|
+| 0s | UPS goes on battery at 45% | Logs `ON_BATTERY` and keeps monitoring |
+| 5m | Battery reaches 24% | Still above the default 20% threshold; no shutdown |
+| 8m | Battery reaches 19% | Low-battery trigger fires because the code checks `battery < 20` |
+| 8m+ | Configured shutdown sequence starts | Local VMs, containers, filesystems, remote servers, and local poweroff run according to the enabled sections |
 
-**Example:** With threshold at 20%, shutdown triggers when battery reports 19% or lower.
-
----
-
-## Critical runtime threshold
+## Critical runtime
 
 ```yaml
 triggers:
-  critical_runtime_threshold: 600  # seconds (10 minutes)
+  critical_runtime_threshold: 600
 ```
 
-Triggers shutdown when the UPS-estimated remaining runtime falls below the configured value.
+Eneru shuts down when the UPS-reported runtime estimate falls below the threshold. Runtime accounts for current load, so a UPS at 50% charge can still be critical if the load is high.
 
-**When it helps:**
+Runtime estimates come from UPS firmware. They can be wrong on old batteries, cheap units, or immediately after a load change. Keep the other triggers enabled.
 
-- Accounts for current load, since the UPS calculates runtime from actual power draw
-- More accurate than battery percentage alone under varying loads
+### Runtime-trigger timeline
 
-### How runtime is calculated by the UPS
-
-The UPS continuously measures current battery capacity, power draw (load), and battery voltage curve to estimate: *"At this load, the battery will last X more seconds."*
-
-**Example scenario:**
-
-```
-Battery: 50%
-Load: 80% (high)
-UPS Runtime Estimate: 8 minutes
-
-Even though battery shows 50%, high load means only 8 minutes remain.
-With threshold at 10 minutes (600s), shutdown triggers.
-```
-
-**Limitations:**
-
-- Estimates can be inaccurate with aged batteries
-- Some UPS models provide unreliable estimates
-- Sudden load changes cause estimate jumps
-
-Multiple triggers compensate for each other's weaknesses.
-
----
+| Time | Runtime estimate | Eneru action |
+|------|------------------|--------------|
+| 0s | UPS goes on battery, runtime estimate is 1800s | Continue monitoring |
+| 2m | Load rises and runtime estimate falls to 800s | Still above threshold |
+| 3m | Runtime estimate falls to 590s | Critical-runtime trigger fires because the code checks `runtime < critical_runtime_threshold` |
+| 3m+ | Shutdown sequence starts | Battery percentage may still be high; runtime is the limiting metric |
 
 ## Depletion rate
 
 ```yaml
 triggers:
   depletion:
-    window: 300         # seconds (5 minutes)
-    critical_rate: 15.0 # percent per minute
-    grace_period: 90    # seconds
+    window: 300
+    critical_rate: 15.0
+    grace_period: 90
 ```
 
-The depletion rate measures **how fast the battery is draining** based on observed data, independent of UPS estimates.
+Depletion rate is calculated from observed battery readings, not the UPS runtime estimate.
 
-### How depletion rate is calculated
-
-The daemon maintains a rolling history of battery readings within the configured window (default: 5 minutes).
-
-**Step 1: Collect Data**
-
-Every check cycle (default: 1 second), the current battery percentage and timestamp are recorded:
-
-```
-History Buffer (last 5 minutes):
-┌──────────────┬───────────┐
-│ Time         │ Battery   │
-├──────────────┼───────────┤
-│ 5 min ago    │ 85%       │ ← Oldest reading
-│ 4 min ago    │ 82%       │
-│ 3 min ago    │ 79%       │
-│ 2 min ago    │ 76%       │
-│ 1 min ago    │ 73%       │
-│ Now          │ 70%       │ ← Current reading
-└──────────────┴───────────┘
+```text
+oldest reading in window: 85%
+current reading:          70%
+elapsed time:              5 minutes
+depletion rate:            3%/min
 ```
 
-**Step 2: Calculate Rate**
+Eneru needs at least 30 readings before the rate can trigger. The `grace_period` ignores the first part of an outage because many UPSes recalibrate battery charge right after power is lost.
 
-Compare the oldest reading to the current reading:
+### Timeline with 90s grace period
 
-```
-Battery difference = 85% - 70% = 15%
-Time difference    = 5 minutes
-Depletion rate     = 15% ÷ 5 min = 3%/min
-```
+The rate is not even returned until 30 readings are present. At the default 1-second poll interval, that is roughly 30 seconds; with a different `check_interval`, scale that part accordingly.
 
-**Step 3: Evaluate**
+| Time | On battery for | Example rate | Eneru action |
+|------|----------------|--------------|--------------|
+| 0s | 0s | N/A | Power loss detected; no depletion rate yet |
+| 10s | 10s | 54%/min | Ignored because there are fewer than 30 readings and Eneru is still inside the grace period |
+| About 30 polls | About 30s at default polling | 28%/min | Rate can be calculated, but shutdown is still blocked by the 90s grace period |
+| 60s | 60s | 16%/min | Still ignored inside grace period |
+| 90s | 90s | 12%/min | Grace period has expired, but the rate is below the default 15%/min threshold |
+| 120s | 120s | 18%/min | Depletion trigger fires |
 
-If rate exceeds threshold (default: 15%/min) and grace period has passed, trigger shutdown.
+Use this trigger to catch:
 
-### Minimum data requirement
-
-At least 30 readings are required before calculating a rate. With 1-second intervals, this means 30 seconds of data minimum. This prevents false positives from single bad readings, startup transients, or statistical noise in short samples.
-
-### The grace period
-
-When power fails, battery readings are often unstable for the first 30-90 seconds as the UPS recalibrates:
-
-```
-Time 0s:   Power fails
-Time 1s:   Battery reads 100%
-Time 2s:   Battery reads 95%   ← Sudden drop (recalibrating)
-Time 5s:   Battery reads 91%   ← Still adjusting
-Time 10s:  Battery reads 94%   ← Bouncing back
-Time 30s:  Battery reads 93%   ← Stabilizing
-Time 90s:  Battery reads 91%   ← Reliable now
-```
-
-Without a grace period, the initial 100% to 91% drop in 10 seconds would calculate as **54%/min**, triggering a false shutdown.
-
-The grace period (default: 90 seconds) ignores high depletion rates immediately after power loss:
-
-```
-Timeline with 90s grace period:
-
-Time     On Battery   Rate        Action
-──────────────────────────────────────────────
-0s       0s           N/A         Power lost
-10s      10s          54%/min     Ignored (grace period)
-30s      30s          28%/min     Ignored (grace period)
-60s      60s          16%/min     Ignored (grace period)
-90s      90s          12%/min     Evaluated → OK (below 15%)
-120s     120s         18%/min     SHUTDOWN TRIGGERED
-```
-
-### When depletion rate helps
-
-- Old batteries may show 50% charge but drain to 0% in minutes
-- Some UPS models have unreliable runtime calculations
-- Catches load spikes mid-outage
-- Uses observed data rather than UPS predictions
-
----
+- Old batteries that drop from a healthy-looking charge to empty very quickly.
+- Load spikes during an outage.
+- UPSes with optimistic runtime estimates.
 
 ## Extended time on battery
 
@@ -362,47 +115,23 @@ Time     On Battery   Rate        Action
 triggers:
   extended_time:
     enabled: true
-    threshold: 900  # seconds (15 minutes)
+    threshold: 900
 ```
 
-Triggers shutdown after the system has been running on battery for the configured duration, regardless of battery level or runtime estimates.
+Extended time shuts down after the UPS has been on battery for the configured number of seconds. It does not care what the charge or runtime estimate says.
 
-**When it helps:**
+This catches long outages where the battery still looks safe but you do not want the system running indefinitely. It also catches UPSes that stop updating battery values correctly.
 
-- If battery still shows 80% after 15 minutes, something may be wrong
-- Old batteries can suddenly fail after appearing stable
-- Catches scenarios where UPS reports incorrect data
-- Shuts down gracefully before potential battery cliff
+### Extended-time timeline
 
-### Example scenarios
+| Time | UPS report | Eneru action |
+|------|------------|--------------|
+| 0s | Power loss, battery 100% | Starts the time-on-battery counter |
+| 5m | Battery 85%, runtime estimate 40m | No extended-time trigger yet |
+| 10m | Battery 75%, runtime estimate 35m | Still below the default 900s threshold |
+| First poll after 15m | `time_on_battery > 900s` | Extended-time trigger fires as a safety net. The code uses a strict greater-than comparison, so it fires on the first poll after the threshold is exceeded |
 
-**Scenario 1: Reliable data, extended outage**
-
-```
-Power out for 15 minutes
-Battery: 45%
-Runtime estimate: 20 minutes
-Depletion rate: 3%/min
-
-All metrics look fine, but extended time threshold reached.
-Shutdown triggered as a precaution.
-```
-
-**Scenario 2: Unreliable UPS data**
-
-```
-Power out for 15 minutes
-Battery: 75% (stuck/not updating)
-Runtime estimate: 45 minutes (clearly wrong)
-Depletion rate: 0%/min (no change detected)
-
-Something is wrong with UPS reporting.
-Extended time safety net catches this and triggers shutdown.
-```
-
-### Disabling extended time
-
-For environments where long outages are expected and battery capacity is sufficient:
+Disable it only if your site intentionally rides through long outages and you trust the UPS telemetry:
 
 ```yaml
 triggers:
@@ -410,233 +139,113 @@ triggers:
     enabled: false
 ```
 
-When disabled, Eneru logs when the threshold is exceeded but does not trigger shutdown.
+## FSD flag
 
----
+FSD is the highest-priority trigger. If `ups.status` includes `FSD`, Eneru starts shutdown immediately. The UPS may be about to cut output power.
 
-## Critical runtime vs extended time
+## Failsafe battery protection
 
-These two triggers cover different failure modes:
+If Eneru was on battery and then loses visibility of the UPS, it starts shutdown immediately. This is not configurable.
 
-| Trigger | Based On | Catches |
-|---------|----------|---------|
-| Critical Runtime | UPS estimate | High load draining battery fast |
-| Extended Time | Wall clock | Prolonged outage, unreliable UPS data |
+Examples:
 
-**Example: Low load, long outage**
+- NUT server dies during an outage.
+- Network path to a remote NUT server drops.
+- USB connection to the UPS fails.
+- The UPS stops returning fresh data.
 
-```
-Runtime estimate: 2 hours (high, low load)
-Actual time on battery: 20 minutes
+The connection-loss grace period only applies while the UPS is on line power. It does not delay failsafe shutdown.
 
-Critical runtime won't trigger (estimate is high).
-Extended time triggers at 15 minutes.
-```
+### Failsafe timeline
 
-**Example: High load, short outage**
+| Time | State | Eneru action |
+|------|-------|--------------|
+| Line power | NUT connection drops while previous UPS status is `OL` | Connection grace may suppress the notification |
+| Line power | NUT returns during grace | No shutdown. The recovery can count toward flap detection |
+| On battery | NUT connection drops while previous UPS status is `OB` | Failsafe bypasses grace and starts shutdown immediately |
+| Afterwards | UPS visibility remains lost | Eneru assumes the UPS may be near cut-off and runs the shutdown sequence |
 
-```
-Runtime estimate: 5 minutes (low, high load)
-Actual time on battery: 3 minutes
+## Voltage sensitivity
 
-Critical runtime triggers at 10-minute threshold.
-Extended time never reached.
-```
+Voltage monitoring warns about line power problems before, during, and after UPS battery events. Eneru does not expose raw voltage thresholds because a bad value could hide a damaging over-voltage or brownout.
 
----
-
-## Failsafe battery protection (FSB)
-
-Eneru has a hardcoded failsafe beyond the configured triggers:
-
-!!! warning "Immediate shutdown"
-    If connection to the UPS is lost while running on battery, immediate shutdown is triggered.
-
-This catches:
-
-- NUT server crash during outage
-- Network failure to remote NUT server
-- USB cable disconnect
-- UPS communication failure
-
-If the system was on battery and can no longer confirm UPS status, it assumes the worst and shuts down.
-
-```
-Timeline:
-1. Power fails, system on battery (OB status)
-2. UPS connection lost (network issue, NUT crash, etc.)
-3. Script detects stale/missing data
-4. FSB triggers: "Was on battery and lost visibility, shut down NOW"
-```
-
-!!! note "Grace period does not affect FSB"
-    The [connection loss grace period](configuration.md#connection-loss-grace-period) only suppresses notifications when the UPS is on line power. If the system is on battery when the connection is lost, FSB triggers immediately regardless of grace period settings.
-
----
-
-## FSD (forced shutdown) flag
-
-The highest priority trigger. When the UPS itself signals FSD, shutdown is immediate.
-
-FSD is set when:
-
-- UPS battery is critically low (UPS-determined)
-- UPS is commanding connected systems to shut down
-- UPS is about to cut power
-
-The UPS has direct knowledge of its own state and may cut power imminently, so all other triggers defer to FSD.
-
----
-
-## Why multiple triggers?
-
-Each trigger catches scenarios the others might miss:
-
-| Scenario | Low Battery | Runtime | Depletion | Extended |
-|----------|:-----------:|:-------:|:---------:|:--------:|
-| Normal discharge | ✓ | ✓ | ✓ | ✓ |
-| Aged battery (sudden failure) | ✗ | ✗ | ✓ | ✓ |
-| UPS reporting stuck values | ✗ | ✗ | ✗ | ✓ |
-| High load spike | ✓ | ✓ | ✓ | ✗ |
-| Inaccurate runtime estimate | ✓ | ✗ | ✓ | ✓ |
-| Very slow discharge | ✓ | ✓ | ✗ | ✓ |
-
-✓ = Would catch this scenario | ✗ = Might miss this scenario
-
----
-
-## Trigger evaluation flow
-
-```
-                    ┌─────────────────────┐
-                    │  On Battery Power   │
-                    └──────────┬──────────┘
-                               │
-                               ▼
-                    ┌─────────────────────┐
-                    │  FSD Flag Set?      │───Yes───▶ SHUTDOWN
-                    └──────────┬──────────┘
-                               │ No
-                               ▼
-                    ┌─────────────────────┐
-                    │  Battery < 20%?     │───Yes───▶ SHUTDOWN
-                    └──────────┬──────────┘
-                               │ No
-                               ▼
-                    ┌─────────────────────┐
-                    │  Runtime < 10min?   │───Yes───▶ SHUTDOWN
-                    └──────────┬──────────┘
-                               │ No
-                               ▼
-                    ┌─────────────────────┐
-                    │  Depletion > 15%/m? │───Yes───┐
-                    └──────────┬──────────┘         │
-                               │ No                 ▼
-                               │          ┌─────────────────────┐
-                               │          │  Grace Period Over? │──No──▶ Log & Continue
-                               │          └──────────┬──────────┘
-                               │                     │ Yes
-                               │                     ▼
-                               │                  SHUTDOWN
-                               ▼
-                    ┌─────────────────────┐
-                    │  On Battery > 15m?  │───Yes───┐
-                    └──────────┬──────────┘         │
-                               │ No                 ▼
-                               │          ┌─────────────────────┐
-                               │          │  Extended Enabled?  │──No──▶ Log & Continue
-                               │          └──────────┬──────────┘
-                               │                     │ Yes
-                               │                     ▼
-                               │                  SHUTDOWN
-                               ▼
-                    ┌─────────────────────┐
-                    │  Continue Monitoring│
-                    │  (check again in 1s)│
-                    └─────────────────────┘
-```
-
----
-
-## Recommended configurations
-
-### Conservative (maximum protection)
+Use the bounded preset instead:
 
 ```yaml
 triggers:
-  low_battery_threshold: 30
-  critical_runtime_threshold: 900  # 15 minutes
-  depletion:
-    window: 300
-    critical_rate: 10.0
-    grace_period: 90
-  extended_time:
-    enabled: true
-    threshold: 600  # 10 minutes
+  voltage_sensitivity: normal
 ```
 
-Shuts down early, prioritizes data safety over runtime.
+| Preset | Band from nominal | Use it for |
+|--------|-------------------|------------|
+| `tight` | +/- 5% | Clean power, managed UPSes, lab environments |
+| `normal` | +/- 10% | Default. Matches common grid quality expectations |
+| `loose` | +/- 15% | Noisy utility power, generator-fed circuits, hot-running grids |
 
-### Balanced (Default)
+Eneru reads `input.voltage.nominal`, snaps it to a standard grid voltage when possible, then derives warning thresholds from the preset.
+
+| Nominal | tight | normal | loose |
+|--------:|------:|-------:|------:|
+| 120 V | 114.0 / 126.0 | 108.0 / 132.0 | 102.0 / 138.0 |
+| 230 V | 218.5 / 241.5 | 207.0 / 253.0 | 195.5 / 264.5 |
+| 240 V | 228.0 / 252.0 | 216.0 / 264.0 | 204.0 / 276.0 |
+
+Some UPS firmware reports the wrong nominal voltage, especially 120 V devices claiming 230 V. After startup, Eneru compares the observed input voltage median with the NUT nominal value. If they disagree sharply, Eneru re-snaps the nominal, logs the correction, and records `VOLTAGE_AUTODETECT_MISMATCH` in the stats database.
+
+Check your UPS transfer points directly:
+
+```bash
+upsc UPS@192.168.1.100 input.voltage.nominal input.transfer.low input.transfer.high
+```
+
+Transfer points are the UPS firmware's battery-switch thresholds. Eneru includes them in logs and notifications for context, but the warning band comes from `voltage_sensitivity`.
+
+### Voltage auto-detect timeline
+
+This timeline is backed by `AUTODETECT_OBSERVATION_COUNT = 10` and `AUTODETECT_DISCREPANCY_V = 25.0` in `src/eneru/health/voltage.py`.
+
+| Time | Data | Eneru action |
+|------|------|--------------|
+| Startup | NUT reports `input.voltage.nominal=230` | Computes initial thresholds from 230 V |
+| First 10 valid voltage polls | Observed input voltage is around 120 V | Fills the 10-reading auto-detect observation window |
+| 10th valid reading | Median differs from NUT nominal by more than 25 V | Re-snaps nominal voltage to the nearest standard grid, such as 120 V |
+| Same startup | Corrected nominal is available | Recomputes thresholds and records `VOLTAGE_AUTODETECT_MISMATCH` with notification suppressed |
+
+## Voltage notification hysteresis
+
+Voltage warnings are logged immediately. Notifications wait for `notifications.voltage_hysteresis_seconds` unless the event is severe.
 
 ```yaml
-triggers:
-  low_battery_threshold: 20
-  critical_runtime_threshold: 600  # 10 minutes
-  depletion:
-    window: 300
-    critical_rate: 15.0
-    grace_period: 90
-  extended_time:
-    enabled: true
-    threshold: 900  # 15 minutes
+notifications:
+  voltage_hysteresis_seconds: 30
 ```
 
-Balances protection against unnecessary shutdowns.
+If a voltage flap clears inside the dwell time, Eneru records `VOLTAGE_FLAP_SUPPRESSED` and does not send a notification. Severe deviations beyond +/- 15% of nominal bypass the dwell and notify immediately.
 
-### Aggressive (maximum runtime)
+### Brownout notification timeline
 
-```yaml
-triggers:
-  low_battery_threshold: 10
-  critical_runtime_threshold: 300  # 5 minutes
-  depletion:
-    window: 300
-    critical_rate: 20.0
-    grace_period: 120
-  extended_time:
-    enabled: false
-```
+The default dwell is `notifications.voltage_hysteresis_seconds: 30`. Severe means deviation is greater than 15% from nominal (`VOLTAGE_SEVERE_DEVIATION_PCT = 0.15`).
 
-Maximizes runtime, accepts higher risk. Only recommended with reliable UPS and new batteries.
+| Time | Input voltage on 230 V nominal | Eneru action |
+|------|--------------------------------|--------------|
+| 0s | 205 V, below normal low threshold 207 V | Logs `BROWNOUT_DETECTED` immediately and starts the dwell timer |
+| 10s | 215 V, back inside band | Suppresses notification and records `VOLTAGE_FLAP_SUPPRESSED` |
+| 0s | 205 V again | Starts a new dwell window |
+| 30s | 204 V, still low | Sends brownout notification with persisted-duration note |
+| Any time | Deviation exceeds 15% from nominal | Severe event bypasses dwell and notifies immediately |
 
----
+## Trigger profiles
 
-## Triggers in redundancy groups
+| Profile | Battery | Runtime | Depletion | Extended time |
+|---------|---------|---------|-----------|---------------|
+| Conservative | 30% | 900s | 10%/min | 600s |
+| Balanced | 20% | 600s | 15%/min | 900s |
+| Runtime-focused | 10% | 300s | 20%/min | disabled |
 
-When a UPS belongs to a [redundancy group](redundancy-groups.md), the
-triggers above (T1-T4, FSD, FAILSAFE) still evaluate on the member's
-monitor thread. Instead of running a local shutdown, they set an
-advisory flag on the per-UPS state snapshot:
+Balanced is the default. Runtime-focused settings are only reasonable with tested batteries and trustworthy UPS telemetry.
 
-```
-⚠️ Trigger condition met (advisory, redundancy group): <reason>
-```
+## Redundancy groups
 
-The group's `RedundancyGroupEvaluator` reads those flags from every
-member, applies the group's quorum policy (`min_healthy`,
-`degraded_counts_as`, `unknown_counts_as`), and only fires the group's
-shutdown when fewer than `min_healthy` members contribute as healthy.
-See [Redundancy Groups](redundancy-groups.md) for the full lifecycle.
+When a UPS belongs to a [redundancy group](redundancy-groups.md), its triggers still run on the UPS monitor thread. They do not directly shut down the resource group. Instead they mark the member as advisory-critical, and the redundancy evaluator applies the group's quorum policy.
 
-A few notes when picking trigger values for redundancy members:
-
-- Per-UPS thresholds still matter. They decide when each member
-  contributes "critical" to the group.
-- The FAILSAFE rule (connection lost while On Battery) does not run a
-  local shutdown for a redundancy member. It sets
-  `connection_state=FAILED` plus the advisory trigger, and the group
-  evaluator decides via `unknown_counts_as`.
-- An independent UPS group (one not referenced by any redundancy
-  group) is unaffected. Its triggers run the local shutdown path
-  byte-identically to single-UPS mode.
+For a dual-PSU rack with `min_healthy: 1`, one critical UPS is not enough to shut the rack down if the other UPS is still healthy. Both feeds must fail, unless you set a stricter quorum policy.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,439 +1,264 @@
 # Troubleshooting
 
-Common issues and how to resolve them.
+Start with the logs and validation output. Most Eneru failures are configuration, NUT connectivity, SSH permissions, or stale shutdown flags from testing.
 
----
+## Quick checks
 
-## Service management
-
-### Basic commands
+Package install:
 
 ```bash
-# Start/stop/restart
-sudo systemctl start eneru.service
-sudo systemctl stop eneru.service
-sudo systemctl restart eneru.service
-
-# Check status
+sudo eneru validate --config /etc/ups-monitor/config.yaml
 sudo systemctl status eneru.service
-
-# View logs (follow mode)
-sudo journalctl -u eneru.service -f
-
-# View recent logs
 sudo journalctl -u eneru.service -e
-
-# View log file directly
-sudo tail -f /var/log/ups-monitor.log
 ```
 
----
-
-## Service won't start
-
-### Check for errors
-
-```bash
-journalctl -u eneru.service -e
-```
-
-### Validate Python version
-
-Eneru requires Python 3.9 or higher:
-
-```bash
-python3 --version
-```
-
-If your version is older, you'll need to upgrade Python or use a distribution with a newer version.
-
-### Check dependencies
-
-```bash
-python3 -c "import yaml; print('PyYAML OK')"
-python3 -c "import apprise; print('Apprise OK')"
-```
-
-If either fails, install the missing dependency:
-
-```bash
-# Debian/Ubuntu
-sudo apt install python3-yaml apprise
-
-# RHEL/Fedora
-sudo dnf install python3-pyyaml apprise
-```
-
-### Validate package syntax
-
-```bash
-# For installed package
-python3 -c "import eneru; print('OK')"
-
-# For development (from repository root)
-python3 -m py_compile src/eneru/*.py
-```
-
-If this produces errors, the package may be corrupted. Reinstall it.
-
-### Pip install shows UNKNOWN-0.0.0 (Ubuntu 22.04)
-
-Ubuntu 22.04 ships pip 22.0.2, which has a regression with `pyproject.toml` dynamic version metadata. Running `pip install eneru` produces an `UNKNOWN-0.0.0` package and the `eneru` command is not available.
-
-Fix by upgrading pip first:
-
-```bash
-pip install --upgrade pip
-pip install eneru
-```
-
-Or use a virtualenv, which typically includes a newer pip:
-
-```bash
-python3 -m venv ~/.venv/eneru
-source ~/.venv/eneru/bin/activate
-pip install eneru
-```
-
-This does not affect `.deb` package installation, which works on Ubuntu 22.04 without issues.
-
-### Validate configuration
+PyPI install:
 
 ```bash
 eneru validate --config /etc/ups-monitor/config.yaml
+eneru run --dry-run --config /etc/ups-monitor/config.yaml
 ```
 
-This checks for YAML syntax errors, invalid configuration values, and multi-UPS ownership rules.
+Check the current state file:
 
----
+```bash
+sudo cat /var/run/ups-monitor.state
+```
+
+## Service will not start
+
+| Check | Command |
+|-------|---------|
+| Last service errors | `sudo journalctl -u eneru.service -e` |
+| Unit definition | `systemctl cat eneru.service` |
+| Package entry point | `sudo eneru version` |
+| Config validity | `sudo eneru validate --config /etc/ups-monitor/config.yaml` |
+| Python version | `python3 --version` |
+
+The packaged systemd unit runs:
+
+```bash
+sudo eneru run --config /etc/ups-monitor/config.yaml
+```
+
+If the wrapper is missing or import errors mention `eneru`, reinstall the native package. Do not try to repair a native package install with system `pip`.
 
 ## Cannot connect to UPS
 
-### Test NUT connection
+Test NUT directly from the Eneru host:
 
 ```bash
-upsc UPS@192.168.178.11
+upsc -l 192.168.1.100
+upsc UPS@192.168.1.100
 ```
 
-This should display all UPS variables. If it fails:
+If this fails, Eneru cannot monitor the UPS. Check these in order:
 
-1. Check that the NUT server is running:
-   ```bash
-   systemctl status nut-server
-   ```
+| Area | What to verify |
+|------|----------------|
+| UPS name | `upsc -l <host>` must list the same name used in `ups.name` |
+| NUT listener | `upsd` listens on the network interface, usually port 3493 |
+| Firewall | TCP 3493 is reachable from the Eneru host |
+| NUT users | Remote access is allowed where your NUT setup requires users |
+| Driver health | NUT driver logs on the UPS server show fresh data |
 
-2. Verify network connectivity:
-   ```bash
-   ping 192.168.178.11
-   ```
-
-3. Check that the NUT server allows remote connections.
-   On the NUT server, verify `/etc/nut/upsd.conf` has:
-   ```
-   LISTEN 0.0.0.0 3493
-   ```
-   And `/etc/nut/upsd.users` has appropriate user configuration.
-
-4. Check the firewall. NUT uses port 3493 by default.
-
-### Verify UPS name
-
-The UPS name in your config must match exactly what NUT reports:
+On the NUT server, common checks are:
 
 ```bash
-upsc -l 192.168.178.11
+systemctl status nut-server
+systemctl status nut-driver
+journalctl -u nut-driver -e
 ```
 
-This lists all UPS names on that server.
+## Intermittent NUT drops
 
-### Flaky NUT server (intermittent connection drops)
-
-Some UPS devices with integrated NUT servers can be intermittently unreachable, causing notification storms. Eneru has a connection loss grace period that suppresses notifications during brief outages:
+Some networked UPSes and embedded NUT servers flap briefly. Use the connection-loss grace period to avoid alerts for short drops while the UPS is on line power:
 
 ```yaml
 ups:
   connection_loss_grace_period:
-    enabled: true    # Suppress transient connection failures
-    duration: 60     # Wait 60s before sending CONNECTION_LOST notification
-    flap_threshold: 5  # Warn after 5 recoveries within 24h
+    enabled: true
+    duration: 60
+    flap_threshold: 5
 ```
 
-If your NUT server flaps frequently, check:
+This does not delay failsafe shutdown. If Eneru loses connection while the UPS is on battery, it shuts down immediately.
 
-1. Network stability between Eneru and the NUT server
-2. NUT server logs for driver or USB errors (`journalctl -u nut-driver`)
-3. UPS firmware updates from the manufacturer
+If flaps continue, check network stability, UPS firmware, and NUT driver logs.
 
-See [Connection loss grace period](configuration.md#connection-loss-grace-period) for details.
+### Connection grace timeline
 
----
+This is grounded in `monitor.py`: connection grace runs only when Eneru is not on battery. Stale data must first reach `max_stale_data_tolerance` attempts, which defaults to 3. A failed poll path waits 5 seconds before the next loop iteration.
 
-## Notifications not working
+| Time | State | Eneru behavior |
+|------|-------|----------------|
+| First stale poll | `stale_data_count=1/3` | Logs a stale-data warning, no grace timer yet |
+| Third stale poll by default | Tolerance reached | Enters `GRACE_PERIOD` and starts the 60s default grace timer |
+| Before 60s expires | Connection recovers | Logs quiet recovery, sends no `CONNECTION_LOST` notification |
+| Recovery within grace repeats | Flap counter increments | After 5 recoveries within the 24h flap window, sends unstable-NUT warning |
+| 60s grace expires | Still disconnected | Sends `CONNECTION_LOST` and marks connection `FAILED` |
+| Any time previous UPS status was `OB` | Connection or stale-data failure | Bypasses grace and starts failsafe shutdown immediately |
 
-### Test built-in command
+## Notifications do not arrive
+
+Run the built-in test:
 
 ```bash
-sudo python3 /opt/ups-monitor/eneru.py --test-notifications
+sudo eneru test-notifications --config /etc/ups-monitor/config.yaml
 ```
 
-### Test Apprise directly
+Then check:
+
+| Cause | Fix |
+|-------|-----|
+| Apprise missing | Install package notification dependencies or use `eneru[notifications]` for PyPI |
+| Bad URL format | Compare with the Apprise service wiki |
+| Outbound network blocked | Test DNS and HTTPS from the Eneru host |
+| Rate limiting | Wait and retry with fewer test sends |
+| Event muted | Check `notifications.suppress` |
+
+Notification rows are stored in SQLite. Pending rows indicate delivery has not succeeded yet:
 
 ```bash
-python3 -c "
-import apprise
-ap = apprise.Apprise()
-ap.add('discord://webhook_id/webhook_token')
-result = ap.notify(body='Test from Apprise', title='Test')
-print('Success' if result else 'Failed')
-"
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db \
+  "SELECT id, status, attempts, cancel_reason, title FROM notifications ORDER BY id DESC LIMIT 20;"
 ```
-
-### Common issues
-
-1. Wrong URL format. Each service has a specific format; check the [Apprise Wiki](https://github.com/caronc/apprise/wiki).
-
-2. Network issues. Can the server reach the notification service?
-   ```bash
-   curl -I https://discord.com
-   ```
-
-3. Rate limiting. If testing frequently, you may hit service rate limits.
-
-4. Firewall blocking outbound. Ensure HTTPS (443) is allowed outbound.
-
----
 
 ## Remote shutdown fails
 
-See also: [Remote servers](remote-servers.md#troubleshooting)
-
-### Test SSH connection
+Test SSH as root on the Eneru host:
 
 ```bash
-# As root (Eneru runs as root)
 sudo ssh user@remote-server "echo OK"
+sudo ssh user@remote-server "sudo -n true && echo sudo OK"
 ```
 
-### Test sudo access
+| Error | Meaning |
+|-------|---------|
+| `Permission denied (publickey,password)` | The key is missing, wrong, unreadable, or installed for a different user |
+| `sudo: a password is required` | Passwordless sudo is not configured for the command Eneru runs |
+| `command not found` | Use a full path or platform-specific shutdown command |
+| Timeout | Firewall, host down, SSH service down, or too-low `connect_timeout` |
+| Host key changed | Verify the remote host before accepting the new key |
 
-```bash
-sudo ssh user@remote-server "sudo -n true && echo 'sudo OK'"
-```
+See [Remote servers](remote-servers.md) for sudoers examples and platform-specific shutdown commands.
 
-If this prompts for a password, the sudoers rule is not configured correctly.
+## Safe dry-run test
 
-### Check SSH key permissions
-
-```bash
-ls -la ~/.ssh/id_*
-```
-
-Keys should be mode 600 (readable only by owner).
-
----
-
-## Dry-run mode for testing
-
-Test the full shutdown sequence without actually shutting anything down:
-
-### Option 1: Config file
+Use dry-run before any real shutdown test:
 
 ```yaml
 behavior:
   dry_run: true
 ```
 
-### Option 2: Command line
+or override from the command line:
 
 ```bash
-sudo python3 /opt/ups-monitor/eneru.py --dry-run
+sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
 ```
 
-In dry-run mode, all actions are logged with `[DRY-RUN]` prefix but not executed.
+During dry-run, Eneru logs every action with a dry-run marker and skips the actual VM, container, remote, filesystem, and local shutdown commands.
 
-### Simulate power failure
+For a controlled test:
 
-1. Enable dry-run mode
-2. Optionally lower `extended_time.threshold` to trigger faster
-3. Unplug UPS input power (or use NUT's test commands if available)
-4. Watch logs for the shutdown sequence
-5. Verify notifications arrive
+1. Enable dry-run.
+2. Lower `triggers.extended_time.threshold` temporarily.
+3. Start Eneru in the foreground.
+4. Simulate or create a short on-battery condition.
+5. Watch the planned shutdown order in the logs.
+6. Restore the production thresholds.
 
-```bash
-# Watch logs during test
-sudo journalctl -u eneru.service -f
-```
+## Clear stale shutdown flags
 
----
+Eneru writes shutdown flag files so an interrupted process does not run the same sequence repeatedly. After a killed dry-run test, a flag can remain.
 
-## Clear shutdown state
-
-If a shutdown sequence is interrupted (e.g., you restored power mid-sequence during dry-run testing), clear the state file:
+Single UPS flag:
 
 ```bash
 sudo rm -f /var/run/ups-shutdown-scheduled
 ```
 
-This allows Eneru to trigger a new shutdown sequence if needed.
-
----
-
-## Check current UPS state
-
-View what Eneru sees from the UPS:
+Redundancy group flags:
 
 ```bash
-cat /var/run/ups-monitor.state
+sudo rm -f /var/run/ups-shutdown-redundancy-*
 ```
 
-This shows the current battery percentage, runtime, status, and other metrics.
+Remove flags only after confirming no real shutdown is in progress.
 
----
+## Graphs or events are empty
 
-## Example log output
-
-### Normal operation (service startup)
-
-```
-Dec 29 17:13:10 nuc.local python3[3366019]: Configuration loaded from: /etc/ups-monitor/config.yaml
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - 📢 Notifications: enabled (1 service(s))
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - 🐳 Container runtime detected: docker
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - 🚀 Eneru v4.3 starting - monitoring UPS@192.168.178.11
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - 📋 Enabled features: VMs, Containers (docker), FS Sync, Unmount (3 mounts), Remote (1 servers), Local Shutdown
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - ⏳ Checking initial connection to UPS@192.168.178.11...
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - ✅ Initial connection successful.
-Dec 29 17:13:10 nuc.local python3[3366019]: 2025-12-29 17:13:10 CET - 📊 Voltage Monitoring Active. Nominal: 230.0V. Low Warning: 175.0V. High Warning: 275.0V.
-```
-
-### Power failure event
-
-```
-Dec 22 22:19:07 nuc.local python3[1274572]: 2025-12-22 22:19:07 CET - 🔄 Status changed: OL CHRG -> OB DISCHRG (Battery: 100%, Runtime: 28m 9s, Load: 29%)
-Dec 22 22:19:07 nuc.local python3[1274572]: 2025-12-22 22:19:07 CET - ⚡ POWER EVENT: ON_BATTERY - Battery: 100%, Runtime: 1689 seconds, Load: 29%
-Dec 22 22:19:10 nuc.local python3[1274572]: 2025-12-22 22:19:10 CET - 🔋 On battery: 100% (28m 5s), Load: 28%, Depletion: 0.0%/min, Time on battery: 3s
-Dec 22 22:19:40 nuc.local python3[1274572]: 2025-12-22 22:19:40 CET - 🔋 On battery: 97% (19m 35s), Load: 23%, Depletion: 5.45%/min, Time on battery: 33s
-Dec 22 22:20:10 nuc.local python3[1274572]: 2025-12-22 22:20:10 CET - 🔋 On battery: 96% (19m 5s), Load: 27%, Depletion: 3.81%/min, Time on battery: 1m 3s
-Dec 22 22:20:45 nuc.local python3[1274572]: 2025-12-22 22:20:45 CET - 🔋 On battery: 93% (18m 31s), Load: 26%, Depletion: 4.29%/min, Time on battery: 1m 38s
-Dec 22 22:21:15 nuc.local python3[1274572]: 2025-12-22 22:21:15 CET - 🔋 On battery: 93% (18m 1s), Load: 23%, Depletion: 3.28%/min, Time on battery: 2m 8s
-```
-
-### Power restored
-
-```
-Dec 22 22:21:17 nuc.local python3[1274572]: 2025-12-22 22:21:17 CET - 🔄 Status changed: OB DISCHRG -> OL CHRG (Battery: 65%, Runtime: 17m 59s, Load: 18%)
-Dec 22 22:21:17 nuc.local python3[1274572]: 2025-12-22 22:21:17 CET - ⚡ POWER EVENT: POWER_RESTORED - Battery: 65% (Status: OL CHRG), Input: 237.6V, Outage duration: 2m 10s
-```
-
----
-
-## Known limitations
-
-### Single UPS only
-
-Eneru monitors one UPS per instance. For multiple UPS units, run multiple instances with different config files:
+The stats writer flushes every few seconds. For a fresh start, wait at least 10 seconds and check the database:
 
 ```bash
-sudo python3 /opt/ups-monitor/eneru.py --config /etc/ups-monitor/ups1.yaml
-sudo python3 /opt/ups-monitor/eneru.py --config /etc/ups-monitor/ups2.yaml
+sudo ls -lh /var/lib/eneru/
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db "SELECT COUNT(*) FROM samples;"
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db "SELECT COUNT(*) FROM events;"
 ```
 
-### UPS compatibility
+If the DB is missing, check `statistics.db_directory` and permissions.
 
-Eneru works with any UPS supported by NUT. However, some UPS models may:
+## Redundancy group does not fire
 
-- Report inaccurate runtime estimates
-- Have delayed battery percentage updates
-- Not support all status flags
+Check these in order:
 
-The multi-trigger system compensates for these issues.
+| Check | Explanation |
+|-------|-------------|
+| Quorum still holds | With `min_healthy: 1`, one healthy member keeps a two-UPS group online |
+| DEGRADED counts healthy | Default `degraded_counts_as: healthy` means on-battery warning state may still satisfy quorum |
+| Advisory trigger missing | Per-UPS thresholds may not have crossed yet |
+| Unknown policy | Default `unknown_counts_as: critical`; custom policy may be more tolerant |
+| Stale flag | `/var/run/ups-shutdown-redundancy-*` may remain after killed tests |
+| Wrong source name | `ups_sources` must exactly match `ups[].name` |
 
-### Battery anomaly detection and firmware jitter
-
-Eneru watches for unexpected battery charge drops (>20% within 120 seconds) while the UPS is on line power. If the charge suddenly falls without the UPS ever going on battery, something is wrong: a firmware recalibration, battery aging, or a hardware problem.
-
-However, some UPS models (APC, CyberPower, and Ubiquiti UniFi UPS are known offenders) briefly report a bogus charge value right after switching from battery (OB) back to line power (OL). A UPS sitting at 100% charge might report 50% for a second or two after power is restored, then go right back to the correct value.
-
-To avoid false alarms, Eneru requires the anomalous reading to persist across 3 consecutive polls before firing a warning. If the charge bounces back before that, the reading is discarded as jitter.
-
-In practice:
-
-- If the charge stays low across multiple polls, it is a real anomaly and Eneru fires the warning
-- If the charge recovers within 1-2 polls, Eneru treats it as transient jitter and ignores it
-
-If you see repeated false `Battery Anomaly Detected` warnings, check your UPS firmware version. Some firmware updates improve charge reporting accuracy during power transitions.
-
----
-
-## Why isn't my redundancy-group server shutting down?
-
-A server lives under a [redundancy group](redundancy-groups.md), one
-UPS clearly failed, but Eneru did nothing. Walk through the list:
-
-**1. The group's quorum has not been lost yet.**
-
-By default `min_healthy: 1` means any single healthy member keeps the
-group up. Check the logs:
-
-```
-🛡️ Redundancy group 'rack-1' evaluator started (2 sources, min_healthy=1)
-```
-
-Then watch for either of these on every tick (~1 s):
-
-- No log line: quorum is healthy and steady.
-- `🚨 Redundancy group 'rack-1' quorum LOST`: the group dropped
-  below `min_healthy`. The next log line is
-  `🚨 ========== REDUNDANCY GROUP SHUTDOWN: rack-1 ==========`.
-
-If quorum is not lost but you expected it to be, `min_healthy` is set
-higher than you intended, or one UPS member is still being counted as
-healthy. Recheck `degraded_counts_as` / `unknown_counts_as` for the
-policies you actually want.
-
-**2. The member UPS is DEGRADED, not CRITICAL.**
-
-A UPS that is on battery but has not yet hit any per-UPS trigger
-condition (low battery, low runtime, depletion, extended time, FSD)
-is `DEGRADED`, not `CRITICAL`. With `degraded_counts_as: healthy`
-(default), a degraded UPS still contributes to `healthy_count`.
-
-For strict behaviour, set `degraded_counts_as: critical`.
-
-**3. The advisory trigger never fired.**
-
-If a per-UPS trigger should have fired but did not, check the member
-monitor's log for `Trigger condition met (advisory, redundancy
-group): ...`. If the line is missing, the per-UPS thresholds (e.g.
-`triggers.low_battery_threshold`) have not been crossed yet. Adjust
-them per [Shutdown triggers](triggers.md#triggers-in-redundancy-groups).
-
-**4. The redundancy executor's flag file is sticky.**
-
-The redundancy shutdown is gated by
-`/var/run/ups-shutdown-redundancy-{sanitized-group-name}` for
-idempotency. If a previous run created the flag and was killed before
-clearing it, the executor will skip subsequent shutdowns. Clean it up:
+Run validation to catch source and ownership errors:
 
 ```bash
-sudo rm /var/run/ups-shutdown-redundancy-*
+sudo eneru validate --config /etc/ups-monitor/config.yaml
 ```
 
-This is normal after a manual `kill -9` of Eneru. SIGTERM and SIGINT
-clear the flag automatically.
+## Battery anomaly warnings
 
-**5. The redundancy group references the wrong UPS names.**
+Eneru warns when battery charge drops sharply while the UPS is on line power. This can mean battery wear, firmware recalibration, or bad telemetry.
 
-The names in `ups_sources` must match the `name:` field in the
-top-level `ups:` section exactly (including `@host:port` suffix). Run
-`eneru validate --config <path>`. Unknown references show up as
-`ERROR: Redundancy group 'X' references unknown UPS name(s): ...`.
+Some APC, CyberPower, and Ubiquiti units briefly report a bogus charge after returning from battery. Eneru requires the anomalous reading to persist across multiple polls before alerting, which filters most one- or two-poll jitter.
 
----
+If anomaly warnings repeat:
+
+- Check UPS firmware and NUT driver versions.
+- Compare `battery.charge` manually with `upsc`.
+- Run a controlled self-test if your UPS supports it.
+- Plan battery replacement if the charge drop persists.
+
+### Battery anomaly timeline
+
+This behavior comes from `src/eneru/health/battery.py`: the drop must be greater than 20 percentage points, occur within 120 seconds while on line power, and persist across 3 consecutive polls.
+
+| Poll | Reading | Eneru behavior |
+|------|---------|----------------|
+| Previous OL poll | Battery 100% | Baseline is stored |
+| Current OL poll | Battery 70% | Drop is greater than 20 points within 120s, so anomaly is marked pending |
+| Next poll | Battery still around 70% | Pending count increments, no alert yet |
+| Third confirming poll | Battery still low | Alert fires if the drop is still greater than 20 points |
+| Any confirming poll | Battery recovers by more than 10 points from pending low value | Pending anomaly is discarded as transient firmware jitter |
+
+## Known limits
+
+| Limit | Detail |
+|-------|--------|
+| UPS support comes from NUT | If NUT cannot read the UPS reliably, Eneru cannot fix that |
+| Runtime estimates can be wrong | Keep depletion and extended-time triggers enabled |
+| Remote shutdown needs trust | SSH keys and passwordless sudo are required for unattended operation |
+| Local resources need local ownership | In multi-UPS mode, only `is_local: true` can own VMs, containers, and filesystems |
 
 ## Getting help
 
-If you're still stuck:
+Open a GitHub issue with:
 
-1. Check the logs. Most issues are visible there.
-2. Enable dry-run mode to test safely.
-3. Open a [GitHub issue](https://github.com/m4r1k/Eneru/issues) with logs and config (redact sensitive data).
+- Eneru version.
+- Install method, package or PyPI.
+- Redacted `config.yaml`.
+- `eneru validate` output.
+- Relevant `journalctl -u eneru.service` lines.
+- NUT output from `upsc <ups@host>`.

--- a/docs/tui-graphs.md
+++ b/docs/tui-graphs.md
@@ -1,148 +1,120 @@
-# TUI graphs
+# Monitor and graphs
 
-`eneru monitor` renders line graphs from the
-[per-UPS SQLite stats](statistics.md). The graphs use the Unicode
-Braille pattern block (U+2800-U+28FF). Each terminal cell encodes a
-2 × 4 dot grid (8 binary pixels per cell), so a few rows of text
-hold a usable plot.
+`eneru monitor` shows current UPS state, recent events, logs, and optional graphs from the SQLite stats store.
+
+## Start the TUI
+
+Package install:
+
+```bash
+sudo eneru monitor --config /etc/ups-monitor/config.yaml
+```
+
+PyPI install:
+
+```bash
+eneru monitor --config /etc/ups-monitor/config.yaml
+```
+
+The `tui` subcommand is an alias:
+
+```bash
+eneru tui --config /etc/ups-monitor/config.yaml
+```
 
 ## Keybindings
 
-While the TUI is running:
-
 | Key | Action |
-|---|---|
+|-----|--------|
 | `Q` | Quit |
-| `R` | Refresh now (forces an out-of-band redraw) |
-| `M` | Toggle "more logs" |
-| `G` | Cycle the graph metric: `off → charge → load → voltage → runtime` |
-| `T` | Cycle the time range: `1h → 6h → 24h → 7d → 30d` |
-| `U` | (multi-UPS) Cycle which UPS the graph shows |
+| `R` | Refresh now |
+| `M` | Toggle expanded logs |
+| `G` | Cycle graph metric: off, charge, load, voltage, runtime |
+| `T` | Cycle graph range: 1h, 6h, 24h, 7d, 30d |
+| `U` | Multi-UPS only. Cycle the UPS shown in the graph |
 
-The graph panel is hidden when the mode is `off` (the default).
+Graphs are hidden until you press `G`.
 
-## Time-range tier selection
+## One-shot status
 
-`StatsStore.query_range()` picks the smallest aggregation tier that
-still covers the requested window:
-
-| Window | Tier used | Resolution |
-|---|---|---|
-| ≤ 24 h | `samples` | per poll (1 Hz typical) |
-| ≤ 30 d | `agg_5min` | 5-minute averages |
-| > 30 d | `agg_hourly` | hourly averages |
-
-The `1h` view is dot-accurate. The `7d` view is a smoothed 5-minute
-trend. The `30d` view aggregates further still. Keeps the database
-small and the queries fast at 5-year retention.
-
-## Headless rendering: `monitor --once --graph`
-
-For scripts, screenshots, or CI, render a graph straight to stdout:
+For scripts, SSH sessions, and CI:
 
 ```bash
-eneru monitor --once --graph charge --time 1h --config /etc/ups-monitor/config.yaml
+sudo eneru monitor --once --config /etc/ups-monitor/config.yaml
 ```
 
-Output (with Braille support):
+Render a graph without opening curses:
 
-```
-Eneru v5.1.0
-Time: 2026-04-20 16:00:00
-
-TestUPS@localhost  --  Status: OL CHRG
-  Battery: 100% (30m 0s)  Load: 25%  Input: 230.5V  Output: 230.0V
-  ...
-
-Graph: TestUPS@localhost
-charge -- last 1h  (0-100%)
-⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀
-y-axis: 0-100%
+```bash
+sudo eneru monitor --once --graph voltage --time 24h --config /etc/ups-monitor/config.yaml
 ```
 
-When the terminal is not Braille-capable (`LANG=C`, very old fonts),
-the renderer falls back to standard block characters
-(`▁ ▂ ▃ ▄ ▅ ▆ ▇ █`). Force the fallback for testing with
-`force_fallback=True` when calling `BrailleGraph.plot()` directly.
+Print recent events only:
 
-## Architecture
-
-- `eneru.graph.BrailleGraph` is a pure, stateless module with no
-  curses dependency. `BrailleGraph.plot(values, width=, height=)`
-  returns one string per terminal row.
-- The TUI opens the per-UPS DB read-only via
-  `StatsStore.open_readonly(path)` (`?mode=ro` URI), so it never
-  contends with the daemon's writer thread. WAL + `PRAGMA
-  busy_timeout = 500` keep reads non-blocking with a half-second
-  upper bound on contention even on slow storage.
-- The DB is opened lazily on the first non-`off` graph mode and
-  closed when the TUI exits.
-- **Live blending (rc6+).** The daemon's stats writer flushes every
-  10 s, but the state file is rewritten every poll cycle (~1 s).
-  Without blending, the graph's right edge would lag the live status
-  panel by up to 10 s. The TUI keeps a per-UPS deque (60 entries,
-  one per refresh) populated from the same state file
-  `collect_group_data` reads. `query_metric_series` extends the
-  SQLite tail with any deque samples newer than the most recent
-  flush, deduped by timestamp. The deque is bounded and bytes
-  cheap; no extra DB I/O.
-
-## Footer hints
-
-The bottom-row hints in `eneru monitor` interpolate the current
-cycle state -- so an operator can see at a glance what the next
-keypress will do:
-
-```
- <Q>  Quit    <R>  Refresh    <M>  More logs   \
- <G>  Graph: charge    <T>  Time: 1h    <U>  UPS: 1/2
+```bash
+sudo eneru monitor --once --events-only --time 24h --config /etc/ups-monitor/config.yaml
 ```
 
-`<U>` is rendered as `UPS` (without the index) when only one UPS is
-configured.
+## Graph metrics
+
+| Metric | Source |
+|--------|--------|
+| `charge` | Battery charge percentage |
+| `load` | UPS load percentage |
+| `voltage` | Input voltage |
+| `runtime` | UPS estimated runtime |
+
+The graph uses Unicode Braille cells when the terminal supports them. In non-UTF-8 terminals it falls back to block characters.
+
+## Data source
+
+Graphs read from the per-UPS SQLite database under `statistics.db_directory`. The TUI opens the DB read-only and uses the same retention tiers described in [Statistics](statistics.md).
+
+| Range | Data tier |
+|-------|-----------|
+| `1h`, `6h`, `24h` | Raw samples |
+| `7d` | Five-minute aggregates |
+| `30d` | Five-minute or hourly aggregates depending on retention |
+
+The daemon flushes samples about every 10 seconds. The TUI blends in the newest state-file values so the graph edge does not lag far behind the live status panel.
+
+### Graph freshness timeline
+
+The graph freshness behavior is tied to the stats writer's 10-second flush interval and the live-sample blending path in `src/eneru/tui.py`.
+
+| Time | Data source | What the operator sees |
+|------|-------------|------------------------|
+| 0s | Daemon polls UPS | State file updates quickly |
+| 1s-9s | SQLite has not flushed yet | Status panel is current; graph tail is blended from live state |
+| About 10s | Stats writer flushes | SQLite catches up with recent samples |
+| Every 300s | Aggregation runs | Longer-range graphs use compact aggregate rows |
+| TUI exits | Read-only DB handle closes | Daemon writer is unaffected |
+
+## Events panel
+
+The Recent Events panel reads the SQLite `events` table. If no database exists yet, it falls back to the log file.
+
+In multi-UPS mode, event lines include the UPS label:
+
+```text
+14:03:12  [Rack A] ON_BATTERY: Battery: 85%
+14:03:14  [Rack B] POWER_RESTORED: Outage 6s
+```
 
 ## Troubleshooting
 
-**The graph is empty.**
-The daemon has not flushed any samples yet (writer flushes every 10s),
-or the TUI's `db_directory` does not match the daemon's. Check with:
+| Symptom | Check |
+|---------|-------|
+| Empty graph | Wait at least one stats flush, usually 10 seconds |
+| Empty graph after minutes | Confirm `statistics.db_directory` matches the running daemon config |
+| Events panel falls back to logs | Database missing, unreadable, or not created yet |
+| Block graph instead of Braille | Terminal locale or font lacks Braille support |
+| TUI looks misaligned | Use a UTF-8 locale and a monospace font with emoji width support |
+
+Useful checks:
 
 ```bash
-ls -la /var/lib/eneru/
-sqlite3 /var/lib/eneru/<sanitized-ups-name>.db "SELECT COUNT(*) FROM samples"
+sudo ls -la /var/lib/eneru/
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db "SELECT COUNT(*) FROM samples;"
+sqlite3 /var/lib/eneru/UPS-192-168-1-100.db "SELECT COUNT(*) FROM events;"
 ```
-
-**The graph shows blocks instead of Braille dots.**
-The locale is not UTF-8 capable, or the terminal font lacks Braille
-glyphs. Both are normal in stripped-down minimal images. The block
-fallback is accurate; only the rendering changes.
-
-## Events panel: sourced from SQLite
-
-The TUI's "Recent Events" panel reads from each UPS's `events` table
-in the per-UPS SQLite store. When no DB is present (fresh installs
-before the first poll, sandbox runs without a writable `db_directory`,
-etc.), the panel falls back to tailing the log file. Same behaviour
-as v5.0.
-
-In multi-UPS mode, each line is prefixed with the UPS label and rows
-from different sources interleave by timestamp:
-
-```
-14:03:12  [Rack PSU-A] ON_BATTERY: Battery: 85%
-14:03:14  [Rack PSU-B] ON_BATTERY: Battery: 82%
-14:03:18  [Rack PSU-A] POWER_RESTORED: Outage 6s
-```
-
-For headless or scripted use, `eneru monitor --once --events-only`
-prints just the events list:
-
-```bash
-eneru monitor --once --events-only --time 24h
-```
-
-## See also
-
-- [Statistics](statistics.md). The SQLite store the TUI reads from.
-- [Configuration](configuration.md). `statistics:` and other settings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Eneru
-site_description: Intelligent UPS Monitoring & Shutdown Orchestration for NUT
+site_description: UPS monitoring and shutdown orchestration for NUT
 site_url: https://eneru.readthedocs.io/
 repo_url: https://github.com/m4r1k/Eneru
 repo_name: m4r1k/Eneru
@@ -30,19 +30,24 @@ theme:
     repo: fontawesome/brands/github
 
 nav:
-  - Home: index.md
-  - Getting Started: getting-started.md
-  - Configuration: configuration.md
-  - Redundancy Groups: redundancy-groups.md
-  - Statistics: statistics.md
-  - TUI Graphs: tui-graphs.md
-  - Shutdown Triggers: triggers.md
-  - Notifications: notifications.md
-  - Remote Servers: remote-servers.md
-  - Testing: testing.md
-  - Troubleshooting: troubleshooting.md
-  - Roadmap: roadmap.md
-  - Changelog: changelog.md
+  - Overview:
+      - Home: index.md
+      - Getting started: getting-started.md
+      - Architecture: architecture.md
+  - Configuration:
+      - Configuration reference: configuration.md
+      - Shutdown triggers: triggers.md
+      - Redundancy groups: redundancy-groups.md
+      - Notifications: notifications.md
+      - Remote servers: remote-servers.md
+  - Operations:
+      - Monitor and graphs: tui-graphs.md
+      - Statistics: statistics.md
+      - Troubleshooting: troubleshooting.md
+  - Project:
+      - Testing: testing.md
+      - Roadmap: roadmap.md
+      - Changelog: changelog.md
 
 markdown_extensions:
   - tables


### PR DESCRIPTION
## Summary

Restructures the docs/ tree for ReadTheDocs: groups the 13 flat pages under **Overview / Configuration / Operations / Project**, adds a new `architecture.md`, and trims verbosity across `triggers.md`, `notifications.md`, and `configuration.md` (~37% net reduction). A second commit restores load-bearing reference content trimmed in the first pass and runs a humanizer touch-up on prose-heavy pages.

## What changed

**Commit 1 — `docs: revamp ReadTheDocs structure`**

- **Nav regrouping** in `mkdocs.yml`: flat 13-page list → 4 sections (Overview, Configuration, Operations, Project)
- **New `architecture.md`** (290 lines): ASCII diagrams + file pointers for the per-UPS loop, mixin pattern, multi-UPS coordinator, redundancy evaluator, persistent notifications, stats writer, config validation, packaging
- **Trims** across `triggers.md` (-410 lines), `notifications.md` (-280 lines), `configuration.md` (-250 lines), `troubleshooting.md` (-180 lines)

**Commit 2 — `docs: restore reference depth dropped during ReadTheDocs revamp`**

- `triggers.md`: restored vendor UPS transfer-point table (APC SUA/SMT/SMC, APC default-wide, APC SMX/Symmetra, Eaton 5P/9PX, CyberPower CP1500, Tripp Lite SMART) — needed for picking `voltage_sensitivity` per unit
- `triggers.md`: voltage preset grid expanded from 3 to 7 standard nominal voltages (added 100 V Japan, 127 V Latam, 208 V US 3-phase, 220 V China)
- `notifications.md`: 5-row conceptual lifecycle table replaced with the full 8-row emoji-prefixed reference (verified against `src/eneru/lifecycle.py`) so operators can look up `📊 Recovered` / `📦 Upgraded` / `🔄 Restarted` directly
- `configuration.md`: cross-link from `connection_loss_grace_period` rows to the troubleshooting flap section; enriched `voltage_sensitivity` pointer to mention the new vendor table
- `architecture.md`, `testing.md`: humanizer pass — dropped "solves a real outage problem" framing, "is not just X. It Y" negative parallelism, and signposting (4 small touch-ups in architecture.md, one sentence rewrite in testing.md)

## Test plan

- [x] `mkdocs serve` renders all pages without broken links
- [x] Spot-check the new tables: vendor UPS transfer points, expanded voltage grid (7 rows), 8-row emoji-prefixed lifecycle table
- [x] Confirm `troubleshooting.md#intermittent-nut-drops` anchor resolves from `configuration.md`
- [x] CI validate matrix passes (E2E suite unaffected by docs-only changes)
- [x] Optional reader test: paste `triggers.md` into a fresh Claude session and ask "If I'm tuning Eneru for an APC Smart-UPS on 230 V, where do I look?" — should resolve from one page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps the ReadTheDocs site with a clearer nav (Overview / Configuration / Operations / Project), a new `architecture.md`, and tighter prose across pages. Restores key reference tables and links so operators keep full guidance with the cleaner layout.

- **New Features**
  - Added `architecture.md` with runtime diagrams and file pointers.
  - Expanded voltage presets from 3 to 7 (incl. 100 V JP, 127 V LATAM, 208 V US 3φ, 220 V CN).
  - Replaced the simplified lifecycle table with the full 8-row emoji reference.

- **Refactors**
  - Regrouped nav in `mkdocs.yml` and reduced verbosity across major pages.
  - Restored vendor UPS transfer-point table and other load-bearing references needed for `voltage_sensitivity`.
  - Added helpful cross-links (e.g., `connection_loss_grace_period` → troubleshooting) and polished wording on prose-heavy pages.

<sup>Written for commit 04b74f0cffb29a343b65e200b1ca5018acad516b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

