### PR TITLE
fix(monitor): re-arm shutdown trigger on POWER_RESTORED (bug #4)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,38 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [5.2.2] - 2026-04-28
+
+TUI usability fixes plus one safety-critical re-arm fix on the shutdown
+state machine. Drop-in upgrade.
 
 ### Fixed
-- **`eneru tui --graph voltage` was silently ignored in interactive mode.**
-  The CLI flag now seeds the initial graph metric (and `--time` seeds the
-  initial window) even without `--once`. Pressing `<G>` / `<T>` still cycles
-  from there.
-- **A single phantom 0V sample squashed the voltage band into a one-pixel
-  strip at the top of the graph.** Two layers of fix: the writer drops
-  on-line `input.voltage <= 0` rows at sample time (with `ups.status` in
-  context, so real outages — `OB` / `FSD` — still record a legitimate dip
-  to 0V), and the graph panel auto-scales unbounded metrics from the
-  5th/95th percentile so any leftover outliers don't dictate the band.
+- **Shutdown trigger never re-armed after `POWER_RESTORED`** when the
+  local-shutdown command failed to actually halt the host (custom
+  no-op command, sandboxed environment, dummy-UPS test rig — bug #4).
+  Subsequent on-battery transitions silently no-op'd at the flag-file
+  gate. The handler now clears the flag on the OB/FSD → OL transition,
+  and `MultiUPSCoordinator` resets its in-memory lock + global flag in
+  the same hook so multi-UPS deployments re-arm too. Gated re-triggers
+  also log a warning so the no-op is no longer silent.
+- **`eneru tui --graph voltage` silently ignored in interactive mode.**
+  The CLI flag now seeds the initial graph metric, and `--time` seeds
+  the initial window; `<G>` / `<T>` cycle from there.
+- **A single phantom 0 V sample squashed the voltage band into a
+  one-pixel strip at the top of the graph.** Writer drops on-line
+  `input.voltage <= 0` rows at sample time (real outages — `OB`/`FSD`
+  — still record the legitimate dip to 0 V); graph panel auto-scales
+  unbounded metrics from the 5th/95th percentile so any leftover
+  outliers don't dictate the band.
 
 ### Added
-- **`--verbose` / `-v` flag** on `eneru tui` (live + `--once`): widens the
+- **`--verbose` / `-v`** on `eneru tui` (live + `--once`): widens the
   events filter to include low-priority chatter alongside the priority
-  defaults. The live TUI also gains a `<V>` keybind to toggle in-session.
-- **`--full-history` flag** for `eneru tui --once`: ignore the `--time`
+  defaults. Live TUI gains a `<V>` keybind to toggle in-session.
+- **`--full-history`** for `eneru tui --once`: ignore the `--time`
   window and query the events table from the beginning. Rejects with
-  ``error: --full-history requires --once`` (exit 2) if combined with the
-  live TUI.
+  `error: --full-history requires --once` (exit 2) when combined with
+  the live TUI.
 
 ### Changed
-- **Events panel now defaults to priority-only** in both live TUI and
-  `eneru tui --once --events-only`. Daemon lifecycle, shutdown triggers,
-  and power transitions surface; per-condition chatter
-  (`VOLTAGE_FLAP_SUPPRESSED`, etc.) is hidden. Migration: scripts that
-  grep the `--once --events-only` output for low-priority event types
-  must add `--verbose`.
+- **Events panel defaults to priority-only** in both live TUI and
+  `eneru tui --once --events-only`. Daemon lifecycle, shutdown
+  triggers, and power transitions surface; per-condition chatter
+  is hidden. Scripts that grep `--once --events-only` for
+  low-priority event types must now pass `--verbose`.
 - Live TUI events panel default cap raised from 8 to 20 rows so a few
   voltage transitions don't push the daemon-level history off-screen.
+
+### Migration notes
+None for the package install. Scripts parsing `eneru tui --once
+--events-only` output: add `--verbose` if you rely on seeing
+low-priority event types (voltage flaps, etc.).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -187,6 +187,15 @@ sudo rm -f /var/run/ups-shutdown-redundancy-*
 
 Remove flags only after confirming no real shutdown is in progress.
 
+If you see this warning in the logs:
+
+```
+⚠️ Shutdown trigger fired (...) but a previous shutdown sequence is already
+   in progress (/var/run/ups-shutdown-scheduled). Ignoring re-trigger.
+```
+
+it means a prior shutdown sequence ran but the host did not actually halt (custom shutdown command was a no-op, sandbox/container intercepted it, or the daemon was running outside systemd's reach). Since 5.2.2 the daemon clears the flag automatically when `POWER_RESTORED` fires, so the next outage re-arms cleanly. The warning surfaces only on the unusual path where a trigger fires *while* a previous sequence is still considered in flight; clearing the flag manually as above is safe once you have confirmed no real shutdown is running.
+
 ## Graphs or events are empty
 
 The stats writer flushes every few seconds. For a fresh start, wait at least 10 seconds and check the database:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -100,6 +100,7 @@ class UPSGroupMonitor(
     def __init__(self, config: Config, exit_after_shutdown: bool = False,
                  coordinator_mode: bool = False,
                  shutdown_callback=None,
+                 power_restored_callback=None,
                  stop_event: Optional[threading.Event] = None,
                  log_prefix: str = "",
                  notification_worker: Optional[NotificationWorker] = None,
@@ -111,6 +112,11 @@ class UPSGroupMonitor(
         self.logger: Optional[UPSLogger] = logger
         self._coordinator_mode = coordinator_mode
         self._shutdown_callback = shutdown_callback
+        # Coordinator-supplied hook fired on the OB/FSD->OL transition so
+        # the coordinator can re-arm its own _local_shutdown_initiated
+        # lock + global flag (the per-monitor flag we clear locally is
+        # suffixed and lives separately). Bug #4 / 5.2.2.
+        self._power_restored_callback = power_restored_callback
         self._stop_event = stop_event or threading.Event()
         self._log_prefix = log_prefix
         # When True, per-UPS triggers (T1-T4, FSD, FAILSAFE) become advisory:
@@ -939,6 +945,15 @@ class UPSGroupMonitor(
     def _trigger_immediate_shutdown(self, reason: str):
         """Trigger an immediate shutdown if not already in progress."""
         if self._shutdown_flag_path.exists():
+            # Surface gated re-triggers (bug #4). The early return used
+            # to be silent, which made correlating "trigger conditions
+            # met but nothing fired" with the stuck flag much harder
+            # than it should have been.
+            self._log_message(
+                f"⚠️ Shutdown trigger fired ({reason}) but a previous "
+                f"shutdown sequence is already in progress "
+                f"({self._shutdown_flag_path}). Ignoring re-trigger."
+            )
             return
 
         self._shutdown_flag_path.touch()
@@ -1224,6 +1239,31 @@ class UPSGroupMonitor(
             self.state.on_battery_start_time = 0
             self.state.extended_time_logged = False
             self.state.battery_history.clear()
+
+            # Re-arm the shutdown trigger (bug #4). The flag file is
+            # _trigger_immediate_shutdown's re-entry guard; the
+            # local_shutdown.enabled=true real-mode path doesn't clear
+            # it (it implicitly trusts the OS reboot is about to take
+            # the daemon down). On a healthy production install systemd
+            # reaps us within seconds and this never matters, but on
+            # edge installs (custom shutdown command, container/sandbox,
+            # dummy UPS test rig) the host stays up and the second
+            # outage's trigger silently no-ops. Clearing the flag here
+            # means: "power came back, daemon is still alive ⇒ the
+            # previous attempt did not actually halt the host ⇒ re-arm".
+            self._shutdown_flag_path.unlink(missing_ok=True)
+            # Coordinator hook: in multi-UPS mode the per-monitor flag
+            # above is suffixed; the coordinator owns a separate
+            # unsuffixed flag + an in-memory _local_shutdown_initiated
+            # lock that would otherwise still gate the next trigger.
+            # The callback resets both. None for single-UPS / standalone.
+            if self._power_restored_callback is not None:
+                try:
+                    self._power_restored_callback()
+                except Exception as exc:  # defensive: never raise into the loop
+                    self._log_message(
+                        f"⚠️ power_restored_callback raised: {exc}"
+                    )
 
             # Power restored on a redundancy-group member: drop any advisory
             # trigger so the group evaluator sees this UPS as healthy again.

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -265,6 +265,7 @@ class MultiUPSCoordinator:
                 exit_after_shutdown=self._exit_after_shutdown,
                 coordinator_mode=True,
                 shutdown_callback=self._on_group_shutdown,
+                power_restored_callback=self._clear_local_shutdown_state,
                 stop_event=self._stop_event,
                 log_prefix=prefix,
                 notification_worker=self._notification_worker,
@@ -364,6 +365,25 @@ class MultiUPSCoordinator:
             # Non-local group shutdown completed, exit if requested
             self._log(f"🛑 Group {label} shutdown complete. Exiting (--exit-after-shutdown).")
             self._stop_event.set()
+
+    def _clear_local_shutdown_state(self):
+        """Re-arm coordinator-level shutdown state on POWER_RESTORED.
+
+        Mirrors UPSGroupMonitor._handle_on_line's per-group flag unlink
+        for the coordinator-owned state. Invoked via the per-monitor
+        ``power_restored_callback`` hook on the OB/FSD->OL transition.
+
+        Without this, the in-memory ``_local_shutdown_initiated`` lock
+        + the unsuffixed ``_global_shutdown_flag`` would persist after
+        a no-op or sandboxed local shutdown, blocking the next outage's
+        trigger across all UPS groups (multi-UPS path of bug #4).
+
+        Idempotent: safe to call repeatedly when no shutdown was in
+        flight, or when this group is the second OL transition in a row.
+        """
+        with self._local_shutdown_lock:
+            self._local_shutdown_initiated = False
+        self._global_shutdown_flag.unlink(missing_ok=True)
 
     def _handle_local_shutdown(self, triggered_by: str):
         """Execute local shutdown with defense-in-depth protection."""

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -380,10 +380,19 @@ class MultiUPSCoordinator:
 
         Idempotent: safe to call repeatedly when no shutdown was in
         flight, or when this group is the second OL transition in a row.
+
+        The boolean reset AND the file unlink BOTH live inside the lock
+        so the two halves of "shutdown is no longer in flight" stay
+        atomic with respect to ``_handle_local_shutdown``. Without
+        this, an interleaving where (A) we cleared the bool, (B) a
+        concurrent ON_BATTERY thread re-took the lock and re-touched
+        the flag, then (C) we unlinked it would leave the coordinator
+        believing a sequence is in flight while the on-disk evidence
+        is gone -- a state worse than the one we set out to fix.
         """
         with self._local_shutdown_lock:
             self._local_shutdown_initiated = False
-        self._global_shutdown_flag.unlink(missing_ok=True)
+            self._global_shutdown_flag.unlink(missing_ok=True)
 
     def _handle_local_shutdown(self, triggered_by: str):
         """Execute local shutdown with defense-in-depth protection."""

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.2.1"
+__version__ = "5.2.2"

--- a/tests/e2e/groups/single-ups.sh
+++ b/tests/e2e/groups/single-ups.sh
@@ -454,8 +454,8 @@ EOF
 # test would still "pass" without exercising the re-arm path. Fail
 # loud instead. Scenario format is plain ``key: value`` lines; battery
 # charge can be a float like ``14`` or ``14.0``.
-LB_CHARGE=$(awk '/^battery\.charge:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' $E2E_DIR/scenarios/low-battery.dev)
-OL_STATUS=$(awk -F': ' '/^ups\.status:/{print $2; exit}' $E2E_DIR/scenarios/online-charging.dev)
+LB_CHARGE=$(awk '/^battery\.charge:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' "$E2E_DIR/scenarios/low-battery.dev")
+OL_STATUS=$(awk -F': ' '/^ups\.status:/{print $2; exit}' "$E2E_DIR/scenarios/online-charging.dev")
 LB_CHARGE_INT=${LB_CHARGE%.*}
 if [ -z "$LB_CHARGE_INT" ] || [ "$LB_CHARGE_INT" -ge 20 ]; then
   echo "FAIL (setup): low-battery.dev battery.charge=${LB_CHARGE:-?} expected < 20"
@@ -472,9 +472,13 @@ sleep 3
 
 # Daemon in background. NO --exit-after-shutdown; we want it to stay
 # alive across all three transitions.
-PYTHONUNBUFFERED=1 eneru run --config $REARM_DIR/config.yaml > $REARM_DIR/daemon.log 2>&1 &
+PYTHONUNBUFFERED=1 eneru run --config "$REARM_DIR/config.yaml" > "$REARM_DIR/daemon.log" 2>&1 &
 DAEMON_PID=$!
-trap "kill $DAEMON_PID 2>/dev/null || true" EXIT
+# Single-quoted trap so $DAEMON_PID resolves at trap-fire time, not
+# trap-set time. Functionally equivalent here (DAEMON_PID is already
+# set when this line runs and never changes), but matches shell-best-
+# practice and silences ShellCheck.
+trap 'kill $DAEMON_PID 2>/dev/null || true' EXIT
 
 # Let the daemon initialise + observe OL.
 sleep 3
@@ -498,7 +502,7 @@ for i in {1..20}; do
 done
 if [ "${COUNT:-0}" -lt 1 ]; then
   echo "FAIL: first EMERGENCY_SHUTDOWN_INITIATED never recorded"
-  tail -40 $REARM_DIR/daemon.log
+  tail -40 "$REARM_DIR/daemon.log"
   exit 1
 fi
 
@@ -517,12 +521,12 @@ for i in {1..20}; do
 done
 if [ "${PR_COUNT:-0}" -lt 1 ]; then
   echo "FAIL: POWER_RESTORED never recorded"
-  tail -40 $REARM_DIR/daemon.log
+  tail -40 "$REARM_DIR/daemon.log"
   exit 1
 fi
 if [ -f "$REARM_DIR/shutdown-flag" ]; then
   echo "FAIL: flag still present after POWER_RESTORED -- re-arm broken (bug #4 regression)"
-  tail -40 $REARM_DIR/daemon.log
+  tail -40 "$REARM_DIR/daemon.log"
   exit 1
 fi
 
@@ -543,13 +547,13 @@ if [ "${COUNT2:-0}" -lt 2 ]; then
   echo "FAIL: second EMERGENCY_SHUTDOWN_INITIATED never recorded -- re-arm broken (bug #4 regression)"
   echo "events table:"
   sqlite3 "$DB" "SELECT ts, event_type, detail FROM events ORDER BY ts" || true
-  tail -60 $REARM_DIR/daemon.log
+  tail -60 "$REARM_DIR/daemon.log"
   exit 1
 fi
 
 # Stop the daemon cleanly.
-kill $DAEMON_PID 2>/dev/null || true
-wait $DAEMON_PID 2>/dev/null || true
+kill "$DAEMON_PID" 2>/dev/null || true
+wait "$DAEMON_PID" 2>/dev/null || true
 trap - EXIT
 
 # Restore baseline so any downstream tests start fresh.

--- a/tests/e2e/groups/single-ups.sh
+++ b/tests/e2e/groups/single-ups.sh
@@ -382,5 +382,180 @@ fi
 cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
 )
 
+# ======================================================================
+# Test 34: Shutdown re-arm on POWER_RESTORED (5.2.2 / bug #4)
+#
+# The shutdown sequence creates a flag file as a re-entry guard. In the
+# local_shutdown.enabled=true real-mode path the daemon doesn't clear
+# it, because it expects the OS reboot to take it down within seconds.
+# On a healthy production install systemd reaps it before this matters,
+# but on edge installs (custom shutdown command, sandboxed env, dummy
+# UPS test rig) the host stays up and the second outage's trigger
+# silently no-ops. _handle_on_line now clears the flag on OB->OL.
+#
+# We exercise this with local_shutdown.enabled=true + dry_run=false +
+# shutdown_command=/bin/true so the daemon "shuts down" the host
+# (no-op) but keeps polling. Any regression here would silently drop
+# the second EMERGENCY_SHUTDOWN_INITIATED row.
+# ======================================================================
+(
+echo ""
+echo ">>> Running: Test 34: Shutdown re-arm on POWER_RESTORED (bug #4)"
+echo "=== Test 34: re-arm after POWER_RESTORED ==="
+
+REARM_DIR=/tmp/eneru-e2e-rearm
+rm -rf $REARM_DIR
+mkdir -p $REARM_DIR
+
+# Inline config: local shutdown "enabled" but the command is a no-op,
+# so the daemon issues "shutdown" and keeps running. The flag file
+# would persist forever pre-5.2.2, blocking the second trigger.
+cat > $REARM_DIR/config.yaml <<EOF
+ups:
+  name: "TestUPS@localhost:3493"
+  check_interval: 1
+  max_stale_data_tolerance: 3
+triggers:
+  low_battery_threshold: 20
+  critical_runtime_threshold: 600
+  depletion:
+    grace_period: 5
+  extended_time:
+    enabled: false
+behavior:
+  dry_run: false
+logging:
+  file: null
+  state_file: $REARM_DIR/state
+  battery_history_file: $REARM_DIR/history
+  shutdown_flag_file: $REARM_DIR/shutdown-flag
+statistics:
+  db_directory: $REARM_DIR
+notifications:
+  enabled: false
+virtual_machines:
+  enabled: false
+containers:
+  enabled: false
+filesystems:
+  sync_enabled: false
+  unmount:
+    enabled: false
+local_shutdown:
+  enabled: true
+  command: "/bin/true e2e-rearm-noop"
+  wall: false
+EOF
+
+# Pin the assumptions this test makes about the scenario contents.
+# If a future scenario tweak nudges low-battery.dev's battery.charge
+# above the trigger threshold (or online-charging.dev away from OL),
+# the scenarios silently stop driving the OB/OL transitions and this
+# test would still "pass" without exercising the re-arm path. Fail
+# loud instead. Scenario format is plain ``key: value`` lines; battery
+# charge can be a float like ``14`` or ``14.0``.
+LB_CHARGE=$(awk '/^battery\.charge:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' $E2E_DIR/scenarios/low-battery.dev)
+OL_STATUS=$(awk -F': ' '/^ups\.status:/{print $2; exit}' $E2E_DIR/scenarios/online-charging.dev)
+LB_CHARGE_INT=${LB_CHARGE%.*}
+if [ -z "$LB_CHARGE_INT" ] || [ "$LB_CHARGE_INT" -ge 20 ]; then
+  echo "FAIL (setup): low-battery.dev battery.charge=${LB_CHARGE:-?} expected < 20"
+  exit 1
+fi
+if ! echo "$OL_STATUS" | grep -q "OL"; then
+  echo "FAIL (setup): online-charging.dev ups.status='${OL_STATUS:-?}' expected to contain OL"
+  exit 1
+fi
+
+# Start with healthy mains so the daemon enters the loop in OL.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+sleep 3
+
+# Daemon in background. NO --exit-after-shutdown; we want it to stay
+# alive across all three transitions.
+PYTHONUNBUFFERED=1 eneru run --config $REARM_DIR/config.yaml > $REARM_DIR/daemon.log 2>&1 &
+DAEMON_PID=$!
+trap "kill $DAEMON_PID 2>/dev/null || true" EXIT
+
+# Let the daemon initialise + observe OL.
+sleep 3
+
+# (1) First outage: low battery -> trigger fires, flag created, no-op
+#     "shutdown" command runs, daemon keeps polling.
+echo "  step 1: low-battery -> first trigger"
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply.dev
+
+# Wait for the first EMERGENCY_SHUTDOWN_INITIATED to land in SQLite.
+DB=$REARM_DIR/default.db
+for i in {1..20}; do
+  if [ -f "$DB" ]; then
+    COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM events WHERE event_type='EMERGENCY_SHUTDOWN_INITIATED'" 2>/dev/null || echo 0)
+    if [ "$COUNT" -ge 1 ]; then
+      echo "  first trigger logged after ${i}s"
+      break
+    fi
+  fi
+  sleep 1
+done
+if [ "${COUNT:-0}" -lt 1 ]; then
+  echo "FAIL: first EMERGENCY_SHUTDOWN_INITIATED never recorded"
+  tail -40 $REARM_DIR/daemon.log
+  exit 1
+fi
+
+# (2) Power restored: daemon must see OL again and clear the flag.
+echo "  step 2: online-charging -> POWER_RESTORED clears flag"
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+
+# Wait until POWER_RESTORED lands AND the flag file is gone.
+for i in {1..20}; do
+  PR_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM events WHERE event_type='POWER_RESTORED'" 2>/dev/null || echo 0)
+  if [ "$PR_COUNT" -ge 1 ] && [ ! -f "$REARM_DIR/shutdown-flag" ]; then
+    echo "  POWER_RESTORED logged + flag cleared after ${i}s"
+    break
+  fi
+  sleep 1
+done
+if [ "${PR_COUNT:-0}" -lt 1 ]; then
+  echo "FAIL: POWER_RESTORED never recorded"
+  tail -40 $REARM_DIR/daemon.log
+  exit 1
+fi
+if [ -f "$REARM_DIR/shutdown-flag" ]; then
+  echo "FAIL: flag still present after POWER_RESTORED -- re-arm broken (bug #4 regression)"
+  tail -40 $REARM_DIR/daemon.log
+  exit 1
+fi
+
+# (3) Second outage: trigger MUST fire again. Pre-5.2.2 the flag
+#     persisted and this no-op'd silently.
+echo "  step 3: low-battery again -> second trigger (re-arm proof)"
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply.dev
+
+for i in {1..20}; do
+  COUNT2=$(sqlite3 "$DB" "SELECT COUNT(*) FROM events WHERE event_type='EMERGENCY_SHUTDOWN_INITIATED'" 2>/dev/null || echo 1)
+  if [ "$COUNT2" -ge 2 ]; then
+    echo "  second trigger logged after ${i}s"
+    break
+  fi
+  sleep 1
+done
+if [ "${COUNT2:-0}" -lt 2 ]; then
+  echo "FAIL: second EMERGENCY_SHUTDOWN_INITIATED never recorded -- re-arm broken (bug #4 regression)"
+  echo "events table:"
+  sqlite3 "$DB" "SELECT ts, event_type, detail FROM events ORDER BY ts" || true
+  tail -60 $REARM_DIR/daemon.log
+  exit 1
+fi
+
+# Stop the daemon cleanly.
+kill $DAEMON_PID 2>/dev/null || true
+wait $DAEMON_PID 2>/dev/null || true
+trap - EXIT
+
+# Restore baseline so any downstream tests start fresh.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
+echo "PASS: bug #4 re-arm; OB->OL->OB produced 2 EMERGENCY_SHUTDOWN_INITIATED rows"
+)
+
 echo ""
 echo "=== Group 'single-ups' completed successfully ==="

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -324,6 +324,158 @@ class TestFSDFlag:
 
         assert call_count == 1
 
+    @pytest.mark.unit
+    def test_trigger_immediate_shutdown_logs_when_gated(self, tmp_path):
+        """5.2.2 (bug #4): when the flag-file gate blocks a re-trigger,
+        a warning must surface so operators can correlate it. Pre-5.2.2
+        the second call returned silently, which made debugging the
+        ckrevel reproduction much harder than it had to be.
+        """
+        monitor = make_monitor(tmp_path)
+
+        with patch.object(monitor, "_execute_shutdown_sequence"):
+            monitor._trigger_immediate_shutdown("First")
+
+        with patch.object(monitor, "_log_message") as mock_log:
+            with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+                monitor._trigger_immediate_shutdown("Second")
+                # Must not run the sequence again (still no-op).
+                mock_exec.assert_not_called()
+            # Must log a warning that mentions the reason and the flag path.
+            assert mock_log.call_count >= 1
+            warning_calls = [
+                call.args[0] for call in mock_log.call_args_list
+                if call.args and "previous shutdown sequence" in call.args[0]
+            ]
+            assert warning_calls, (
+                f"expected a 'previous shutdown sequence' warning; "
+                f"got: {[c.args for c in mock_log.call_args_list]}"
+            )
+            assert "Second" in warning_calls[0]
+            assert str(monitor._shutdown_flag_path) in warning_calls[0]
+
+
+# ==============================================================================
+# Shutdown re-arm on POWER_RESTORED (5.2.2 / bug #4)
+# ==============================================================================
+
+class TestShutdownReArmOnPowerRestored:
+    """When the OS reboot fails to take down the daemon (custom shutdown
+    command, sandboxed environment, dummy-UPS test rig), the previous
+    shutdown sequence's flag file persists and silently blocks the next
+    trigger. _handle_on_line clears the flag on OB->OL so the daemon
+    re-arms.
+    """
+
+    @pytest.mark.unit
+    def test_power_restored_unlinks_shutdown_flag(self, tmp_path):
+        """OB -> OL transition must remove the shutdown flag file."""
+        monitor = make_monitor(tmp_path)
+        monitor.state.previous_status = "OB DISCHRG"
+        monitor.state.on_battery_start_time = int(time.time()) - 30
+        # Simulate a previous trigger leaving the flag behind.
+        monitor._shutdown_flag_path.touch()
+        assert monitor._shutdown_flag_path.exists()
+
+        ups_data = {
+            "ups.status": "OL CHRG",
+            "battery.charge": "85",
+            "input.voltage": "230.0",
+        }
+        monitor._handle_on_line(ups_data)
+
+        assert not monitor._shutdown_flag_path.exists(), (
+            "POWER_RESTORED must clear the shutdown flag so the next OB "
+            "transition can re-trigger; pre-5.2.2 the flag persisted "
+            "and the second trigger silently no-op'd (bug #4)."
+        )
+
+    @pytest.mark.unit
+    def test_power_restored_no_flag_is_safe(self, tmp_path):
+        """Clearing a non-existent flag must not raise (missing_ok=True)."""
+        monitor = make_monitor(tmp_path)
+        monitor.state.previous_status = "OB"
+        monitor.state.on_battery_start_time = int(time.time()) - 5
+        assert not monitor._shutdown_flag_path.exists()
+
+        ups_data = {
+            "ups.status": "OL",
+            "battery.charge": "100",
+            "input.voltage": "230.0",
+        }
+        # No exception, no flag.
+        monitor._handle_on_line(ups_data)
+        assert not monitor._shutdown_flag_path.exists()
+
+    @pytest.mark.unit
+    def test_no_unlink_when_already_on_line(self, tmp_path):
+        """OL -> OL (no transition) must NOT touch the shutdown flag.
+
+        If a shutdown sequence is genuinely in flight while the daemon
+        is still on line (extremely unusual but possible during dry-run
+        or coordinator-mode chains), removing the flag could let a
+        concurrent re-trigger fire. Only the OB/FSD -> OL transition
+        is expected to clear the flag.
+        """
+        monitor = make_monitor(tmp_path)
+        monitor.state.previous_status = "OL CHRG"
+        # Pre-existing flag (someone or something put it there).
+        monitor._shutdown_flag_path.touch()
+
+        ups_data = {
+            "ups.status": "OL CHRG",
+            "battery.charge": "100",
+            "input.voltage": "230.0",
+        }
+        monitor._handle_on_line(ups_data)
+
+        assert monitor._shutdown_flag_path.exists(), (
+            "Steady-state OL polls must not clear the shutdown flag; "
+            "the unlink is gated on the OB/FSD -> OL transition."
+        )
+
+    @pytest.mark.unit
+    def test_full_outage_recovery_rearms_trigger(self, tmp_path):
+        """End-to-end: OB triggers shutdown -> flag set; OL clears flag;
+        second OB triggers shutdown again. Mirrors the bug #4 reproducer
+        exactly (with the shutdown sequence mocked so the test doesn't
+        actually call out to real shutdown code).
+        """
+        monitor = make_monitor(tmp_path)
+
+        # First OB: trigger fires, flag is set.
+        monitor.state.previous_status = ""
+        ob_data = {
+            "ups.status": "OB DISCHRG",
+            "battery.charge": "5",   # below default low_battery_threshold
+            "battery.runtime": "30",
+            "ups.load": "30",
+        }
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            monitor._handle_on_battery(ob_data)
+        assert mock_exec.called, "first OB must trigger shutdown"
+        assert monitor._shutdown_flag_path.exists()
+        monitor.state.previous_status = "OB DISCHRG"
+
+        # OL: power restored, flag cleared.
+        ol_data = {
+            "ups.status": "OL CHRG",
+            "battery.charge": "100",
+            "input.voltage": "230.0",
+        }
+        monitor._handle_on_line(ol_data)
+        assert not monitor._shutdown_flag_path.exists()
+        monitor.state.previous_status = "OL CHRG"
+
+        # Second OB: trigger must fire again (re-arm worked).
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec2:
+            monitor._handle_on_battery(ob_data)
+        assert mock_exec2.called, (
+            "second OB after OL must re-trigger shutdown; if this fails "
+            "the bug #4 regression is back."
+        )
+        assert monitor._shutdown_flag_path.exists()
+
 
 # ==============================================================================
 # FAILSAFE (Connection Lost While On Battery)

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -376,6 +376,78 @@ class TestMultiUPSCoordinator:
         coord._handle_local_shutdown("UPS2")
         assert len(shutdown_count) == 1
 
+    @pytest.mark.unit
+    def test_clear_local_shutdown_state_resets_lock_and_flag(self, tmp_path):
+        """5.2.2 (bug #4 / multi-UPS): _clear_local_shutdown_state resets
+        BOTH the in-memory ``_local_shutdown_initiated`` lock and the
+        unsuffixed ``_global_shutdown_flag`` so the next outage on any
+        group can re-trigger. Without this, the per-monitor unlink in
+        ``_handle_on_line`` re-arms only the suffixed per-group flag --
+        the second OB still hits the coordinator's stuck lock."""
+        flag_path = tmp_path / "global-shutdown-flag"
+        config = self._make_config(
+            [UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+                shutdown_flag_file=str(flag_path),
+            ),
+            local_shutdown=LocalShutdownConfig(enabled=False),
+        )
+        coord = MultiUPSCoordinator(config)
+
+        # Simulate a prior shutdown sequence having set both pieces.
+        coord._local_shutdown_initiated = True
+        flag_path.touch()
+        assert flag_path.exists()
+
+        coord._clear_local_shutdown_state()
+
+        assert coord._local_shutdown_initiated is False, (
+            "in-memory lock must be reset on POWER_RESTORED so the next "
+            "OB re-triggers (bug #4 multi-UPS path)"
+        )
+        assert not flag_path.exists(), (
+            "global flag must be cleared on POWER_RESTORED"
+        )
+
+    @pytest.mark.unit
+    def test_clear_local_shutdown_state_idempotent(self, tmp_path):
+        """Safe to call when nothing was in flight (steady-state OL or
+        repeated OL transitions)."""
+        flag_path = tmp_path / "global-shutdown-flag"
+        config = self._make_config(
+            [UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+                shutdown_flag_file=str(flag_path),
+            ),
+            local_shutdown=LocalShutdownConfig(enabled=False),
+        )
+        coord = MultiUPSCoordinator(config)
+        # Nothing set, no flag file.
+        coord._clear_local_shutdown_state()  # must not raise
+        coord._clear_local_shutdown_state()  # idempotent
+        assert coord._local_shutdown_initiated is False
+        assert not flag_path.exists()
+
+    @pytest.mark.unit
+    def test_coordinator_passes_power_restored_callback_to_monitors(self):
+        """The coordinator MUST wire its ``_clear_local_shutdown_state``
+        into each monitor as ``power_restored_callback`` -- otherwise
+        the OB/FSD->OL transition can clear the per-group flag but the
+        coordinator's own flag/lock stay set (multi-UPS bug #4)."""
+        import inspect
+        from eneru import multi_ups as mu_mod
+
+        src = inspect.getsource(mu_mod.MultiUPSCoordinator._start_monitors)
+        assert "power_restored_callback=self._clear_local_shutdown_state" in src, (
+            "coordinator must pass power_restored_callback to UPSGroupMonitor; "
+            "without it, multi-UPS deployments still hit bug #4 even after "
+            "the per-group _handle_on_line clears its suffixed flag."
+        )
+
 
 # ==============================================================================
 # UPS MONITOR COORDINATOR MODE


### PR DESCRIPTION
Fixes #4 (latest comment).

## Summary

The shutdown sequence creates a flag file as a re-entry guard so a mid-flight trigger can't pile on. The `local_shutdown.enabled=true` real-mode path doesn't clear it — the design assumes the OS reboot is about to take the daemon down within seconds. On healthy production installs systemd reaps the daemon before this matters, but on edge installs the host stays up:

- custom `local_shutdown.command` that's a no-op
- container/sandbox where shutdown is intercepted
- non-root invocation without sudo
- ckrevel's case: dummy NUT backend with the eneru host deliberately staying up

Result: the next outage's `_trigger_immediate_shutdown` silently no-ops at the flag-file gate. ckrevel's reproducer hits this exactly.

## Fixes

1. **`UPSGroupMonitor._handle_on_line`** clears the per-monitor flag on the OB/FSD → OL transition. If power has been restored *and* the daemon is still alive, the previous shutdown attempt did not actually halt the host — re-arming is safe.
2. **`MultiUPSCoordinator._clear_local_shutdown_state`** wired into each monitor as `power_restored_callback`. Without this the coordinator's in-memory `_local_shutdown_initiated` lock + unsuffixed `_global_shutdown_flag` persist after a no-op shutdown, blocking the next OB on any group. **This was caught by pre-push review and would have shipped broken otherwise** — the per-monitor unlink alone touches the suffixed per-group flag, not the coordinator's separate state.
3. **`_trigger_immediate_shutdown`** logs a warning when the gate fires instead of returning silently, so operators can correlate "trigger conditions met but nothing fired" with the stuck flag.

## Sequencing with PR A

This PR does NOT bump `version.py` or touch `docs/changelog.md` to avoid conflicts with #40 (TUI usability fixes, which has its own `[Unreleased]` block). Plan: after #40 merges, rebase this branch onto updated main, then in a follow-up commit bump `version.py` to `5.2.2` and consolidate `[Unreleased]` → `[5.2.2]` covering both PRs as one release.

## Test plan

- [x] 953 unit/integration tests pass (`pytest -q --timeout=30` in uv venv)
- [x] 5 new unit tests in `test_monitor_core` for the per-monitor re-arm path
- [x] 3 new unit tests in `test_multi_ups` for the coordinator state reset + callback wiring
- [x] Pre-push code review (agent-skills:code-reviewer, opus): P1 finding (multi-UPS coordinator gap) addressed; P2 (E2E scenario brittleness) addressed; P3 (code-comment version reference) addressed
- [ ] CI must pass: validate matrix (Python 3.9-3.14) + 5 E2E matrix jobs. The new Test 34 in `E2E UPS Single` exercises the previously-untested `local_shutdown.enabled=true` + no-op shutdown command path (the only path where the bug actually manifests), driving OB → OL → OB and asserting 2× `EMERGENCY_SHUTDOWN_INITIATED` rows in the events table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-arms the shutdown trigger on POWER_RESTORED so the next outage still initiates shutdown even if the previous attempt didn’t stop the host. Fixes #4 and ships as 5.2.2 (changelog consolidated with recent TUI fixes).

- **Bug Fixes**
  - Clear per-monitor shutdown flag on OB/FSD→OL in `UPSGroupMonitor._handle_on_line`.
  - Multi-UPS: coordinator passes `power_restored_callback` to `_clear_local_shutdown_state`, and makes the lock reset + global flag unlink atomic under `_local_shutdown_lock`.
  - Log a warning in `_trigger_immediate_shutdown` when a re-trigger is gated by an existing flag.
  - Docs: troubleshooting updated with the new warning and guidance.
  - Tests: +5 monitor unit tests, +3 multi-UPS tests, E2E Test 34 for `local_shutdown.enabled=true` with a no-op command; script quoting/trap fixes.

<sup>Written for commit 5d3aa1aaad316e5fab5cde9ec3e4c9087a1459c6. Summary will update on new commits. <a href="https://cubic.dev/pr/m4r1k/Eneru/pull/41?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 5.2.2

* **Bug Fixes**
  * Fixed shutdown trigger failing to re-arm after power restoration when the local shutdown command did not actually halt the host.
  * Fixed TUI graph initialization for voltage and time graphs.
  * Fixed phantom 0V voltage samples appearing in graph display.

* **New Features**
  * Added warning logs when shutdown re-triggers are blocked during active shutdown sequences.

* **Documentation**
  * Updated changelog for version 5.2.2.
  * Added troubleshooting guidance for shutdown-flag behavior and power restoration scenarios.
  * Clarified CLI option documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->