### PR TITLE
fix(tui): voltage filter, events priority filter, --graph interactive

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **`eneru tui --graph voltage` was silently ignored in interactive mode.**
+  The CLI flag now seeds the initial graph metric (and `--time` seeds the
+  initial window) even without `--once`. Pressing `<G>` / `<T>` still cycles
+  from there.
+- **A single phantom 0V sample squashed the voltage band into a one-pixel
+  strip at the top of the graph.** Two layers of fix: the writer drops
+  on-line `input.voltage <= 0` rows at sample time (with `ups.status` in
+  context, so real outages — `OB` / `FSD` — still record a legitimate dip
+  to 0V), and the graph panel auto-scales unbounded metrics from the
+  5th/95th percentile so any leftover outliers don't dictate the band.
+
+### Added
+- **`--verbose` / `-v` flag** on `eneru tui` (live + `--once`): widens the
+  events filter to include low-priority chatter alongside the priority
+  defaults. The live TUI also gains a `<V>` keybind to toggle in-session.
+- **`--full-history` flag** for `eneru tui --once`: ignore the `--time`
+  window and query the events table from the beginning. Rejects with
+  ``error: --full-history requires --once`` (exit 2) if combined with the
+  live TUI.
+
+### Changed
+- **Events panel now defaults to priority-only** in both live TUI and
+  `eneru tui --once --events-only`. Daemon lifecycle, shutdown triggers,
+  and power transitions surface; per-condition chatter
+  (`VOLTAGE_FLAP_SUPPRESSED`, etc.) is hidden. Migration: scripts that
+  grep the `--once --events-only` output for low-priority event types
+  must add `--verbose`.
+- Live TUI events panel default cap raised from 8 to 20 rows so a few
+  voltage transitions don't push the daemon-level history off-screen.
+
+---
+
 ## [5.2.1] - 2026-04-24
 
 Bug-fix release for two v5.2.0 regressions. Drop-in upgrade. See

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,5 +442,5 @@ Example package commands:
 sudo eneru validate --config /etc/ups-monitor/config.yaml
 sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
 sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
-sudo eneru monitor --once --events-only --verbose --full-history --config /etc/ups-monitor/config.yaml
+sudo /opt/ups-monitor/eneru.py monitor --once --events-only --verbose --full-history --config /etc/ups-monitor/config.yaml
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,9 +430,11 @@ Common flags:
 | `run` | `--exit-after-shutdown` | Exit after a shutdown sequence finishes |
 | `monitor` | `--once` | Print one status snapshot |
 | `monitor` | `--interval` | TUI refresh interval |
-| `monitor` | `--graph {charge,load,voltage,runtime}` | Render a graph with `--once` |
-| `monitor` | `--time {1h,6h,24h,7d,30d}` | Graph or event window |
+| `monitor` | `--graph {charge,load,voltage,runtime}` | Initial graph metric (interactive: cycle with `<G>`) |
+| `monitor` | `--time {1h,6h,24h,7d,30d}` | Initial graph / event window (interactive seeds the cycle, still toggle with `<T>`) |
 | `monitor` | `--events-only` | Print recent events only |
+| `monitor` | `--verbose`, `-v` | Show low-priority events too (default: priority only); `<V>` toggles in-session |
+| `monitor` | `--full-history` | Ignore `--time`, query events from the beginning (`--once` only) |
 
 Example package commands:
 
@@ -440,4 +442,5 @@ Example package commands:
 sudo eneru validate --config /etc/ups-monitor/config.yaml
 sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
 sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
