### PR TITLE
fix(tui): tier events priority + decouple --time from events

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,50 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.2.2] - 2026-04-28
 
-TUI usability fixes plus one safety-critical re-arm fix on the shutdown
-state machine. Drop-in upgrade.
+Bug-fix release. Drop-in upgrade.
 
 ### Fixed
-- **Shutdown trigger never re-armed after `POWER_RESTORED`** when the
-  local-shutdown command failed to actually halt the host (custom
-  no-op command, sandboxed environment, dummy-UPS test rig — bug #4).
-  Subsequent on-battery transitions silently no-op'd at the flag-file
-  gate. The handler now clears the flag on the OB/FSD → OL transition,
-  and `MultiUPSCoordinator` resets its in-memory lock + global flag in
-  the same hook so multi-UPS deployments re-arm too. Gated re-triggers
-  also log a warning so the no-op is no longer silent.
-- **`eneru tui --graph voltage` silently ignored in interactive mode.**
-  The CLI flag now seeds the initial graph metric, and `--time` seeds
-  the initial window; `<G>` / `<T>` cycle from there.
-- **A single phantom 0 V sample squashed the voltage band into a
-  one-pixel strip at the top of the graph.** Writer drops on-line
-  `input.voltage <= 0` rows at sample time (real outages — `OB`/`FSD`
-  — still record the legitimate dip to 0 V); graph panel auto-scales
-  unbounded metrics from the 5th/95th percentile so any leftover
-  outliers don't dictate the band.
+- Shutdown trigger never re-armed after `POWER_RESTORED` when the
+  local-shutdown command didn't actually halt the host (bug #4).
+  Single-UPS and multi-UPS coordinator paths both fixed. Gated
+  re-triggers now log a warning instead of returning silently.
+- `eneru tui --graph voltage` silently ignored in interactive mode.
+- Phantom 0 V samples squashed the voltage graph into a one-row strip
+  at the top. Writer drops on-line `input.voltage <= 0` (real
+  outages still record the dip); graph uses 5th/95th percentile bounds.
+- Events panel showed daemon-lifecycle chatter instead of power
+  events. Priority filter is now tiered: power events always survive
+  the cap; daemon events fill remaining slots.
+- `eneru tui --once --events-only` silently fell back to log parsing
+  because the default 1 h window was empty for sparse events. Events
+  no longer use a time window at all.
 
 ### Added
-- **`--verbose` / `-v`** on `eneru tui` (live + `--once`): widens the
-  events filter to include low-priority chatter alongside the priority
-  defaults. Live TUI gains a `<V>` keybind to toggle in-session.
-- **`--full-history`** for `eneru tui --once`: ignore the `--time`
-  window and query the events table from the beginning. Rejects with
-  `error: --full-history requires --once` (exit 2) when combined with
+- `--verbose` / `-v`: include low-priority events. `<V>` toggles in
   the live TUI.
+- `--length N`: cap events output (default 30, `0` = no cap).
 
 ### Changed
-- **Events panel defaults to priority-only** in both live TUI and
-  `eneru tui --once --events-only`. Daemon lifecycle, shutdown
-  triggers, and power transitions surface; per-condition chatter
-  is hidden. Scripts that grep `--once --events-only` for
-  low-priority event types must now pass `--verbose`.
-- Live TUI events panel default cap raised from 8 to 20 rows so a few
-  voltage transitions don't push the daemon-level history off-screen.
+- `--time` and `<T>` apply to the graph only. Use `--length` for events.
+- Events panel defaults to priority-only.
+- Live TUI events cap raised from 8 to 30 rows.
 
 ### Migration notes
-None for the package install. Scripts parsing `eneru tui --once
---events-only` output: add `--verbose` if you rely on seeing
-low-priority event types (voltage flaps, etc.).
+- Scripts grepping `--events-only` output for low-priority event
+  types: add `--verbose`.
+- Scripts using `--time` to size events: switch to `--length`.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,7 +35,9 @@ Bug-fix release. Drop-in upgrade.
 ### Changed
 - `--time` and `<T>` apply to the graph only. Use `--length` for events.
 - Events panel defaults to priority-only.
-- Live TUI events cap raised from 8 to 30 rows.
+- Live TUI events cap raised (now `min(30, visible_panel_rows)` so
+  power events stay inside the visible window on smaller terminals;
+  `<M>` still expands to 500 rows for full scrollable history).
 
 ### Migration notes
 - Scripts grepping `--events-only` output for low-priority event

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,5 +442,5 @@ Example package commands:
 sudo eneru validate --config /etc/ups-monitor/config.yaml
 sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
 sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
-sudo /opt/ups-monitor/eneru.py monitor --once --events-only --verbose --length 100 --config /etc/ups-monitor/config.yaml
+sudo eneru monitor --once --events-only --verbose --length 100 --config /etc/ups-monitor/config.yaml
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -431,10 +431,10 @@ Common flags:
 | `monitor` | `--once` | Print one status snapshot |
 | `monitor` | `--interval` | TUI refresh interval |
 | `monitor` | `--graph {charge,load,voltage,runtime}` | Initial graph metric (interactive: cycle with `<G>`) |
-| `monitor` | `--time {1h,6h,24h,7d,30d}` | Initial graph / event window (interactive seeds the cycle, still toggle with `<T>`) |
+| `monitor` | `--time {1h,6h,24h,7d,30d}` | **Graph** time range (interactive: cycle with `<T>`). Does NOT affect the events list — events have no time window |
 | `monitor` | `--events-only` | Print recent events only |
 | `monitor` | `--verbose`, `-v` | Show low-priority events too (default: priority only); `<V>` toggles in-session |
-| `monitor` | `--full-history` | Ignore `--time`, query events from the beginning (`--once` only) |
+| `monitor` | `--length N` | With `--once`: max events to print (default 30, 0 = no cap). Power events always preserved within the cap |
 
 Example package commands:
 
@@ -442,5 +442,5 @@ Example package commands:
 sudo eneru validate --config /etc/ups-monitor/config.yaml
 sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
 sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
-sudo /opt/ups-monitor/eneru.py monitor --once --events-only --verbose --full-history --config /etc/ups-monitor/config.yaml
+sudo /opt/ups-monitor/eneru.py monitor --once --events-only --verbose --length 100 --config /etc/ups-monitor/config.yaml
 ```

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -18,6 +18,21 @@ except ImportError:
     apprise = None
 
 
+def _non_negative_int(value: str) -> int:
+    """argparse type for ``--length``: int >= 0 (0 = no cap)."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            f"--length must be a non-negative integer, got {value!r}"
+        )
+    if n < 0:
+        raise argparse.ArgumentTypeError(
+            f"--length must be >= 0 (0 = no cap), got {n}"
+        )
+    return n
+
+
 def _load_config(args):
     """Load configuration from the --config path."""
     return ConfigLoader.load(getattr(args, 'config', None))
@@ -368,31 +383,9 @@ def _cmd_deliver_stop(args):
 
 def _cmd_monitor(args):
     """Launch the TUI dashboard."""
-    # Validate flag combinations BEFORE _load_config so the rejection
-    # isn't preceded by a "Configuration loaded from: ..." message --
-    # that ordering looked like the validate-then-fail had succeeded.
-    # argparse can't easily express "this flag requires --once" so we
-    # do it here, exit with the same code argparse would use, and
-    # mimic its ``error: ...`` stderr format so log scrapers keep
-    # working.
-    if getattr(args, "full_history", False) and not args.once:
-        # Compose the prefix from the actual invocation so users running
-        # ``eneru monitor`` don't get an "eneru tui: ..." message and
-        # vice versa. ``args.command`` is set by argparse via the
-        # subparsers' ``dest="command"``; fall back to ``argv[1]`` if
-        # that's somehow missing (defensive: monitor / tui are aliases).
-        sub = getattr(args, "command", None) or (
-            sys.argv[1] if len(sys.argv) > 1 else "monitor"
-        )
-        sys.stderr.write(
-            f"eneru {sub}: error: --full-history requires --once "
-            "(interactive TUI is real-time)\n"
-        )
-        sys.exit(2)
-
     config = _load_config(args)
 
-    from eneru.tui import run_tui, run_once
+    from eneru.tui import run_tui, run_once, EVENTS_MAX_ROWS_NORMAL
 
     if args.once:
         run_once(
@@ -401,7 +394,7 @@ def _cmd_monitor(args):
             time_range=getattr(args, "time", "1h"),
             events_only=getattr(args, "events_only", False),
             verbose=getattr(args, "verbose", False),
-            full_history=getattr(args, "full_history", False),
+            length=getattr(args, "length", EVENTS_MAX_ROWS_NORMAL),
         )
     else:
         run_tui(
@@ -465,9 +458,14 @@ def main():
                        choices=["charge", "load", "voltage", "runtime"],
                        help="Initial graph metric. With --once renders a Braille snapshot; "
                             "in interactive TUI pre-selects the metric (still cycle with <G>)")
+        # IMPORTANT: --time is GRAPH-ONLY in 5.2.2+. It must NOT be
+        # threaded into the events query. Events are sparse and a fixed
+        # window made the panel silently empty for normal homelab usage
+        # (the events panel then fell back to log parsing without the
+        # operator noticing). Use --length to size the events list.
         p.add_argument("--time", default="1h",
-                       help="Initial graph time range (1h/6h/24h/7d/30d). Applies to "
-                            "--once snapshots and to the interactive TUI's initial view")
+                       help="Graph time range (1h/6h/24h/7d/30d). Applies only to the "
+                            "graph -- the events list is independent (use --length to size it)")
         p.add_argument("--events-only", action="store_true",
                        help="With --once: print only the events list (SQLite, log-tail fallback)")
         p.add_argument("--verbose", "-v", action="store_true",
@@ -475,9 +473,11 @@ def main():
                             "(daemon lifecycle, shutdown triggers, power transitions). "
                             "Applies to both --once and the interactive TUI; toggle "
                             "in-session with <V>")
-        p.add_argument("--full-history", action="store_true",
-                       help="Ignore --time and query the events table from the beginning. "
-                            "Only valid with --once")
+        p.add_argument("--length", type=_non_negative_int, default=30,
+                       metavar="N",
+                       help="With --once: max events to print (default: 30, 0 = no cap). "
+                            "Power events are always preserved within the cap; daemon-"
+                            "lifecycle events fill remaining slots")
         p.set_defaults(func=_cmd_monitor)
 
     mon_parser = subparsers.add_parser("monitor", help="Launch real-time TUI dashboard")

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -1171,9 +1171,22 @@ def run_tui(config: Config, interval: int = 5, *,
             for g in config.ups_groups:
                 groups_data.append(collect_group_data(g, config))
                 update_live_buffer(g, config)
-            events_cap = (
-                EVENTS_MAX_ROWS_MORE if show_more else EVENTS_MAX_ROWS_NORMAL
+            # Couple the data cap to the visible-rows estimate. Without
+            # this, the cap is 30 but the panel only renders ~12 rows
+            # anchored at the bottom (most-recent end of the chronological
+            # list). With tier-trim placing power events at the top of
+            # the list, the visible window shows the daemon-rich tail and
+            # power events sit off-screen until the operator scrolls up.
+            # Sizing the data cap to the panel keeps power events inside
+            # the visible window in normal mode; <M> still expands to
+            # EVENTS_MAX_ROWS_MORE (500) for full scrollable history.
+            visible_estimate = max(
+                3, logs_end - logs_start - 4  # title + footer + padding
             )
+            if show_more:
+                events_cap = EVENTS_MAX_ROWS_MORE
+            else:
+                events_cap = min(EVENTS_MAX_ROWS_NORMAL, visible_estimate)
             log_events = query_events_for_display(
                 config, max_events=events_cap,
                 priority_only=not events_verbose,

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -429,11 +429,11 @@ def query_events_for_display(
 
     ``max_events=None`` (or 0) disables the row cap entirely.
 
-    Trim is **tiered**: when capping, every row in :data:`POWER_EVENTS`
-    is preserved, then remaining slots are filled with the most-recent
-    :data:`LIFECYCLE_EVENTS` and other priority rows. Daemon noise can
-    therefore never push power events off-screen, even when the cap is
-    20 and the most recent 50 events are all daemon restarts.
+    Trim is **3-tier**: POWER_EVENTS always survive the cap; remaining
+    slots are filled first with most-recent LIFECYCLE_EVENTS, then with
+    chatter (only reachable when ``priority_only=False`` widens the
+    upstream filter). Power events are never evicted; lifecycle context
+    outranks voltage-flap chatter when the cap is hit in verbose mode.
     """
     multi_ups = config.multi_ups
     rows: List[tuple] = []  # (ts, label, event_type, detail)
@@ -470,22 +470,33 @@ def query_events_for_display(
 
     rows.sort(key=lambda r: r[0])
 
-    # Tiered trim: power events always survive the cap. ``max_events``
-    # in (None, 0) means no cap.
+    # Three-tier trim: POWER_EVENTS always survive; if room left,
+    # LIFECYCLE_EVENTS fill next; only then chatter (other rows that
+    # made it through ``priority_only=False``). This matches the
+    # priority hierarchy users care about: power transitions are
+    # never evicted, daemon-lifecycle context is preferred over
+    # voltage-flap chatter, and chatter rounds out the cap when
+    # ``--verbose`` is on. ``max_events`` in (None, 0) means no cap.
     if max_events and len(rows) > max_events:
         power = [r for r in rows if r[2] in POWER_EVENTS]
-        non_power = [r for r in rows if r[2] not in POWER_EVENTS]
+        lifecycle = [r for r in rows if r[2] in LIFECYCLE_EVENTS]
+        chatter = [r for r in rows
+                   if r[2] not in POWER_EVENTS and r[2] not in LIFECYCLE_EVENTS]
         if len(power) >= max_events:
             # Pathological: more power events than the cap. Show the
             # most-recent N -- still better than evicting them.
             kept = power[-max_events:]
         else:
             remaining = max_events - len(power)
-            kept_non_power = non_power[-remaining:]
+            # Lifecycle fills first; chatter only if room remains.
+            kept_lifecycle = lifecycle[-remaining:]
+            remaining -= len(kept_lifecycle)
+            kept_chatter = chatter[-remaining:] if remaining > 0 else []
             # Re-sort by ts so the panel never displays out-of-time-order
             # rows after the tier merge. Python's sort is stable, so
-            # equal-timestamp rows preserve insertion order (power first).
-            kept = sorted(power + kept_non_power, key=lambda r: r[0])
+            # equal-timestamp rows preserve insertion order.
+            kept = sorted(power + kept_lifecycle + kept_chatter,
+                          key=lambda r: r[0])
         rows = kept
 
     return [_format_event_line(ts, label, etype, detail, multi_ups)

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -22,6 +22,20 @@ from eneru.stats import StatsStore
 
 # Cycle order for the G key + --graph flag.
 GRAPH_MODES = ("off", "charge", "load", "voltage", "runtime")
+
+# ----------------------------------------------------------------------
+# IMPORTANT: TIME_RANGES / TIME_RANGE_SECONDS / the --time CLI flag /
+# the <T> keystroke are GRAPH-ONLY in 5.2.2+. They scope the graph's
+# X-axis window. They must NOT be used to filter the events panel.
+#
+# Events are sparse (one row per power transition or daemon lifecycle
+# event, not per-poll), so a fixed time window made the panel silently
+# empty for normal homelab usage. The events panel queries the full
+# events table and trims by row count via --length / EVENTS_MAX_ROWS_*.
+# Don't re-couple the two -- the original 5.2.0 coupling is exactly
+# the bug that made the events panel silently fall back to log
+# parsing. See query_events_for_display + run_once for the new wiring.
+# ----------------------------------------------------------------------
 TIME_RANGES = ("1h", "6h", "24h", "7d", "30d")
 TIME_RANGE_SECONDS = {
     "1h": 3600,
@@ -37,30 +51,52 @@ TIME_RANGE_SECONDS = {
 # table is one row per power event, not per poll, so even years of
 # history stay tiny) and lets the operator scroll through with the
 # arrow keys.
-EVENTS_MAX_ROWS_NORMAL = 20
-EVENTS_MAX_ROWS_MORE = 500
+EVENTS_MAX_ROWS_NORMAL = 30  # default cap; matches CLI --length default
+EVENTS_MAX_ROWS_MORE = 500   # <M> "More logs" toggle cap
 
-# Default-visible event types. The events table accumulates a mix of
-# load-bearing milestones (daemon lifecycle, shutdown triggers, power
-# transitions) and chatter that's useful when debugging but noisy
-# day-to-day (per-condition voltage warnings, suppressed flaps, etc.).
-# The TUI ships filtered to the milestones; ``--verbose`` (CLI) and the
-# ``<V>`` key (interactive) widen the filter to include everything.
-PRIORITY_EVENTS = frozenset({
+# Two tiers of priority. The events table accumulates power transitions
+# (operator's reason for opening the panel), daemon lifecycle (useful
+# context but high-volume during testing or rapid restarts), and chatter
+# that's only relevant when debugging.
+#
+# POWER_EVENTS are *always* preserved within the row cap -- never
+# evicted by daemon noise. LIFECYCLE_EVENTS fill the remaining slots
+# with the most-recent rows. Anything outside both sets is "verbose"
+# chatter, surfaced only when ``--verbose`` / ``<V>`` is on.
+#
+# Without this tiering, a homelab user who hits a real outage 4 days
+# ago and then iterates on the daemon today sees 20 rows of
+# DAEMON_RESTARTED / DAEMON_UPGRADED in the panel and the actual
+# ON_BATTERY rows are pushed off-screen. (Bug surfaced in 5.2.2 by
+# the maintainer's own data: 65 daemon-lifecycle rows vs 5 power-event
+# rows in the events table.)
+POWER_EVENTS = frozenset({
+    "ON_BATTERY",
+    "POWER_RESTORED",
+    "EMERGENCY_SHUTDOWN_INITIATED",
+    "SHUTDOWN_SEQUENCE_COMPLETE",
+    "VOLTAGE_LOW",
+    "VOLTAGE_HIGH",
+    "BROWNOUT_DETECTED",
+    "OVER_VOLTAGE_DETECTED",
+    "OVERLOAD_DETECTED",
+    "BATTERY_LOW",
+    "FSD_DETECTED",
+    "CONNECTION_LOST",
+    "CONNECTION_RESTORED",
+})
+
+LIFECYCLE_EVENTS = frozenset({
     "DAEMON_START",
     "DAEMON_STOP",
     "DAEMON_RESTARTED",
     "DAEMON_UPGRADED",
     "DAEMON_RECOVERED",
-    "EMERGENCY_SHUTDOWN_INITIATED",
-    "SHUTDOWN_SEQUENCE_COMPLETE",
-    "POWER_RESTORED",
-    "ON_BATTERY",
-    "VOLTAGE_LOW",
-    "VOLTAGE_HIGH",
-    "CONNECTION_LOST",
-    "CONNECTION_RESTORED",
 })
+
+# Union for backwards compatibility with callers / tests that grep for
+# "is this row in the priority set" without caring about the tier split.
+PRIORITY_EVENTS = POWER_EVENTS | LIFECYCLE_EVENTS
 
 # Map graph modes to (column, unit_suffix, y_min, y_max, value_formatter).
 # value_formatter takes a float and returns the user-facing display
@@ -369,31 +405,36 @@ def _format_event_line(ts: int, label: str, event_type: str,
 
 def query_events_for_display(
     config: Config,
-    time_range_seconds: Optional[int] = None,
     *,
-    max_events: Optional[int] = EVENTS_MAX_ROWS_MORE,
+    max_events: Optional[int] = EVENTS_MAX_ROWS_NORMAL,
     priority_only: bool = True,
 ) -> List[str]:
     """Pull events from each UPS's SQLite store, sorted by timestamp.
 
-    ``time_range_seconds=None`` (default) returns everything in the
-    events table; pass an explicit window to limit by age. Returns
-    formatted display strings ready to drop into the TUI events panel.
-    Returns an empty list when no per-UPS DB exists -- callers should
-    fall back to ``parse_log_events`` in that case.
+    Always queries the full events table -- there is no time-range
+    parameter. Events are sparse compared to graph samples, and a
+    fixed time window made the panel silently empty for normal
+    homelab usage (the daemon emits maybe one or two power events per
+    week). Callers that want to *narrow* the result use ``max_events``;
+    callers that want *all* of them pass ``max_events=None``.
+
+    Returns formatted display strings ready to drop into the TUI events
+    panel. Returns an empty list when no per-UPS DB exists -- callers
+    should fall back to ``parse_log_events`` in that case.
 
     ``priority_only=True`` (default) limits the result to event types in
     :data:`PRIORITY_EVENTS` so the panel surfaces daemon and power
     transitions instead of being crowded out by per-condition chatter.
     Pass ``False`` (CLI ``--verbose`` / TUI ``<V>``) to include all rows.
 
-    ``max_events=None`` disables the row cap entirely. Used by the CLI
-    ``--full-history`` path so that "from the beginning" actually means
-    every row in the events table -- a finite cap of 500 silently
-    dropped older events on long-running installs.
+    ``max_events=None`` (or 0) disables the row cap entirely.
+
+    Trim is **tiered**: when capping, every row in :data:`POWER_EVENTS`
+    is preserved, then remaining slots are filled with the most-recent
+    :data:`LIFECYCLE_EVENTS` and other priority rows. Daemon noise can
+    therefore never push power events off-screen, even when the cap is
+    20 and the most recent 50 events are all daemon restarts.
     """
-    end = int(time.time())
-    start = 0 if time_range_seconds is None else end - max(60, int(time_range_seconds))
     multi_ups = config.multi_ups
     rows: List[tuple] = []  # (ts, label, event_type, detail)
     any_db_seen = False
@@ -408,7 +449,10 @@ def query_events_for_display(
             store = StatsStore(db_path)
             store._conn = conn
             try:
-                events = store.query_events(start, end)
+                # Query from epoch to now -- no time window. Events are
+                # sparse (per-event, not per-poll) so the full table is
+                # tiny even after years of uptime.
+                events = store.query_events(0, int(time.time()))
             finally:
                 store._conn = None
             for ts, etype, detail in events:
@@ -425,8 +469,25 @@ def query_events_for_display(
         return []  # signal "no DB" so callers can fall back
 
     rows.sort(key=lambda r: r[0])
-    if max_events is not None:
-        rows = rows[-max_events:]
+
+    # Tiered trim: power events always survive the cap. ``max_events``
+    # in (None, 0) means no cap.
+    if max_events and len(rows) > max_events:
+        power = [r for r in rows if r[2] in POWER_EVENTS]
+        non_power = [r for r in rows if r[2] not in POWER_EVENTS]
+        if len(power) >= max_events:
+            # Pathological: more power events than the cap. Show the
+            # most-recent N -- still better than evicting them.
+            kept = power[-max_events:]
+        else:
+            remaining = max_events - len(power)
+            kept_non_power = non_power[-remaining:]
+            # Re-sort by ts so the panel never displays out-of-time-order
+            # rows after the tier merge. Python's sort is stable, so
+            # equal-timestamp rows preserve insertion order (power first).
+            kept = sorted(power + kept_non_power, key=lambda r: r[0])
+        rows = kept
+
     return [_format_event_line(ts, label, etype, detail, multi_ups)
             for ts, label, etype, detail in rows]
 
@@ -1256,27 +1317,30 @@ def render_graph_text(
 
 def run_once(config: Config, *, graph_metric: Optional[str] = None,
              time_range: str = "1h", events_only: bool = False,
-             verbose: bool = False, full_history: bool = False):
+             verbose: bool = False, length: int = EVENTS_MAX_ROWS_NORMAL):
     """Print a status snapshot to stdout and exit.
 
     With ``events_only=True`` the status / resource summary and graph
     block are skipped -- only the events list (from SQLite if available,
     otherwise the log tail) is printed. Useful for scripts and CI.
 
+    ``time_range`` is **graph-only** -- it does not affect the events
+    list. Events are sparse and a fixed window made the panel silently
+    empty for normal homelab usage.
+
     ``verbose=True`` includes low-priority chatter alongside the
-    :data:`PRIORITY_EVENTS` defaults. ``full_history=True`` ignores the
-    ``time_range`` window and queries the events table from epoch.
+    :data:`PRIORITY_EVENTS` defaults.
+
+    ``length`` caps the events list (default :data:`EVENTS_MAX_ROWS_NORMAL`,
+    set to 0 for no cap). Tiered preservation: power events always
+    survive the cap; daemon-lifecycle events fill remaining slots.
     """
-    # When --full-history is set, the cap is removed entirely (None) so
-    # "from the beginning" means every row, not "the most recent 500".
-    # Otherwise the events-only window caps at 50 to keep stdout sane;
-    # the snapshot path uses a smaller 10-row tail.
-    events_cap = None if full_history else 50
+    # length=0 means "no cap" -- pass None through to the query.
+    events_cap = None if length == 0 else length
 
     if events_only:
-        window = None if full_history else TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
         events = query_events_for_display(
-            config, window, max_events=events_cap,
+            config, max_events=events_cap,
             priority_only=not verbose,
         )
         if not events:
@@ -1328,13 +1392,15 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
             print()
 
     # Snapshot path: same flag semantics as the events-only branch
-    # above. --full-history widens the time window AND the row cap;
-    # --verbose drops the priority filter so low-priority chatter can
-    # surface here too. Pre-fix this section silently ignored both.
-    snapshot_window = None if full_history else TIME_RANGE_SECONDS.get(time_range, 24 * 3600)
-    snapshot_cap = None if full_history else 10
+    # above. --verbose drops the priority filter; --length caps the
+    # row count. The snapshot tail is a small summary under the
+    # status block -- it always caps at 10 even when --length is
+    # higher (or 0/unbounded), so an operator asking for "all events"
+    # gets that via --events-only, not via the snapshot tail
+    # drowning the status header it was designed to summarize.
+    snapshot_cap = 10 if events_cap is None else min(events_cap, 10)
     events = query_events_for_display(
-        config, snapshot_window, max_events=snapshot_cap,
+        config, max_events=snapshot_cap,
         priority_only=not verbose,
     )
     if not events:

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -264,8 +264,12 @@ echo "  PASS: priority-only filter hides chatter, keeps DAEMON_START"
 # --length 5 caps output. There's only one daemon-lifecycle event in the
 # stats DB at this point (from the daemon's own DAEMON_START), so we
 # can't easily count to 5 here -- just confirm --length runs cleanly.
-eneru monitor --once --events-only --length 5 --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-length.log 2>&1
-if [ $? -ne 0 ]; then
+# Wrap the invocation in the `if` directly: under `set -e` a separate
+# `[ $? -ne 0 ]` branch would never run because the script aborts on
+# the first non-zero exit, masking any regression with no log dump.
+if ! eneru monitor --once --events-only --length 5 \
+    --config "$E2E_DIR/config-e2e-stats.yaml" \
+    > /tmp/test31-length.log 2>&1; then
   echo "FAIL: --length 5 returned non-zero"
   cat /tmp/test31-length.log
   exit 1

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -226,7 +226,11 @@ fi
 NOW=$(date +%s)
 sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($NOW, 'TEST31_MARKER', 'e2e injected');"
 
-eneru monitor --once --events-only --verbose --time 1h --config "$E2E_DIR/config-e2e-stats.yaml" 2>&1 | tee /tmp/test31.log
+# 5.2.2: --time is graph-only; --length sizes the events list.
+# TEST31_MARKER is not a priority event type so verify with --verbose --
+# the test scope is "events panel reads from SQLite", not the priority
+# filter itself.
+eneru monitor --once --events-only --verbose --config "$E2E_DIR/config-e2e-stats.yaml" 2>&1 | tee /tmp/test31.log
 
 if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31.log; then
   echo "FAIL: injected event not surfaced by --events-only --verbose"
@@ -235,17 +239,16 @@ if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31.log; then
 fi
 echo "PASS: events panel reads from SQLite"
 
-# ----- 5.2.2: priority filter, --verbose, --full-history -----
-# These piggyback on the seeded DB (no extra container churn). Assert:
+# ----- 5.2.2: priority filter + --length -----
+# Assert:
 #   1. Default (no --verbose) hides TEST31_MARKER but shows DAEMON_START.
-#   2. --verbose surfaces TEST31_MARKER again.
-#   3. --full-history requires --once -- without it the CLI must reject
-#      with exit code 2 (argparse-style), not just any non-zero.
+#   2. --length 5 caps output at 5 rows.
+#   3. --length -1 is rejected (argparse type validator).
 
 echo ""
-echo "  --- 5.2.2 events filter checks ---"
+echo "  --- 5.2.2 events filter + length checks ---"
 
-eneru monitor --once --events-only --time 1h --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-priority.log 2>&1
+eneru monitor --once --events-only --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-priority.log 2>&1
 if grep -q "TEST31_MARKER" /tmp/test31-priority.log; then
   echo "FAIL: priority-only default leaked TEST31_MARKER"
   cat /tmp/test31-priority.log
@@ -258,31 +261,29 @@ if ! grep -q "DAEMON_START" /tmp/test31-priority.log; then
 fi
 echo "  PASS: priority-only filter hides chatter, keeps DAEMON_START"
 
-# --full-history with --once is fine; --full-history without --once must
-# reject. Capture the actual exit code and assert it's exactly 2 (the
-# code argparse uses for argument rejection); accepting "any non-zero"
-# would mask a regression that turned the rejection into a generic
-# crash with exit 1.
+# --length 5 caps output. There's only one daemon-lifecycle event in the
+# stats DB at this point (from the daemon's own DAEMON_START), so we
+# can't easily count to 5 here -- just confirm --length runs cleanly.
+eneru monitor --once --events-only --length 5 --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-length.log 2>&1
+if [ $? -ne 0 ]; then
+  echo "FAIL: --length 5 returned non-zero"
+  cat /tmp/test31-length.log
+  exit 1
+fi
+echo "  PASS: --length 5 accepted"
+
+# --length -1 must reject with argparse exit 2 (negative count is
+# meaningless and accepting it would mask user error).
 set +e
-eneru monitor --events-only --full-history --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-fhfail.log 2>&1
+eneru monitor --once --events-only --length -1 --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-lenfail.log 2>&1
 RC=$?
 set -e
-if [ "$RC" -eq 0 ]; then
-  echo "FAIL: --full-history without --once should have rejected (got exit 0)"
-  cat /tmp/test31-fhfail.log
-  exit 1
-fi
 if [ "$RC" -ne 2 ]; then
-  echo "FAIL: --full-history rejection should exit 2 (argparse convention), got $RC"
-  cat /tmp/test31-fhfail.log
+  echo "FAIL: --length -1 should reject with exit 2 (argparse), got $RC"
+  cat /tmp/test31-lenfail.log
   exit 1
 fi
-if ! grep -q "full-history" /tmp/test31-fhfail.log; then
-  echo "FAIL: --full-history rejection message missing the flag name"
-  cat /tmp/test31-fhfail.log
-  exit 1
-fi
-echo "  PASS: --full-history without --once rejects with exit 2"
+echo "  PASS: --length -1 rejects with exit 2"
 )
 
 # ======================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,8 +86,12 @@ class TestCLITuiAlias:
         # Sanity: must include the monitor-specific options, not just
         # the universal --help / --config.
         assert {"--once", "--interval", "--graph", "--time",
-                "--events-only", "--verbose", "--full-history"}.issubset(
+                "--events-only", "--verbose", "--length"}.issubset(
             opts_seen["tui"])
+        # 5.2.2: --full-history was a transient flag added and removed
+        # before release. --length covers the same use case more cleanly
+        # (--length 0 = no cap).
+        assert "--full-history" not in opts_seen["tui"]
 
 
 class TestCLICompletion:
@@ -131,7 +135,7 @@ class TestCLICompletion:
 
 
 class TestCLIMonitorFlags:
-    """Test the new --verbose / --full-history flags on monitor/tui."""
+    """Test the --verbose / --length flags on monitor/tui."""
 
     def _minimal_config(self, tmp_path):
         config_file = tmp_path / "config.yaml"
@@ -140,73 +144,6 @@ class TestCLIMonitorFlags:
             "behavior:\n  dry_run: true\n"
         )
         return config_file
-
-    @pytest.mark.unit
-    def test_full_history_requires_once(self, tmp_path, capsys):
-        """``--full-history`` without ``--once`` must reject loudly with
-        argparse-style ``exit 2`` + ``error: ...`` on stderr. Live TUI
-        is real-time by definition; silently dropping the flag would
-        mask user error.
-        """
-        config_file = self._minimal_config(tmp_path)
-        # Patch run_tui at its source module (cli imports it locally) so
-        # if the reject regresses the curses entry point can't actually
-        # try to start.
-        with patch("eneru.tui.run_tui") as mock_run_tui:
-            with patch.object(sys, "argv", ["eneru", "tui",
-                                            "-c", str(config_file),
-                                            "--full-history"]):
-                with pytest.raises(SystemExit) as exc_info:
-                    main()
-                # argparse uses exit 2 for argument-rejection. Match it.
-                assert exc_info.value.code == 2
-                err = capsys.readouterr().err
-                assert "--full-history" in err
-                assert "--once" in err
-                assert "error:" in err
-                # 5.2.2 (CodeRabbit): the prefix must reflect the
-                # invocation -- "eneru tui:" when invoked as `tui`,
-                # "eneru monitor:" when invoked as `monitor`. The
-                # earlier hardcoded "eneru tui:" lied for monitor users.
-                assert "eneru tui:" in err
-                mock_run_tui.assert_not_called()
-
-    @pytest.mark.unit
-    def test_full_history_rejection_uses_invoked_subcommand_prefix(
-        self, tmp_path, capsys
-    ):
-        """5.2.2 (CodeRabbit): same rejection via the ``monitor`` alias
-        must say "eneru monitor:" -- not "eneru tui:". The error prefix
-        is composed from the actual subcommand the user typed."""
-        config_file = self._minimal_config(tmp_path)
-        with patch("eneru.tui.run_tui"):
-            with patch.object(sys, "argv", ["eneru", "monitor",
-                                            "-c", str(config_file),
-                                            "--full-history"]):
-                with pytest.raises(SystemExit):
-                    main()
-            err = capsys.readouterr().err
-            assert "eneru monitor:" in err, (
-                f"expected 'eneru monitor:' prefix, got: {err!r}"
-            )
-            assert "eneru tui:" not in err
-
-    @pytest.mark.unit
-    def test_full_history_with_once_accepted(self, tmp_path):
-        """The same flag with ``--once`` reaches run_once with
-        full_history=True."""
-        from eneru.tui import run_once
-        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
-            config_file = self._minimal_config(tmp_path)
-            with patch.object(sys, "argv", ["eneru", "tui",
-                                            "-c", str(config_file),
-                                            "--once", "--events-only",
-                                            "--full-history"]):
-                main()
-            mock_once.assert_called_once()
-            kwargs = mock_once.call_args.kwargs
-            assert kwargs.get("full_history") is True
-            assert kwargs.get("events_only") is True
 
     @pytest.mark.unit
     def test_verbose_short_form_accepted(self, tmp_path):
@@ -221,6 +158,89 @@ class TestCLIMonitorFlags:
                 main()
             mock_once.assert_called_once()
             assert mock_once.call_args.kwargs.get("verbose") is True
+
+    @pytest.mark.unit
+    def test_length_default_is_30(self, tmp_path):
+        """``--length`` default reaches run_once as 30."""
+        from eneru.tui import run_once
+        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
+            config_file = self._minimal_config(tmp_path)
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only"]):
+                main()
+            assert mock_once.call_args.kwargs.get("length") == 30
+
+    @pytest.mark.unit
+    def test_length_explicit_value_accepted(self, tmp_path):
+        """``--length 5`` reaches run_once as 5."""
+        from eneru.tui import run_once
+        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
+            config_file = self._minimal_config(tmp_path)
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only",
+                                            "--length", "5"]):
+                main()
+            assert mock_once.call_args.kwargs.get("length") == 5
+
+    @pytest.mark.unit
+    def test_length_zero_accepted(self, tmp_path):
+        """``--length 0`` (no cap) is a valid value."""
+        from eneru.tui import run_once
+        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
+            config_file = self._minimal_config(tmp_path)
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only",
+                                            "--length", "0"]):
+                main()
+            assert mock_once.call_args.kwargs.get("length") == 0
+
+    @pytest.mark.unit
+    def test_length_negative_rejected(self, tmp_path, capsys):
+        """``--length -1`` rejects with argparse exit 2 + clear stderr."""
+        config_file = self._minimal_config(tmp_path)
+        with patch("eneru.tui.run_once"):
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only",
+                                            "--length", "-1"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 2
+                err = capsys.readouterr().err
+                assert "--length" in err
+
+    @pytest.mark.unit
+    def test_length_non_numeric_rejected(self, tmp_path, capsys):
+        """``--length foo`` rejects cleanly via the type validator."""
+        config_file = self._minimal_config(tmp_path)
+        with patch("eneru.tui.run_once"):
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only",
+                                            "--length", "foo"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 2
+
+    @pytest.mark.unit
+    def test_full_history_flag_no_longer_exists(self, tmp_path, capsys):
+        """5.2.2 design: ``--full-history`` was added then removed
+        before release. Use ``--length 0`` for the same effect.
+        Argparse must reject the flag as unknown."""
+        config_file = self._minimal_config(tmp_path)
+        with patch("eneru.tui.run_once"):
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only",
+                                            "--full-history"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 2
+                err = capsys.readouterr().err
+                assert "--full-history" in err  # argparse names the bad flag
 
 
 class TestCLIValidateConfig:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1239,16 +1239,16 @@ class TestQueryEventsForDisplay:
 
         lines = query_events_for_display(config, max_events=20)
         # All 3 power-event rows MUST survive the cap.
-        assert any("ON_BATTERY: real outage" in l for l in lines), (
+        assert any("ON_BATTERY: real outage" in line for line in lines), (
             f"ON_BATTERY pushed off by daemon noise -- tiered trim regressed. "
             f"Got: {lines}"
         )
-        assert any("POWER_RESTORED: outage 10m" in l for l in lines)
-        assert any("EMERGENCY_SHUTDOWN_INITIATED" in l for l in lines)
+        assert any("POWER_RESTORED: outage 10m" in line for line in lines)
+        assert any("EMERGENCY_SHUTDOWN_INITIATED" in line for line in lines)
         # Result respects the cap.
         assert len(lines) == 20
         # Remaining 17 slots are most-recent daemon rows.
-        daemon_lines = [l for l in lines if "DAEMON_RESTARTED" in l]
+        daemon_lines = [line for line in lines if "DAEMON_RESTARTED" in line]
         assert len(daemon_lines) == 17
 
     @pytest.mark.unit
@@ -1271,9 +1271,48 @@ class TestQueryEventsForDisplay:
         lines = query_events_for_display(config, max_events=10)
         # 10 most-recent ON_BATTERY rows; daemon entirely evicted.
         assert len(lines) == 10
-        assert all("ON_BATTERY" in l for l in lines)
-        assert any("outage-49" in l for l in lines)  # latest power event
-        assert any("outage-40" in l for l in lines)  # 10th-latest
+        assert all("ON_BATTERY" in line for line in lines)
+        assert any("outage-49" in line for line in lines)  # latest power event
+        assert any("outage-40" in line for line in lines)  # 10th-latest
+
+    @pytest.mark.unit
+    def test_tiered_trim_lifecycle_outranks_chatter(self, tmp_path):
+        """5.2.2 (CodeRabbit refinement): in --verbose mode (priority_only
+        =False), chatter rows reach the trim layer alongside lifecycle
+        rows. Lifecycle is more important than per-condition chatter --
+        when the cap evicts non-power rows, lifecycle should survive
+        first, then chatter fills any leftover slots."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        # 1 power event + 30 chatter rows + 4 lifecycle rows.
+        # Cap = 7. Result must be: 1 power + 4 lifecycle + 2 chatter,
+        # NOT: 1 power + 6 chatter (chatter evicting lifecycle).
+        events = [(now - 5000, "ON_BATTERY", "outage")]
+        for i in range(30):
+            events.append(
+                (now - 1000 + i, "VOLTAGE_FLAP_SUPPRESSED", f"flap-{i}")
+            )
+        for i in range(4):
+            events.append(
+                (now - 100 + i * 10, "DAEMON_RESTARTED", f"d-{i}")
+            )
+        _seed_events(config, config.ups_groups[0], events)
+
+        lines = query_events_for_display(
+            config, max_events=7, priority_only=False,
+        )
+        assert len(lines) == 7
+        assert sum("ON_BATTERY" in line for line in lines) == 1, (
+            f"power event must survive: {lines}"
+        )
+        assert sum("DAEMON_RESTARTED" in line for line in lines) == 4, (
+            f"all 4 lifecycle rows must outrank chatter; got: {lines}"
+        )
+        assert sum("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines) == 2, (
+            f"chatter fills only the 2 leftover slots; got: {lines}"
+        )
 
 
 class TestRobustBounds:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1055,7 +1055,7 @@ class TestQueryEventsForDisplay:
             (now - 60, "ON_BATTERY", "Battery: 85%"),
             (now - 30, "POWER_RESTORED", "Outage 30s"),
         ])
-        lines = query_events_for_display(config, time_range_seconds=3600)
+        lines = query_events_for_display(config)
         assert len(lines) == 2
         # Single-UPS configs do not prefix with [LABEL].
         assert "[" not in lines[0]
@@ -1073,7 +1073,7 @@ class TestQueryEventsForDisplay:
                      [(now - 60, "ON_BATTERY", "ups1")])
         _seed_events(config, config.ups_groups[1],
                      [(now - 30, "ON_BATTERY", "ups2")])
-        lines = query_events_for_display(config, time_range_seconds=3600)
+        lines = query_events_for_display(config)
         assert len(lines) == 2
         # Sorted by ts ascending, prefixed with [label].
         assert "[UPS1@host1] ON_BATTERY: ups1" in lines[0]
@@ -1092,31 +1092,11 @@ class TestQueryEventsForDisplay:
                      [(now - 100, "A", ""), (now - 20, "C", "")])
         _seed_events(config, config.ups_groups[1],
                      [(now - 60, "B", "")])
-        lines = query_events_for_display(
-            config, time_range_seconds=3600, priority_only=False,
-        )
+        lines = query_events_for_display(config, priority_only=False)
         # Order: A (UPS1), B (UPS2), C (UPS1)
         assert "[UPS1@h] A" in lines[0]
         assert "[UPS2@h] B" in lines[1]
         assert "[UPS1@h] C" in lines[2]
-
-    @pytest.mark.unit
-    def test_outside_time_window_excluded(self, tmp_path):
-        from eneru.tui import query_events_for_display
-        import time as _time
-        config = _events_config(tmp_path)
-        now = int(_time.time())
-        _seed_events(config, config.ups_groups[0], [
-            (now - 7200, "OLD", "two hours ago"),
-            (now - 60, "RECENT", "one minute ago"),
-        ])
-        # 1-hour window -> only RECENT included. priority_only=False so
-        # the test stays focused on the time window, not on the type filter.
-        lines = query_events_for_display(
-            config, time_range_seconds=3600, priority_only=False,
-        )
-        assert len(lines) == 1
-        assert "RECENT" in lines[0]
 
     @pytest.mark.unit
     def test_max_events_caps_results(self, tmp_path):
@@ -1129,8 +1109,7 @@ class TestQueryEventsForDisplay:
         ])
         # priority_only=False — testing the row cap, not the type filter.
         lines = query_events_for_display(
-            config, time_range_seconds=3600, max_events=3,
-            priority_only=False,
+            config, max_events=3, priority_only=False,
         )
         # Most recent 3 events.
         assert len(lines) == 3
@@ -1186,9 +1165,7 @@ class TestQueryEventsForDisplay:
         events.append((now - 50, "DAEMON_START", "v1"))
         events.append((now - 5, "POWER_RESTORED", "Outage 12s"))
         _seed_events(config, config.ups_groups[0], events)
-        lines = query_events_for_display(
-            config, time_range_seconds=3600, max_events=8,
-        )
+        lines = query_events_for_display(config, max_events=8)
         # Both priority rows present, no VOLTAGE_FLAP_SUPPRESSED lines.
         assert any("DAEMON_START" in line for line in lines)
         assert any("POWER_RESTORED" in line for line in lines)
@@ -1206,66 +1183,97 @@ class TestQueryEventsForDisplay:
             (now - 100, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
             (now - 50, "DAEMON_START", "v1"),
         ])
-        lines = query_events_for_display(
-            config, time_range_seconds=3600, priority_only=False,
-        )
+        lines = query_events_for_display(config, priority_only=False)
         assert len(lines) == 2
         assert any("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines)
         assert any("DAEMON_START" in line for line in lines)
 
     @pytest.mark.unit
-    def test_full_history_ignores_time_window(self, tmp_path):
-        """Calling with ``time_range_seconds=None`` (the wire-level
-        equivalent of ``--full-history``) returns events older than any
-        finite window would surface."""
-        from eneru.tui import query_events_for_display
-        import time as _time
-        config = _events_config(tmp_path)
-        now = int(_time.time())
-        # Far older than any --time choice (largest is 30d).
-        old_ts = now - 90 * 86400
-        _seed_events(config, config.ups_groups[0], [
-            (old_ts, "DAEMON_START", "ancient"),
-            (now - 60, "DAEMON_START", "recent"),
-        ])
-        # 24h window misses the ancient one.
-        windowed = query_events_for_display(config, time_range_seconds=86400)
-        assert len(windowed) == 1
-        assert "recent" in windowed[0]
-        # No window -> ancient included.
-        full = query_events_for_display(config, time_range_seconds=None)
-        assert len(full) == 2
-        assert "ancient" in full[0]
-        assert "recent" in full[1]
-
-    @pytest.mark.unit
     def test_max_events_none_disables_cap(self, tmp_path):
-        """5.2.2 (CodeRabbit P1): ``max_events=None`` returns every
-        matching row -- the ``--full-history`` promise. Pre-fix the
-        cap was hardcoded at 500 in the events-only path so installs
-        with longer event histories silently lost the older rows."""
+        """``max_events=None`` returns every priority row in the events
+        table -- the ``--length 0`` promise. The default cap of 30
+        would otherwise silently drop older rows on long-running installs.
+        """
         from eneru.tui import query_events_for_display
         import time as _time
         config = _events_config(tmp_path)
         now = int(_time.time())
-        # Seed 600 priority events -- comfortably above the old 500 cap.
+        # Seed 600 priority events -- comfortably above the new default cap of 30.
         _seed_events(config, config.ups_groups[0], [
             (now - 600 + i, "DAEMON_START", f"row-{i}")
             for i in range(600)
         ])
-        # Default cap (EVENTS_MAX_ROWS_MORE=500) drops the oldest 100.
-        capped = query_events_for_display(config, time_range_seconds=None)
-        assert len(capped) == 500
+        # Default cap (EVENTS_MAX_ROWS_NORMAL=30) drops the oldest 570.
+        capped = query_events_for_display(config)
+        assert len(capped) == 30
         # max_events=None must surface every row.
-        full = query_events_for_display(
-            config, time_range_seconds=None, max_events=None,
-        )
+        full = query_events_for_display(config, max_events=None)
         assert len(full) == 600, (
             f"max_events=None must disable the cap; got {len(full)} rows"
         )
         # Ordering preserved (ascending by timestamp).
         assert "row-0" in full[0]
         assert "row-599" in full[-1]
+
+    @pytest.mark.unit
+    def test_tiered_trim_preserves_power_events(self, tmp_path):
+        """5.2.2 (real bug surfaced by maintainer's data): when the cap
+        triggers, POWER_EVENTS must always survive even when the most-
+        recent rows are all daemon-lifecycle. Pre-fix, 65 daemon rows
+        could push 5 power-event rows off-screen at cap=20 since both
+        tiers were treated as one undifferentiated 'priority' set.
+        """
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        # Mirror the maintainer's actual data shape: a sea of recent
+        # DAEMON_RESTARTED + a handful of older ON_BATTERY / POWER_RESTORED.
+        events = []
+        for i in range(60):
+            events.append((now - 60 + i, "DAEMON_RESTARTED", f"daemon-{i}"))
+        events.append((now - 86400 * 5, "ON_BATTERY", "real outage"))
+        events.append((now - 86400 * 5 + 600, "POWER_RESTORED", "outage 10m"))
+        events.append((now - 86400 * 7, "EMERGENCY_SHUTDOWN_INITIATED", "low batt"))
+        _seed_events(config, config.ups_groups[0], events)
+
+        lines = query_events_for_display(config, max_events=20)
+        # All 3 power-event rows MUST survive the cap.
+        assert any("ON_BATTERY: real outage" in l for l in lines), (
+            f"ON_BATTERY pushed off by daemon noise -- tiered trim regressed. "
+            f"Got: {lines}"
+        )
+        assert any("POWER_RESTORED: outage 10m" in l for l in lines)
+        assert any("EMERGENCY_SHUTDOWN_INITIATED" in l for l in lines)
+        # Result respects the cap.
+        assert len(lines) == 20
+        # Remaining 17 slots are most-recent daemon rows.
+        daemon_lines = [l for l in lines if "DAEMON_RESTARTED" in l]
+        assert len(daemon_lines) == 17
+
+    @pytest.mark.unit
+    def test_tiered_trim_pathological_more_power_than_cap(self, tmp_path):
+        """Edge case: more power events than the cap. Take the most
+        recent N -- still better than evicting them in favor of daemon
+        events."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        events = [
+            (now - 1000 + i, "ON_BATTERY", f"outage-{i}") for i in range(50)
+        ]
+        events += [
+            (now - 100 + i, "DAEMON_RESTARTED", f"daemon-{i}") for i in range(5)
+        ]
+        _seed_events(config, config.ups_groups[0], events)
+
+        lines = query_events_for_display(config, max_events=10)
+        # 10 most-recent ON_BATTERY rows; daemon entirely evicted.
+        assert len(lines) == 10
+        assert all("ON_BATTERY" in l for l in lines)
+        assert any("outage-49" in l for l in lines)  # latest power event
+        assert any("outage-40" in l for l in lines)  # 10th-latest
 
 
 class TestRobustBounds:
@@ -1480,33 +1488,61 @@ class TestRunOnceEventsOnly:
         )
 
     @pytest.mark.unit
-    def test_snapshot_path_honours_full_history_flag(self, tmp_path, capsys):
-        """5.2.2 (CodeRabbit P1): same as verbose -- the non-events-only
-        branch ignored ``--full-history`` and stayed bound to the
-        ``--time`` window. Older events were silently dropped from the
-        tail block even when the user asked for the full picture."""
+    def test_snapshot_path_no_time_window_for_events(self, tmp_path, capsys):
+        """5.2.2: events have no time window -- ``--time`` only affects
+        graphs. The snapshot tail must surface old DAEMON rows even
+        though they fall outside any ``--time`` choice."""
         from eneru.tui import run_once
         import time as _time
         config = _events_config(tmp_path)
         now = int(_time.time())
-        old_ts = now - 90 * 86400  # well outside any --time choice
+        old_ts = now - 90 * 86400  # 3 months ago
         _seed_events(config, config.ups_groups[0], [
             (old_ts, "DAEMON_START", "ancient"),
             (now - 60, "DAEMON_START", "recent"),
         ])
-        # Default snapshot path with default 24h window: only recent.
         run_once(config, events_only=False)
-        out_default = capsys.readouterr().out
-        assert "recent" in out_default
-        assert "ancient" not in out_default
-        # --full-history: ancient also surfaces.
-        run_once(config, events_only=False, full_history=True)
-        out_full = capsys.readouterr().out
-        assert "recent" in out_full
-        assert "ancient" in out_full, (
-            "snapshot path must honour --full-history; pre-5.2.2 it "
-            "stayed bound to the --time window"
+        out = capsys.readouterr().out
+        # Both surface even though "ancient" is well outside any --time:
+        # the snapshot tail caps at 10 rows but applies no time filter.
+        assert "recent" in out
+        assert "ancient" in out, (
+            "snapshot path must show events regardless of --time; events "
+            "have no time window in 5.2.2+"
         )
+
+    @pytest.mark.unit
+    def test_events_only_length_caps_output(self, tmp_path, capsys):
+        """``--length N`` (events_only=True path) caps output to N rows."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 100 + i, "DAEMON_START", f"row-{i}") for i in range(50)
+        ])
+        run_once(config, events_only=True, length=5)
+        out = capsys.readouterr().out
+        # Should see exactly 5 lines -- the most-recent 5 DAEMON_START rows.
+        lines = [l for l in out.splitlines() if "DAEMON_START" in l]
+        assert len(lines) == 5
+        assert "row-49" in lines[-1]
+        assert "row-45" in lines[0]
+
+    @pytest.mark.unit
+    def test_events_only_length_zero_means_no_cap(self, tmp_path, capsys):
+        """``--length 0`` returns every priority row."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 100 + i, "DAEMON_START", f"row-{i}") for i in range(40)
+        ])
+        run_once(config, events_only=True, length=0)
+        out = capsys.readouterr().out
+        lines = [l for l in out.splitlines() if "DAEMON_START" in l]
+        assert len(lines) == 40, f"length=0 must show all rows; got {len(lines)}"
 
 
 class TestDisplayWidthAndTruncate:


### PR DESCRIPTION
Three real bugs in the unreleased v5.2.2 surfaced when testing against the maintainer's own data (65 daemon-lifecycle events vs 5 power events in the SQLite events table — the priority filter as it shipped was actually pushing power events off-screen).

## Bugs fixed

1. **Events panel showed daemon noise instead of power events.** `PRIORITY_EVENTS` lumped power transitions and daemon-lifecycle into one undifferentiated set, so the most-recent N rows in the cap were all `DAEMON_RESTARTED` / `DAEMON_UPGRADED` from package iteration. Power events from days ago got pushed off-screen.

   Fix: split into `POWER_EVENTS` (always preserved within cap) and `LIFECYCLE_EVENTS` (fill remaining slots). `query_events_for_display` trim logic preserves all power events first, then fills with most-recent lifecycle events. Daemon noise can no longer push power events off-screen.

2. **`eneru tui --once --events-only` silently fell back to log parsing** for sparse-event installs. The default 1h time window was almost always empty, so SQLite returned `[]` and the code parsed `/var/log/ups-monitor.log` instead. Live TUI and `--once` showed structurally different content and the operator never noticed.

   Fix: events query no longer takes a time-range parameter at all. Always queries the full events table (events are sparse, this is fine).

3. **`--time` accidentally scoped both the graph window AND the events panel.** Cause of #2.

   Fix: `--time` and `<T>` are graph-only now. Anchor comments at `tui.py` (TIME_RANGES) and `cli.py` (`--time` flag def) name the bug they prevent so this can't be re-coupled by accident.

## Knob change

- **Removed `--full-history`** (only added in unreleased 5.2.2; replaced cleanly by `--length 0`).
- **Added `--length N`** for `--once`: cap events output (default 30, `0` = no cap; argparse type validator rejects negatives + non-numerics).
- **Live TUI events cap** now coupled to the visible-rows estimate (`min(EVENTS_MAX_ROWS_NORMAL, visible_panel_rows)`). Without this, the data cap was 30 but the panel only renders ~11 rows on a 24-row terminal, so the tier-trim's preserved power events sat above the visible window. `<M>` still expands to 500 rows.

## Sequencing

This rides on the existing unreleased v5.2.2 in main. No version bump or changelog re-tag needed — the `[5.2.2]` entry is updated in this PR to reflect the final design (tier-trim, `--length`, no `--full-history`). Maintainer asked the changelog be kept tiny since this is a bugfix release.

## Test plan

- [x] 981 unit/integration tests pass (`pytest -q --timeout=30` in uv venv); 13 new tests covering tier preservation (incl. the maintainer's exact reproducer: 60 daemon + 3 power, asserts all 3 power events survive cap=20), pathological "more power events than cap", `--length` validation, and snapshot-path tail behavior
- [x] Manual on Rocky Linux 9 (rebuilt RPM, `dnf reinstall`): `eneru tui` (live, 24×80) shows the 5 power events at top of panel; `--once --events-only --length 5` returns the 5 most-recent power events; `--length -1` rejects with exit 2; `--full-history` rejected as unknown by argparse
- [x] Pre-push code review (agent-skills:code-reviewer, opus): one P3 (snapshot tail unbounded with `--length 0`) addressed before push
- [x] CI must pass: validate matrix (Python 3.9-3.14) + 5 E2E matrix jobs. E2E `Stats` exercises the new `--length` validation + priority-only default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI events list with three-tier priority so power events never get pushed off-screen, and makes `--time` graph-only. Adds `--length` for `--once`, removes `--full-history`, and sizes live events to the visible rows.

- **Bug Fixes**
  - Three-tier priority: power events are always kept; lifecycle fills next; chatter only when `--verbose`. Prevents chatter from evicting lifecycle rows in verbose mode.
  - Events read the full SQLite table (no time window). Prevents empty panels and log fallbacks. `--time` and `<T>` now affect only the graph.
  - Live TUI caps events to the visible rows (`min(30, visible_panel_rows)`; `<M>` still expands to 500).
  - Snapshot tail always caps at 10 lines to keep the header readable.

- **Migration**
  - Replace `--full-history` with `--length 0`.
  - If you used `--time` to size events, switch to `--length`.
  - If you grep for low‑priority types, pass `--verbose`.

<sup>Written for commit 7cdd1e7d92ce02657b76a58fe84316eaeac43cd2. Summary will update on new commits. <a href="https://cubic.dev/pr/m4r1k/Eneru/pull/42?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified `--time` controls only graph time range, not events query

* **Changed**
  * Replaced `--full-history` with new `--length N` parameter to cap event output
  * Power events now prioritized in display; lifecycle events fill remaining slots
  * Increased events display cap from 20 to 30 rows in live mode
  * `--verbose/-v` now includes low-priority events

* **Bug Fixes**
  * Events panel decoupled from graph time selection
  * `--events-only` now falls back to log parsing when default window is empty

<!-- end of auto-generated comment: release notes by coderabbit.ai -->