+sudo eneru monitor --once --events-only --verbose --full-history --config /etc/ups-monitor/config.yaml
 ```

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -368,6 +368,20 @@ def _cmd_deliver_stop(args):
 
 def _cmd_monitor(args):
     """Launch the TUI dashboard."""
+    # Validate flag combinations BEFORE _load_config so the rejection
+    # isn't preceded by a "Configuration loaded from: ..." message --
+    # that ordering looked like the validate-then-fail had succeeded.
+    # argparse can't easily express "this flag requires --once" so we
+    # do it here, exit with the same code argparse would use, and
+    # mimic its ``error: ...`` stderr format so log scrapers keep
+    # working.
+    if getattr(args, "full_history", False) and not args.once:
+        sys.stderr.write(
+            "eneru tui: error: --full-history requires --once "
+            "(interactive TUI is real-time)\n"
+        )
+        sys.exit(2)
+
     config = _load_config(args)
 
     from eneru.tui import run_tui, run_once
@@ -378,9 +392,17 @@ def _cmd_monitor(args):
             graph_metric=getattr(args, "graph", None),
             time_range=getattr(args, "time", "1h"),
             events_only=getattr(args, "events_only", False),
+            verbose=getattr(args, "verbose", False),
+            full_history=getattr(args, "full_history", False),
         )
     else:
-        run_tui(config, interval=args.interval)
+        run_tui(
+            config,
+            interval=args.interval,
+            initial_graph=getattr(args, "graph", None),
+            initial_time_range=getattr(args, "time", "1h"),
+            verbose=getattr(args, "verbose", False),
+        )
 
 
 def main():
@@ -433,11 +455,21 @@ def main():
                        help="Refresh interval in seconds (default: 5)")
         p.add_argument("--graph",
                        choices=["charge", "load", "voltage", "runtime"],
-                       help="With --once: render an ASCII/Braille graph for the metric")
+                       help="Initial graph metric. With --once renders a Braille snapshot; "
+                            "in interactive TUI pre-selects the metric (still cycle with <G>)")
         p.add_argument("--time", default="1h",
-                       help="With --once + --graph: time range (1h/6h/24h/7d/30d)")
+                       help="Initial graph time range (1h/6h/24h/7d/30d). Applies to "
+                            "--once snapshots and to the interactive TUI's initial view")
         p.add_argument("--events-only", action="store_true",
                        help="With --once: print only the events list (SQLite, log-tail fallback)")
+        p.add_argument("--verbose", "-v", action="store_true",
+                       help="Show low-priority events alongside the priority defaults "
+                            "(daemon lifecycle, shutdown triggers, power transitions). "
+                            "Applies to both --once and the interactive TUI; toggle "
+                            "in-session with <V>")
+        p.add_argument("--full-history", action="store_true",
+                       help="Ignore --time and query the events table from the beginning. "
+                            "Only valid with --once")
         p.set_defaults(func=_cmd_monitor)
 
     mon_parser = subparsers.add_parser("monitor", help="Launch real-time TUI dashboard")

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -376,8 +376,16 @@ def _cmd_monitor(args):
     # mimic its ``error: ...`` stderr format so log scrapers keep
     # working.
     if getattr(args, "full_history", False) and not args.once:
+        # Compose the prefix from the actual invocation so users running
+        # ``eneru monitor`` don't get an "eneru tui: ..." message and
+        # vice versa. ``args.command`` is set by argparse via the
+        # subparsers' ``dest="command"``; fall back to ``argv[1]`` if
+        # that's somehow missing (defensive: monitor / tui are aliases).
+        sub = getattr(args, "command", None) or (
+            sys.argv[1] if len(sys.argv) > 1 else "monitor"
+        )
         sys.stderr.write(
-            "eneru tui: error: --full-history requires --once "
+            f"eneru {sub}: error: --full-history requires --once "
             "(interactive TUI is real-time)\n"
         )
         sys.exit(2)

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -67,6 +67,31 @@ def _to_int(value) -> Optional[int]:
     return int(f) if f is not None else None
 
 
+def _to_input_voltage(value, *, ups_status: str) -> Optional[float]:
+    """Sanitize ``input.voltage`` against on-line phantom zeros.
+
+    A reading of 0 V is meaningful when the UPS is on battery (mains is
+    actually gone, the inverter holds the output). On line, 0 V is a
+    sensor glitch or poll race against a NUT driver mid-transition --
+    keeping it pollutes the graph and drags the AVG/MIN aggregates. Drop
+    only the latter case; outage history stays intact.
+
+    The "is OB present" predicate matches the convention used by
+    ``_handle_on_battery`` in ``monitor.py`` -- ``OL OB`` (a transient
+    mid-transition status) is treated as "on battery", so its 0 V is
+    kept. ``BOOST`` / ``TRIM`` / ``BYPASS`` etc. are AVR/bypass states
+    *of* the on-line condition; they're excluded from the drop set
+    below by the explicit ``"OL" in status`` check.
+    """
+    f = _to_float(value)
+    if f is None:
+        return None
+    status = ups_status or ""
+    if f <= 0.0 and "OL" in status and "OB" not in status and "FSD" not in status:
+        return None
+    return f
+
+
 def _sample_from_ups_data(
     ups_data: Dict[str, str],
     *,
@@ -81,13 +106,14 @@ def _sample_from_ups_data(
     ``executemany`` works against any schema version reached via
     additive migrations.
     """
+    status = ups_data.get("ups.status", "")
     return (
         int(ts if ts is not None else time.time()),
-        ups_data.get("ups.status", ""),
+        status,
         _to_float(ups_data.get("battery.charge")),
         _to_float(ups_data.get("battery.runtime")),
         _to_float(ups_data.get("ups.load")),
-        _to_float(ups_data.get("input.voltage")),
+        _to_input_voltage(ups_data.get("input.voltage"), ups_status=status),
         _to_float(ups_data.get("output.voltage")),
         float(depletion_rate or 0.0),
         int(time_on_battery or 0),

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -37,8 +37,30 @@ TIME_RANGE_SECONDS = {
 # table is one row per power event, not per poll, so even years of
 # history stay tiny) and lets the operator scroll through with the
 # arrow keys.
-EVENTS_MAX_ROWS_NORMAL = 8
+EVENTS_MAX_ROWS_NORMAL = 20
 EVENTS_MAX_ROWS_MORE = 500
+
+# Default-visible event types. The events table accumulates a mix of
+# load-bearing milestones (daemon lifecycle, shutdown triggers, power
+# transitions) and chatter that's useful when debugging but noisy
+# day-to-day (per-condition voltage warnings, suppressed flaps, etc.).
+# The TUI ships filtered to the milestones; ``--verbose`` (CLI) and the
+# ``<V>`` key (interactive) widen the filter to include everything.
+PRIORITY_EVENTS = frozenset({
+    "DAEMON_START",
+    "DAEMON_STOP",
+    "DAEMON_RESTARTED",
+    "DAEMON_UPGRADED",
+    "DAEMON_RECOVERED",
+    "EMERGENCY_SHUTDOWN_INITIATED",
+    "SHUTDOWN_SEQUENCE_COMPLETE",
+    "POWER_RESTORED",
+    "ON_BATTERY",
+    "VOLTAGE_LOW",
+    "VOLTAGE_HIGH",
+    "CONNECTION_LOST",
+    "CONNECTION_RESTORED",
+})
 
 # Map graph modes to (column, unit_suffix, y_min, y_max, value_formatter).
 # value_formatter takes a float and returns the user-facing display
@@ -344,6 +366,7 @@ def query_events_for_display(
     time_range_seconds: Optional[int] = None,
     *,
     max_events: int = EVENTS_MAX_ROWS_MORE,
+    priority_only: bool = True,
 ) -> List[str]:
     """Pull events from each UPS's SQLite store, sorted by timestamp.
 
@@ -352,6 +375,11 @@ def query_events_for_display(
     formatted display strings ready to drop into the TUI events panel.
     Returns an empty list when no per-UPS DB exists -- callers should
     fall back to ``parse_log_events`` in that case.
+
+    ``priority_only=True`` (default) limits the result to event types in
+    :data:`PRIORITY_EVENTS` so the panel surfaces daemon and power
+    transitions instead of being crowded out by per-condition chatter.
+    Pass ``False`` (CLI ``--verbose`` / TUI ``<V>``) to include all rows.
     """
     end = int(time.time())
     start = 0 if time_range_seconds is None else end - max(60, int(time_range_seconds))
@@ -373,6 +401,8 @@ def query_events_for_display(
             finally:
                 store._conn = None
             for ts, etype, detail in events:
+                if priority_only and etype not in PRIORITY_EVENTS:
+                    continue
                 rows.append((int(ts), group.ups.label, etype, detail or ""))
         finally:
             try:
@@ -713,7 +743,7 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
                        events: List[str], show_more: bool,
                        *, graph_mode: str = "off", time_range: str = "1h",
                        ups_index: int = 0, ups_total: int = 1,
-                       scroll_offset: int = 0):
+                       scroll_offset: int = 0, verbose: bool = False):
     """Render the logs panel with yellow/gold background, edge to edge.
 
     The bottom-row key hints reflect the *current* graph mode, time
@@ -782,6 +812,10 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
     x = 2
     ups_descr = (f"UPS: {ups_index + 1}/{ups_total}" if ups_total > 1
                  else "UPS")
+    # Hint order: most useful keys first so narrow terminals (which drop
+    # tail hints via the width check below) keep the actionable cycles
+    # visible. <V> is shorter than "Verbose: ..." would imply -- "Verb"
+    # keeps a 120-col terminal showing every hint.
     hints = (
         ("<Q>", "Quit"),
         ("<R>", "Refresh"),
@@ -790,6 +824,7 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
         ("<G>", f"Graph: {graph_mode}"),
         ("<T>", f"Time: {time_range}"),
         ("<U>", ups_descr),
+        ("<V>", f"Verb: {'on' if verbose else 'off'}"),
     )
     for label, descr in hints:
         if x + len(label) + len(descr) + 6 > width:
@@ -811,6 +846,34 @@ def cycle(values: tuple, current: str) -> str:
     except ValueError:
         return values[0]
     return values[(idx + 1) % len(values)]
+
+
+def _robust_bounds(values: List[float]) -> Tuple[float, float]:
+    """5th/95th percentile of ``values``, with a min(values)/max(values)
+    fallback for short series. Used by the graph panel to keep a single
+    outlier (e.g. a stray 0V from a NUT poll race) from squashing the
+    plotted band into a single row at the top of the chart.
+
+    When the percentile bounds collapse (every sample inside the 5..95
+    band is identical), the caller's pad-around-flat logic handles the
+    ``hi == lo`` case -- we deliberately do *not* fall back to
+    min/max here, because that would re-introduce the very outlier the
+    helper exists to clip.
+
+    At ``n < 40`` only one outlier can be clipped per side; with two or
+    more bottom-side outliers in a 20-sample series, one survives into
+    the bound. Acceptable for our use case (the writer-side filter at
+    ``stats._to_input_voltage`` has already dropped most phantom zeros).
+    """
+    if not values:
+        return 0.0, 0.0  # caller guards but defensive: don't raise on min([])
+    n = len(values)
+    if n < 20:
+        return min(values), max(values)
+    sorted_vals = sorted(values)
+    lo = sorted_vals[int(n * 0.05)]
+    hi = sorted_vals[min(n - 1, int(n * 0.95))]
+    return lo, hi
 
 
 def render_graph_panel(stdscr, y_start: int, y_end: int, width: int,
@@ -859,8 +922,19 @@ def render_graph_panel(stdscr, y_start: int, y_end: int, width: int,
     # the actual range, not "0-235".
     obs_min = min(values)
     obs_max = max(values)
-    y_min = cfg_y_min if cfg_y_min is not None else obs_min
-    y_max = cfg_y_max if cfg_y_max is not None else obs_max
+    if cfg_y_min is None or cfg_y_max is None:
+        # Unbounded metric (voltage / runtime). A single outlier -- e.g.
+        # a phantom 0V sample left over from before the on-line zero
+        # filter -- would otherwise drag obs_min to 0 and squash the
+        # meaningful band into one row at the top of the chart. Use the
+        # 5th/95th percentile when there's enough data to compute one;
+        # outliers still plot (clipped) at the band edges thanks to the
+        # norm-clamp in BrailleGraph.plot.
+        scale_min, scale_max = _robust_bounds(values)
+    else:
+        scale_min, scale_max = obs_min, obs_max
+    y_min = cfg_y_min if cfg_y_min is not None else scale_min
+    y_max = cfg_y_max if cfg_y_max is not None else scale_max
     if y_max <= y_min:  # single sample or flat line
         pad = max(abs(y_min) * 0.05, 1.0)
         y_min -= pad
@@ -921,8 +995,22 @@ def render_graph_panel(stdscr, y_start: int, y_end: int, width: int,
         safe_addstr(stdscr, y_end - 1, 0, footer, gray_attr)
 
 
-def run_tui(config: Config, interval: int = 5):
-    """Run the curses TUI dashboard."""
+def run_tui(config: Config, interval: int = 5, *,
+            initial_graph: Optional[str] = None,
+            initial_time_range: str = "1h",
+            initial_ups_index: int = 0,
+            verbose: bool = False):
+    """Run the curses TUI dashboard.
+
+    Optional kwargs let the CLI pre-seed the cycle state so flags like
+    ``--graph voltage --time 7d`` open the dashboard already showing the
+    requested view, instead of starting on the default (graph off) and
+    forcing the operator to press <G>/<T> to get there.
+
+    ``verbose=True`` opens the events panel showing all event types
+    (matching ``--verbose`` on the CLI). The ``<V>`` key toggles this
+    in-session.
+    """
     def _main(stdscr):
         init_colors()
         curses.curs_set(0)
@@ -936,9 +1024,16 @@ def run_tui(config: Config, interval: int = 5):
         stdscr.keypad(True)
 
         show_more = False
-        graph_mode = "off"           # G key cycles through GRAPH_MODES
-        time_range = "1h"            # T key cycles through TIME_RANGES
-        ups_index = 0                # U key cycles which UPS the graph shows
+        graph_mode = (
+            initial_graph if initial_graph in GRAPH_MODES else "off"
+        )
+        time_range = (
+            initial_time_range if initial_time_range in TIME_RANGES else "1h"
+        )
+        ups_index = max(
+            0, min(int(initial_ups_index or 0), max(0, len(config.ups_groups) - 1))
+        )
+        events_verbose = bool(verbose)
         events_scroll = 0            # ↑/↓ scrolls events panel; 0 = bottom
 
         while True:
@@ -1000,6 +1095,7 @@ def run_tui(config: Config, interval: int = 5):
             )
             log_events = query_events_for_display(
                 config, max_events=events_cap,
+                priority_only=not events_verbose,
             )
             if not log_events:
                 log_events = parse_log_events(
@@ -1029,7 +1125,8 @@ def run_tui(config: Config, interval: int = 5):
                               time_range=time_range,
                               ups_index=ups_index,
                               ups_total=len(config.ups_groups) or 1,
-                              scroll_offset=events_scroll)
+                              scroll_offset=events_scroll,
+                              verbose=events_verbose)
 
             # Move cursor to bottom-right to avoid visual artifacts
             try:
@@ -1048,6 +1145,9 @@ def run_tui(config: Config, interval: int = 5):
                 continue
             elif key in (ord('m'), ord('M')):
                 show_more = not show_more
+            elif key in (ord('v'), ord('V')):
+                events_verbose = not events_verbose
+                events_scroll = 0  # reset so the new (longer/shorter) list anchors at bottom
             elif key in (ord('g'), ord('G')):
                 graph_mode = cycle(GRAPH_MODES, graph_mode)
             elif key in (ord('t'), ord('T')):
@@ -1135,18 +1235,30 @@ def render_graph_text(
 
 
 def run_once(config: Config, *, graph_metric: Optional[str] = None,
-             time_range: str = "1h", events_only: bool = False):
+             time_range: str = "1h", events_only: bool = False,
+             verbose: bool = False, full_history: bool = False):
     """Print a status snapshot to stdout and exit.
 
     With ``events_only=True`` the status / resource summary and graph
     block are skipped -- only the events list (from SQLite if available,
     otherwise the log tail) is printed. Useful for scripts and CI.
+
+    ``verbose=True`` includes low-priority chatter alongside the
+    :data:`PRIORITY_EVENTS` defaults. ``full_history=True`` ignores the
+    ``time_range`` window and queries the events table from epoch.
     """
     if events_only:
-        seconds = TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
-        events = query_events_for_display(config, seconds, max_events=50)
+        if full_history:
+            window = None
+        else:
+            window = TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
+        events = query_events_for_display(
+            config, window, max_events=500 if full_history else 50,
+            priority_only=not verbose,
+        )
         if not events:
-            events = parse_log_events(config.logging.file or "", max_events=50)
+            events = parse_log_events(config.logging.file or "",
+                                      max_events=500 if full_history else 50)
         if events:
             for line in events:
                 print(line)

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -286,8 +286,14 @@ def parse_state_file(path: Path) -> Optional[Dict[str, str]]:
         return None
 
 
-def parse_log_events(log_path: str, max_events: int = 8) -> List[str]:
-    """Read recent power events from the log file tail (fallback path)."""
+def parse_log_events(log_path: str,
+                     max_events: Optional[int] = 8) -> List[str]:
+    """Read recent power events from the log file tail (fallback path).
+
+    ``max_events=None`` returns every matching event in the file, no
+    cap. Used when the CLI passes ``--full-history`` and the SQLite
+    DB isn't present so we fall back to the log tail.
+    """
     INCLUDE = (
         "POWER EVENT", "Status changed", "SHUTDOWN", "shutdown",
         "CRITICAL", "FSD", "flap", "Flap", "On battery",
@@ -310,7 +316,7 @@ def parse_log_events(log_path: str, max_events: int = 8) -> List[str]:
                 continue
             if any(inc in line for inc in INCLUDE):
                 events.append(line)
-                if len(events) >= max_events:
+                if max_events is not None and len(events) >= max_events:
                     break
         events.reverse()
         return events
@@ -365,7 +371,7 @@ def query_events_for_display(
     config: Config,
     time_range_seconds: Optional[int] = None,
     *,
-    max_events: int = EVENTS_MAX_ROWS_MORE,
+    max_events: Optional[int] = EVENTS_MAX_ROWS_MORE,
     priority_only: bool = True,
 ) -> List[str]:
     """Pull events from each UPS's SQLite store, sorted by timestamp.
@@ -380,6 +386,11 @@ def query_events_for_display(
     :data:`PRIORITY_EVENTS` so the panel surfaces daemon and power
     transitions instead of being crowded out by per-condition chatter.
     Pass ``False`` (CLI ``--verbose`` / TUI ``<V>``) to include all rows.
+
+    ``max_events=None`` disables the row cap entirely. Used by the CLI
+    ``--full-history`` path so that "from the beginning" actually means
+    every row in the events table -- a finite cap of 500 silently
+    dropped older events on long-running installs.
     """
     end = int(time.time())
     start = 0 if time_range_seconds is None else end - max(60, int(time_range_seconds))
@@ -414,7 +425,8 @@ def query_events_for_display(
         return []  # signal "no DB" so callers can fall back
 
     rows.sort(key=lambda r: r[0])
-    rows = rows[-max_events:]
+    if max_events is not None:
+        rows = rows[-max_events:]
     return [_format_event_line(ts, label, etype, detail, multi_ups)
             for ts, label, etype, detail in rows]
 
@@ -854,6 +866,13 @@ def _robust_bounds(values: List[float]) -> Tuple[float, float]:
     outlier (e.g. a stray 0V from a NUT poll race) from squashing the
     plotted band into a single row at the top of the chart.
 
+    Symmetric drop-count formulation: clip ``int(n * 0.05)`` samples
+    from each end of the sorted series. For ``n = 20`` that's one
+    sample per side -- ``lo = sorted[1]``, ``hi = sorted[18]`` --
+    cleanly excluding both extremes. The earlier ``int(n * 0.95)``
+    formulation produced ``sorted[19]`` (the actual max) and silently
+    no-op'd the helper at small n.
+
     When the percentile bounds collapse (every sample inside the 5..95
     band is identical), the caller's pad-around-flat logic handles the
     ``hi == lo`` case -- we deliberately do *not* fall back to
@@ -871,8 +890,9 @@ def _robust_bounds(values: List[float]) -> Tuple[float, float]:
     if n < 20:
         return min(values), max(values)
     sorted_vals = sorted(values)
-    lo = sorted_vals[int(n * 0.05)]
-    hi = sorted_vals[min(n - 1, int(n * 0.95))]
+    drop = int(n * 0.05)  # number of samples to clip from each end
+    lo = sorted_vals[drop]
+    hi = sorted_vals[n - 1 - drop]
     return lo, hi
 
 
@@ -1247,18 +1267,21 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
     :data:`PRIORITY_EVENTS` defaults. ``full_history=True`` ignores the
     ``time_range`` window and queries the events table from epoch.
     """
+    # When --full-history is set, the cap is removed entirely (None) so
+    # "from the beginning" means every row, not "the most recent 500".
+    # Otherwise the events-only window caps at 50 to keep stdout sane;
+    # the snapshot path uses a smaller 10-row tail.
+    events_cap = None if full_history else 50
+
     if events_only:
-        if full_history:
-            window = None
-        else:
-            window = TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
+        window = None if full_history else TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
         events = query_events_for_display(
-            config, window, max_events=500 if full_history else 50,
+            config, window, max_events=events_cap,
             priority_only=not verbose,
         )
         if not events:
             events = parse_log_events(config.logging.file or "",
-                                      max_events=500 if full_history else 50)
+                                      max_events=events_cap)
         if events:
             for line in events:
                 print(line)
@@ -1304,10 +1327,19 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
         if i < group_count - 1:
             print()
 
-    seconds = TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
-    events = query_events_for_display(config, seconds, max_events=10)
+    # Snapshot path: same flag semantics as the events-only branch
+    # above. --full-history widens the time window AND the row cap;
+    # --verbose drops the priority filter so low-priority chatter can
+    # surface here too. Pre-fix this section silently ignored both.
+    snapshot_window = None if full_history else TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
+    snapshot_cap = None if full_history else 10
+    events = query_events_for_display(
+        config, snapshot_window, max_events=snapshot_cap,
+        priority_only=not verbose,
+    )
     if not events:
-        events = parse_log_events(config.logging.file or "", max_events=10)
+        events = parse_log_events(config.logging.file or "",
+                                  max_events=snapshot_cap)
     if events:
         print()
         print("Recent Events:")

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -220,18 +220,56 @@ if [ ! -f "$DB" ]; then
 fi
 
 # Inject a known event row directly so we have something to assert.
+# TEST31_MARKER is not a priority event type (5.2.2+ default filter), so
+# verify with --verbose -- the test scope is "events panel reads from
+# SQLite", not "the priority filter is correct".
 NOW=$(date +%s)
 sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($NOW, 'TEST31_MARKER', 'e2e injected');"
 
-# Read back via the new --events-only mode.
-eneru monitor --once --events-only --time 1h --config $E2E_DIR/config-e2e-stats.yaml 2>&1 | tee /tmp/test31.log
+eneru monitor --once --events-only --verbose --time 1h --config $E2E_DIR/config-e2e-stats.yaml 2>&1 | tee /tmp/test31.log
 
 if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31.log; then
-  echo "FAIL: injected event not surfaced by --events-only"
+  echo "FAIL: injected event not surfaced by --events-only --verbose"
   tail -20 /tmp/test31.log
   exit 1
 fi
 echo "PASS: events panel reads from SQLite"
+
+# ----- 5.2.2: priority filter, --verbose, --full-history -----
+# These piggyback on the seeded DB (no extra container churn). Assert:
+#   1. Default (no --verbose) hides TEST31_MARKER but shows DAEMON_START.
+#   2. --verbose surfaces TEST31_MARKER again.
+#   3. --full-history requires --once -- without it the CLI must reject.
+
+echo ""
+echo "  --- 5.2.2 events filter checks ---"
+
+eneru monitor --once --events-only --time 1h --config $E2E_DIR/config-e2e-stats.yaml > /tmp/test31-priority.log 2>&1
+if grep -q "TEST31_MARKER" /tmp/test31-priority.log; then
+  echo "FAIL: priority-only default leaked TEST31_MARKER"
+  cat /tmp/test31-priority.log
+  exit 1
+fi
+if ! grep -q "DAEMON_START" /tmp/test31-priority.log; then
+  echo "FAIL: priority-only default dropped DAEMON_START"
+  cat /tmp/test31-priority.log
+  exit 1
+fi
+echo "  PASS: priority-only filter hides chatter, keeps DAEMON_START"
+
+# --full-history with --once is fine; --full-history without --once must
+# reject. We capture stderr because argparse-style errors land there.
+if eneru monitor --events-only --full-history --config $E2E_DIR/config-e2e-stats.yaml > /tmp/test31-fhfail.log 2>&1; then
+  echo "FAIL: --full-history without --once should have rejected"
+  cat /tmp/test31-fhfail.log
+  exit 1
+fi
+if ! grep -q "full-history" /tmp/test31-fhfail.log; then
+  echo "FAIL: --full-history rejection message missing the flag name"
+  cat /tmp/test31-fhfail.log
+  exit 1
+fi
+echo "  PASS: --full-history without --once rejects"
 )
 
 # ======================================================================

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -226,7 +226,7 @@ fi
 NOW=$(date +%s)
 sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($NOW, 'TEST31_MARKER', 'e2e injected');"
 
-eneru monitor --once --events-only --verbose --time 1h --config $E2E_DIR/config-e2e-stats.yaml 2>&1 | tee /tmp/test31.log
+eneru monitor --once --events-only --verbose --time 1h --config "$E2E_DIR/config-e2e-stats.yaml" 2>&1 | tee /tmp/test31.log
 
 if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31.log; then
   echo "FAIL: injected event not surfaced by --events-only --verbose"
@@ -239,12 +239,13 @@ echo "PASS: events panel reads from SQLite"
 # These piggyback on the seeded DB (no extra container churn). Assert:
 #   1. Default (no --verbose) hides TEST31_MARKER but shows DAEMON_START.
 #   2. --verbose surfaces TEST31_MARKER again.
-#   3. --full-history requires --once -- without it the CLI must reject.
+#   3. --full-history requires --once -- without it the CLI must reject
+#      with exit code 2 (argparse-style), not just any non-zero.
 
 echo ""
 echo "  --- 5.2.2 events filter checks ---"
 
-eneru monitor --once --events-only --time 1h --config $E2E_DIR/config-e2e-stats.yaml > /tmp/test31-priority.log 2>&1
+eneru monitor --once --events-only --time 1h --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-priority.log 2>&1
 if grep -q "TEST31_MARKER" /tmp/test31-priority.log; then
   echo "FAIL: priority-only default leaked TEST31_MARKER"
   cat /tmp/test31-priority.log
@@ -258,9 +259,21 @@ fi
 echo "  PASS: priority-only filter hides chatter, keeps DAEMON_START"
 
 # --full-history with --once is fine; --full-history without --once must
-# reject. We capture stderr because argparse-style errors land there.
-if eneru monitor --events-only --full-history --config $E2E_DIR/config-e2e-stats.yaml > /tmp/test31-fhfail.log 2>&1; then
-  echo "FAIL: --full-history without --once should have rejected"
+# reject. Capture the actual exit code and assert it's exactly 2 (the
+# code argparse uses for argument rejection); accepting "any non-zero"
+# would mask a regression that turned the rejection into a generic
+# crash with exit 1.
+set +e
+eneru monitor --events-only --full-history --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-fhfail.log 2>&1
+RC=$?
+set -e
+if [ "$RC" -eq 0 ]; then
+  echo "FAIL: --full-history without --once should have rejected (got exit 0)"
+  cat /tmp/test31-fhfail.log
+  exit 1
+fi
+if [ "$RC" -ne 2 ]; then
+  echo "FAIL: --full-history rejection should exit 2 (argparse convention), got $RC"
   cat /tmp/test31-fhfail.log
   exit 1
 fi
@@ -269,7 +282,7 @@ if ! grep -q "full-history" /tmp/test31-fhfail.log; then
   cat /tmp/test31-fhfail.log
   exit 1
 fi
-echo "  PASS: --full-history without --once rejects"
+echo "  PASS: --full-history without --once rejects with exit 2"
 )
 
 # ======================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,7 +164,32 @@ class TestCLIMonitorFlags:
                 assert "--full-history" in err
                 assert "--once" in err
                 assert "error:" in err
+                # 5.2.2 (CodeRabbit): the prefix must reflect the
+                # invocation -- "eneru tui:" when invoked as `tui`,
+                # "eneru monitor:" when invoked as `monitor`. The
+                # earlier hardcoded "eneru tui:" lied for monitor users.
+                assert "eneru tui:" in err
                 mock_run_tui.assert_not_called()
+
+    @pytest.mark.unit
+    def test_full_history_rejection_uses_invoked_subcommand_prefix(
+        self, tmp_path, capsys
+    ):
+        """5.2.2 (CodeRabbit): same rejection via the ``monitor`` alias
+        must say "eneru monitor:" -- not "eneru tui:". The error prefix
+        is composed from the actual subcommand the user typed."""
+        config_file = self._minimal_config(tmp_path)
+        with patch("eneru.tui.run_tui"):
+            with patch.object(sys, "argv", ["eneru", "monitor",
+                                            "-c", str(config_file),
+                                            "--full-history"]):
+                with pytest.raises(SystemExit):
+                    main()
+            err = capsys.readouterr().err
+            assert "eneru monitor:" in err, (
+                f"expected 'eneru monitor:' prefix, got: {err!r}"
+            )
+            assert "eneru tui:" not in err
 
     @pytest.mark.unit
     def test_full_history_with_once_accepted(self, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,8 @@ class TestCLITuiAlias:
         # Sanity: must include the monitor-specific options, not just
         # the universal --help / --config.
         assert {"--once", "--interval", "--graph", "--time",
-                "--events-only"}.issubset(opts_seen["tui"])
+                "--events-only", "--verbose", "--full-history"}.issubset(
+            opts_seen["tui"])
 
 
 class TestCLICompletion:
@@ -127,6 +128,74 @@ class TestCLICompletion:
                 main()
             # argparse exits 2 on invalid choice.
             assert exc_info.value.code == 2
+
+
+class TestCLIMonitorFlags:
+    """Test the new --verbose / --full-history flags on monitor/tui."""
+
+    def _minimal_config(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "ups:\n  name: 'TestUPS@localhost'\n"
+            "behavior:\n  dry_run: true\n"
+        )
+        return config_file
+
+    @pytest.mark.unit
+    def test_full_history_requires_once(self, tmp_path, capsys):
+        """``--full-history`` without ``--once`` must reject loudly with
+        argparse-style ``exit 2`` + ``error: ...`` on stderr. Live TUI
+        is real-time by definition; silently dropping the flag would
+        mask user error.
+        """
+        config_file = self._minimal_config(tmp_path)
+        # Patch run_tui at its source module (cli imports it locally) so
+        # if the reject regresses the curses entry point can't actually
+        # try to start.
+        with patch("eneru.tui.run_tui") as mock_run_tui:
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--full-history"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                # argparse uses exit 2 for argument-rejection. Match it.
+                assert exc_info.value.code == 2
+                err = capsys.readouterr().err
+                assert "--full-history" in err
+                assert "--once" in err
+                assert "error:" in err
+                mock_run_tui.assert_not_called()
+
+    @pytest.mark.unit
+    def test_full_history_with_once_accepted(self, tmp_path):
+        """The same flag with ``--once`` reaches run_once with
+        full_history=True."""
+        from eneru.tui import run_once
+        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
+            config_file = self._minimal_config(tmp_path)
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only",
+                                            "--full-history"]):
+                main()
+            mock_once.assert_called_once()
+            kwargs = mock_once.call_args.kwargs
+            assert kwargs.get("full_history") is True
+            assert kwargs.get("events_only") is True
+
+    @pytest.mark.unit
+    def test_verbose_short_form_accepted(self, tmp_path):
+        """``-v`` is the short form of ``--verbose`` and reaches
+        run_once with verbose=True."""
+        from eneru.tui import run_once
+        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
+            config_file = self._minimal_config(tmp_path)
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only", "-v"]):
+                main()
+            mock_once.assert_called_once()
+            assert mock_once.call_args.kwargs.get("verbose") is True
 
 
 class TestCLIValidateConfig:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -882,6 +882,94 @@ class TestBufferSample:
 
 
 # ===========================================================================
+# Voltage contextual filter (v5.2.2: drop on-line phantom 0V samples)
+# ===========================================================================
+
+class TestInputVoltageContextualFilter:
+    """``_to_input_voltage`` drops 0V (or negative) input.voltage readings
+    only when ups.status indicates the mains is supposed to be present.
+    On battery / FSD, 0V is a real measurement and must survive.
+    """
+
+    @pytest.mark.unit
+    def test_zero_voltage_on_line_dropped(self):
+        from eneru.stats import _to_input_voltage
+        assert _to_input_voltage("0", ups_status="OL") is None
+        assert _to_input_voltage("0.0", ups_status="OL CHRG") is None
+        assert _to_input_voltage(0, ups_status="OL") is None
+
+    @pytest.mark.unit
+    def test_zero_voltage_on_battery_kept(self):
+        # Real outage: input is 0V, output held by inverter. Must persist
+        # so the graph + aggregates show the dip.
+        from eneru.stats import _to_input_voltage
+        assert _to_input_voltage("0", ups_status="OB DISCHRG") == 0.0
+        assert _to_input_voltage("0.0", ups_status="OB") == 0.0
+        assert _to_input_voltage("0", ups_status="OB LB") == 0.0
+
+    @pytest.mark.unit
+    def test_zero_voltage_on_fsd_kept(self):
+        # Forced-shutdown state: mains is gone, 0V is the truth.
+        from eneru.stats import _to_input_voltage
+        assert _to_input_voltage("0", ups_status="OB FSD") == 0.0
+        assert _to_input_voltage("0", ups_status="FSD") == 0.0
+
+    @pytest.mark.unit
+    def test_normal_voltage_passes_through(self):
+        from eneru.stats import _to_input_voltage
+        assert _to_input_voltage("230.5", ups_status="OL") == 230.5
+        assert _to_input_voltage("120.0", ups_status="OL CHRG") == 120.0
+        assert _to_input_voltage("100", ups_status="OB") == 100.0
+
+    @pytest.mark.unit
+    def test_empty_and_non_numeric_return_none(self):
+        from eneru.stats import _to_input_voltage
+        assert _to_input_voltage("", ups_status="OL") is None
+        assert _to_input_voltage(None, ups_status="OL") is None
+        assert _to_input_voltage("abc", ups_status="OL") is None
+
+    @pytest.mark.unit
+    def test_negative_voltage_on_line_dropped(self):
+        # Some buggy drivers report -1.0 to signal "no reading". Treat
+        # the same as 0 -- a sensor signal, not a real measurement.
+        from eneru.stats import _to_input_voltage
+        assert _to_input_voltage("-1.0", ups_status="OL") is None
+
+    @pytest.mark.unit
+    def test_sample_roundtrip_filters_on_line_zero(self, store):
+        """End-to-end: buffer_sample with status=OL + input.voltage=0
+        results in a NULL input_voltage row in SQLite."""
+        store.buffer_sample({
+            "ups.status": "OL CHRG",
+            "battery.charge": "100",
+            "input.voltage": "0",
+            "output.voltage": "230.0",
+        })
+        store.flush()
+        row = store._conn.execute(
+            "SELECT input_voltage FROM samples"
+        ).fetchone()
+        assert row[0] is None
+
+    @pytest.mark.unit
+    def test_sample_roundtrip_keeps_on_battery_zero(self, store):
+        """End-to-end: buffer_sample with status=OB + input.voltage=0
+        keeps the 0.0 in SQLite (real outage signal)."""
+        store.buffer_sample({
+            "ups.status": "OB DISCHRG",
+            "battery.charge": "85",
+            "input.voltage": "0",
+            "output.voltage": "230.0",
+        })
+        store.flush()
+        row = store._conn.execute(
+            "SELECT input_voltage, status FROM samples"
+        ).fetchone()
+        assert row[0] == 0.0
+        assert row[1] == "OB DISCHRG"
+
+
+# ===========================================================================
 # flush + aggregate + purge
 # ===========================================================================
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1238,6 +1238,35 @@ class TestQueryEventsForDisplay:
         assert "ancient" in full[0]
         assert "recent" in full[1]
 
+    @pytest.mark.unit
+    def test_max_events_none_disables_cap(self, tmp_path):
+        """5.2.2 (CodeRabbit P1): ``max_events=None`` returns every
+        matching row -- the ``--full-history`` promise. Pre-fix the
+        cap was hardcoded at 500 in the events-only path so installs
+        with longer event histories silently lost the older rows."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        # Seed 600 priority events -- comfortably above the old 500 cap.
+        _seed_events(config, config.ups_groups[0], [
+            (now - 600 + i, "DAEMON_START", f"row-{i}")
+            for i in range(600)
+        ])
+        # Default cap (EVENTS_MAX_ROWS_MORE=500) drops the oldest 100.
+        capped = query_events_for_display(config, time_range_seconds=None)
+        assert len(capped) == 500
+        # max_events=None must surface every row.
+        full = query_events_for_display(
+            config, time_range_seconds=None, max_events=None,
+        )
+        assert len(full) == 600, (
+            f"max_events=None must disable the cap; got {len(full)} rows"
+        )
+        # Ordering preserved (ascending by timestamp).
+        assert "row-0" in full[0]
+        assert "row-599" in full[-1]
+
 
 class TestRobustBounds:
     """``_robust_bounds`` keeps a single 0V outlier from squashing the
@@ -1278,6 +1307,27 @@ class TestRobustBounds:
         lo, hi = _robust_bounds(values)
         assert 220.0 < lo < 230.0
         assert 230.0 < hi < 240.0
+
+    @pytest.mark.unit
+    def test_n_equals_20_excludes_extremes_both_sides(self):
+        """Boundary test (CodeRabbit P1): for n=20 the helper must
+        actually clip the top sample, not return it. The earlier
+        ``int(n * 0.95)`` formulation produced sorted_vals[19] (the
+        max itself), silently no-op'ing the helper at small n.
+        """
+        from eneru.tui import _robust_bounds
+        # 18 samples at 230V plus one extreme on each side. Expected:
+        # clip BOTH extremes -- lo and hi should both be 230.0.
+        values = [0.0] + [230.0] * 18 + [999.0]
+        lo, hi = _robust_bounds(values)
+        assert lo == 230.0, (
+            f"n=20 must clip the bottom outlier (was: {lo}); regression "
+            "of the percentile off-by-one"
+        )
+        assert hi == 230.0, (
+            f"n=20 must clip the top outlier (was: {hi}); the earlier "
+            "int(n*0.95) returned sorted[19]=999, silently no-op'ing"
+        )
 
 
 class TestSanitizeEventDetail:
@@ -1399,6 +1449,64 @@ class TestRunOnceEventsOnly:
         run_once(config, events_only=True)
         out = capsys.readouterr().out
         assert "(no events)" in out
+
+    @pytest.mark.unit
+    def test_snapshot_path_honours_verbose_flag(self, tmp_path, capsys):
+        """5.2.2 (cubic.dev / CodeRabbit P1): the non-events-only branch
+        of run_once also reads events for its tail block. Pre-fix it
+        used the default ``priority_only=True`` and silently ignored
+        ``--verbose``, so chatter never surfaced even when the user
+        explicitly asked for it."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 60, "VOLTAGE_FLAP_SUPPRESSED", "low-prio chatter"),
+            (now - 30, "DAEMON_START", "high-prio"),
+        ])
+        # Default snapshot path: chatter hidden.
+        run_once(config, events_only=False)
+        out_default = capsys.readouterr().out
+        assert "DAEMON_START" in out_default
+        assert "VOLTAGE_FLAP_SUPPRESSED" not in out_default
+        # --verbose: chatter must surface.
+        run_once(config, events_only=False, verbose=True)
+        out_verbose = capsys.readouterr().out
+        assert "DAEMON_START" in out_verbose
+        assert "VOLTAGE_FLAP_SUPPRESSED" in out_verbose, (
+            "snapshot path must honour --verbose; pre-5.2.2 the events "
+            "tail in the snapshot block silently ignored the flag"
+        )
+
+    @pytest.mark.unit
+    def test_snapshot_path_honours_full_history_flag(self, tmp_path, capsys):
+        """5.2.2 (CodeRabbit P1): same as verbose -- the non-events-only
+        branch ignored ``--full-history`` and stayed bound to the
+        ``--time`` window. Older events were silently dropped from the
+        tail block even when the user asked for the full picture."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        old_ts = now - 90 * 86400  # well outside any --time choice
+        _seed_events(config, config.ups_groups[0], [
+            (old_ts, "DAEMON_START", "ancient"),
+            (now - 60, "DAEMON_START", "recent"),
+        ])
+        # Default snapshot path with default 24h window: only recent.
+        run_once(config, events_only=False)
+        out_default = capsys.readouterr().out
+        assert "recent" in out_default
+        assert "ancient" not in out_default
+        # --full-history: ancient also surfaces.
+        run_once(config, events_only=False, full_history=True)
+        out_full = capsys.readouterr().out
+        assert "recent" in out_full
+        assert "ancient" in out_full, (
+            "snapshot path must honour --full-history; pre-5.2.2 it "
+            "stayed bound to the --time window"
+        )
 
 
 class TestDisplayWidthAndTruncate:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1086,11 +1086,15 @@ class TestQueryEventsForDisplay:
         config = _events_config(tmp_path,
                                 ups_names=("UPS1@h", "UPS2@h"))
         now = int(_time.time())
+        # priority_only=False — this test exercises sort/interleave for
+        # arbitrary event types, not the priority filter itself.
         _seed_events(config, config.ups_groups[0],
                      [(now - 100, "A", ""), (now - 20, "C", "")])
         _seed_events(config, config.ups_groups[1],
                      [(now - 60, "B", "")])
-        lines = query_events_for_display(config, time_range_seconds=3600)
+        lines = query_events_for_display(
+            config, time_range_seconds=3600, priority_only=False,
+        )
         # Order: A (UPS1), B (UPS2), C (UPS1)
         assert "[UPS1@h] A" in lines[0]
         assert "[UPS2@h] B" in lines[1]
@@ -1106,8 +1110,11 @@ class TestQueryEventsForDisplay:
             (now - 7200, "OLD", "two hours ago"),
             (now - 60, "RECENT", "one minute ago"),
         ])
-        # 1-hour window -> only RECENT included.
-        lines = query_events_for_display(config, time_range_seconds=3600)
+        # 1-hour window -> only RECENT included. priority_only=False so
+        # the test stays focused on the time window, not on the type filter.
+        lines = query_events_for_display(
+            config, time_range_seconds=3600, priority_only=False,
+        )
         assert len(lines) == 1
         assert "RECENT" in lines[0]
 
@@ -1120,8 +1127,10 @@ class TestQueryEventsForDisplay:
         _seed_events(config, config.ups_groups[0], [
             (now - i, f"EVT{i}", "") for i in range(1, 11)
         ])
+        # priority_only=False — testing the row cap, not the type filter.
         lines = query_events_for_display(
             config, time_range_seconds=3600, max_events=3,
+            priority_only=False,
         )
         # Most recent 3 events.
         assert len(lines) == 3
@@ -1157,6 +1166,118 @@ class TestQueryEventsForDisplay:
             detail="", multi_ups=False,
         )
         assert line.startswith("????-??-?? ??:??:??")
+
+    @pytest.mark.unit
+    def test_priority_only_default_filters_chatter(self, tmp_path):
+        """Default ``priority_only=True`` keeps the panel focused on
+        daemon-lifecycle and power transitions even when the events
+        table is full of low-priority chatter."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        events = []
+        # 30 chatter rows that should be filtered.
+        for i in range(30):
+            events.append(
+                (now - 100 + i, "VOLTAGE_FLAP_SUPPRESSED", f"flap {i}")
+            )
+        # 2 priority rows that must survive the filter.
+        events.append((now - 50, "DAEMON_START", "v1"))
+        events.append((now - 5, "POWER_RESTORED", "Outage 12s"))
+        _seed_events(config, config.ups_groups[0], events)
+        lines = query_events_for_display(
+            config, time_range_seconds=3600, max_events=8,
+        )
+        # Both priority rows present, no VOLTAGE_FLAP_SUPPRESSED lines.
+        assert any("DAEMON_START" in line for line in lines)
+        assert any("POWER_RESTORED" in line for line in lines)
+        assert all("VOLTAGE_FLAP_SUPPRESSED" not in line for line in lines)
+
+    @pytest.mark.unit
+    def test_verbose_includes_low_priority(self, tmp_path):
+        """``priority_only=False`` (set by ``--verbose`` / ``<V>``)
+        widens the filter to all event types."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 100, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
+            (now - 50, "DAEMON_START", "v1"),
+        ])
+        lines = query_events_for_display(
+            config, time_range_seconds=3600, priority_only=False,
+        )
+        assert len(lines) == 2
+        assert any("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines)
+        assert any("DAEMON_START" in line for line in lines)
+
+    @pytest.mark.unit
+    def test_full_history_ignores_time_window(self, tmp_path):
+        """Calling with ``time_range_seconds=None`` (the wire-level
+        equivalent of ``--full-history``) returns events older than any
+        finite window would surface."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        # Far older than any --time choice (largest is 30d).
+        old_ts = now - 90 * 86400
+        _seed_events(config, config.ups_groups[0], [
+            (old_ts, "DAEMON_START", "ancient"),
+            (now - 60, "DAEMON_START", "recent"),
+        ])
+        # 24h window misses the ancient one.
+        windowed = query_events_for_display(config, time_range_seconds=86400)
+        assert len(windowed) == 1
+        assert "recent" in windowed[0]
+        # No window -> ancient included.
+        full = query_events_for_display(config, time_range_seconds=None)
+        assert len(full) == 2
+        assert "ancient" in full[0]
+        assert "recent" in full[1]
+
+
+class TestRobustBounds:
+    """``_robust_bounds`` keeps a single 0V outlier from squashing the
+    voltage band into a one-row strip at the top of the chart."""
+
+    @pytest.mark.unit
+    def test_short_series_falls_back_to_min_max(self):
+        from eneru.tui import _robust_bounds
+        # < 20 samples -> percentile math is meaningless; use min/max.
+        assert _robust_bounds([1.0, 2.0, 3.0]) == (1.0, 3.0)
+
+    @pytest.mark.unit
+    def test_single_outlier_clipped_from_bounds(self):
+        """A single 0V dot among 99 normal voltage samples must not
+        drag the lower bound down to zero. The 5th-percentile bound
+        should stay close to the band of normal values."""
+        from eneru.tui import _robust_bounds
+        values = [230.0] * 99 + [0.0]
+        lo, hi = _robust_bounds(values)
+        assert lo > 200.0, f"expected lo > 200V, got {lo}"
+        assert hi == 230.0
+
+    @pytest.mark.unit
+    def test_constant_series_falls_back_to_min_max(self):
+        """When every sample is the same, percentiles collapse and the
+        helper falls back to min/max so the renderer can still pad."""
+        from eneru.tui import _robust_bounds
+        assert _robust_bounds([42.0] * 50) == (42.0, 42.0)
+
+    @pytest.mark.unit
+    def test_normal_voltage_band_preserved(self):
+        """Realistic 230V ± 5V series: percentile bounds stay tight to
+        the meaningful range."""
+        from eneru.tui import _robust_bounds
+        import random
+        random.seed(0)
+        values = [230.0 + random.uniform(-5, 5) for _ in range(200)]
+        lo, hi = _robust_bounds(values)
+        assert 220.0 < lo < 230.0
+        assert 230.0 < hi < 240.0
 
 
 class TestSanitizeEventDetail:


### PR DESCRIPTION
## Summary

Three TUI usability fixes from a single user session against v5.2.1:

- **Voltage 0V on graph.** A single phantom 0V `input.voltage` sample squashed the band into a 1-row strip. `_to_input_voltage()` in `stats.py` drops on-line zeros (status `OL` and not `OB`/`FSD`) at sample time; on-battery zeros remain (real outage measurement). `_robust_bounds()` in `tui.py` uses 5th/95th percentile auto-scale for unbounded metrics so any leftover outliers don't dictate the band.
- **Events panel mismatch.** Live TUI and `--once --events-only` both default to priority-only (`DAEMON_*`, `EMERGENCY_SHUTDOWN_*`, `POWER_RESTORED`, `ON_BATTERY`, `VOLTAGE_LOW/HIGH`, `CONNECTION_*`). New `--verbose` / `-v` widens the filter; live TUI gains `<V>` toggle. New `--full-history` (requires `--once`) ignores `--time` and queries from epoch. Live TUI normal cap raised 8 → 20.
- **`tui --graph voltage` ignored interactively.** `run_tui()` now accepts `initial_graph` / `initial_time_range` kwargs, plumbed from `cli._cmd_monitor`. CLI help strings updated.

## Behavior change

Scripts grepping `eneru tui --once --events-only` output for low-priority event types must add `--verbose`. Called out under **Changed** in the changelog.

## Sequencing with PR B

This PR adds a brief `[Unreleased]` block but does not bump `version.py`. The follow-up PR B (shutdown re-arm fix for #4) will branch off post-merge main, consolidate `[Unreleased]` into `[5.2.2]`, and bump the version, so the two land as one release.

## Test plan

- [x] 963 unit/integration tests pass (`pytest -q --timeout=30` in uv venv)
- [x] Manual: `eneru tui --full-history` rejects with `error: ... requires --once` and `exit 2`
- [x] Manual: `eneru tui --help` shows the new `--verbose` and `--full-history` flags
- [x] Pre-push code review (agent-skills:code-reviewer, opus): P1 finding addressed (clean exit-2 + stderr instead of stack trace), P2 polish applied (defensive `_robust_bounds([])` guard, comment cross-references in `_to_input_voltage`, hint-row reorder + abbreviated `Verb:`, `--time` doc wording)
- [ ] CI must pass: validate matrix (Python 3.9-3.14) + 5 E2E matrix jobs (CLI, UPS Single, UPS Multi, Redundancy, Stats — Stats job exercises new priority + `--full-history` rejection assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes squashed voltage graphs, adds a priority-first events filter with a `--verbose` toggle, and makes `--graph`/`--time` seed the interactive TUI view. Also tightens history handling so `--full-history` returns all events and the snapshot path honors `--verbose`/`--full-history`.

- **Bug Fixes**
  - Drop on-line 0V `input.voltage` samples at write time; keep on-battery/FSD zeros.
  - Graph auto-scales unbounded metrics using 5th/95th percentiles; correct for small series.
  - `eneru tui --graph ...` and `--time` now seed the interactive TUI on launch.
  - Snapshot path (`--once` without `--events-only`) now respects `--verbose` and `--full-history`.
  - `--full-history` without `--once` rejects with exit 2 and the correct subcommand prefix.

- **New Features**
  - Events default to priority-only (daemon lifecycle, shutdown triggers, power transitions). Toggle all events with `--verbose`/`-v` or `<V>` in the TUI. Scripts parsing `eneru tui --once --events-only` for low-priority events must add `--verbose`.
  - `--full-history` for `--once` queries from the beginning and returns all rows (no cap); rejects without `--once`.
  - Live TUI events panel cap increased from 8 to 20 rows.

<sup>Written for commit 8f3f81634b5b61d25bf633ca70221fca81f13abd. Summary will update on new commits. <a href="https://cubic.dev/pr/m4r1k/Eneru/pull/40?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--verbose`/`-v` flag to include low-priority events, with `<V>` in-session toggle
  * Added `--full-history` flag for `--once` mode to query from the beginning

* **Bug Fixes**
  * Fixed `--graph` and `--time` flags now properly seed initial view in interactive mode
  * Fixed voltage graph rendering by filtering erroneous 0V readings
  * Improved graph y-axis auto-scaling to prevent outliers from collapsing display

* **Improvements**
  * Events panel now defaults to priority-only filtering
  * Events panel history capacity increased from 8 to 20 rows

* **Documentation**
  * Updated CLI reference with new flags and interactive keybindings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->