### PR TITLE
Tier TUI event display by verbosity

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.0] - Unreleased
+
+### Changed
+- Event display now uses user-facing tiers: Power Events by default,
+  Diagnostics with `-v` / `<V>`, and Lifecycle with `-vv` / a second
+  `<V>` press.
+- Live TUI events are grouped by tier; `--once` remains a flat,
+  timestamp-sorted list.
+- Event caps preserve Power first, then Diagnostics, then Lifecycle.
+
+---
+
 ## [5.2.2] - 2026-04-28
 
 Bug-fix release. Drop-in upgrade.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -433,8 +433,8 @@ Common flags:
 | `monitor` | `--graph {charge,load,voltage,runtime}` | Initial graph metric (interactive: cycle with `<G>`) |
 | `monitor` | `--time {1h,6h,24h,7d,30d}` | **Graph** time range (interactive: cycle with `<T>`). Does NOT affect the events list — events have no time window |
 | `monitor` | `--events-only` | Print recent events only |
-| `monitor` | `--verbose`, `-v` | Show low-priority events too (default: priority only); `<V>` toggles in-session |
-| `monitor` | `--length N` | With `--once`: max events to print (default 30, 0 = no cap). Power events always preserved within the cap |
+| `monitor` | `--verbose`, `-v` | Increase event verbosity: default shows Power Events, `-v` adds Diagnostics, `-vv` adds Lifecycle; `<V>` cycles in-session |
+| `monitor` | `--length N` | With `--once`: max events to print (default 30, 0 = no cap). Caps preserve Power, then Diagnostics, then Lifecycle |
 
 Example package commands:
 
@@ -442,5 +442,5 @@ Example package commands:
 sudo eneru validate --config /etc/ups-monitor/config.yaml
 sudo eneru run --dry-run --config /etc/ups-monitor/config.yaml
 sudo eneru monitor --once --events-only --config /etc/ups-monitor/config.yaml
-sudo eneru monitor --once --events-only --verbose --length 100 --config /etc/ups-monitor/config.yaml
+sudo eneru monitor --once --events-only -vv --length 100 --config /etc/ups-monitor/config.yaml
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -81,7 +81,7 @@ done
 | Redundancy runtime | Quorum evaluation, advisory triggers, idempotent group execution |
 | Health monitoring | Voltage thresholds, AVR, bypass, overload, battery anomaly filtering |
 | Notifications | Formatting, retry queue, lifecycle classification, coalescing, suppression rules |
-| Statistics and TUI | SQLite schema, aggregation, event queries, graphs, one-shot monitor output |
+| Statistics and TUI | SQLite schema, aggregation, event tier filtering, TUI grouping, graphs, one-shot monitor output |
 | Packaging | nFPM file list, package install paths, wrapper execution |
 
 ## End-to-end tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -145,7 +145,7 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 36 numb
 | 28 | Stats | SQLite stats DB is created with samples and daemon-start event rows |
 | 29 | Stats | Stats writer failure is non-fatal and does not crash monitoring |
 | 30 | Stats | `monitor --once --graph` renders a graph from persisted stats data |
-| 31 | Stats | `monitor --once --events-only` reads events from SQLite |
+| 31 | Stats | `monitor --once --events-only` reads SQLite events and enforces event verbosity tiers |
 | 32 | Stats | Voltage nominal auto-detect re-snaps misreported NUT nominal voltage and records a silent event |
 | 33 | UPS Single | `voltage_sensitivity` avoids 120 V hot-grid false alarms while preserving real brownout detection |
 | 34 | Stats | Pending on-battery and restored notifications coalesce into one brief-outage summary |

--- a/docs/tui-graphs.md
+++ b/docs/tui-graphs.md
@@ -94,6 +94,16 @@ The graph freshness behavior is tied to the stats writer's 10-second flush inter
 
 The Recent Events panel reads the SQLite `events` table. If no database exists yet, it falls back to the log file.
 
+Events are filtered by operator relevance:
+
+| Verbosity | CLI | Live TUI | Events shown |
+|-----------|-----|----------|--------------|
+| Default | none | initial view | Power Events only |
+| Diagnostics | `-v` / `--verbose` | press `<V>` once | Power Events and Diagnostics |
+| All | `-vv` | press `<V>` twice | Power Events, Diagnostics, and Lifecycle |
+
+The live TUI groups enabled tiers as Power Events, Diagnostics, then Lifecycle. `--once` keeps a flat timestamp-sorted list for scripts. When `--length` caps output, Power Events are kept first, Diagnostics fill next, and Lifecycle rows fill last.
+
 In multi-UPS mode, event lines include the UPS label:
 
 ```text

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -468,16 +468,15 @@ def main():
                             "graph -- the events list is independent (use --length to size it)")
         p.add_argument("--events-only", action="store_true",
                        help="With --once: print only the events list (SQLite, log-tail fallback)")
-        p.add_argument("--verbose", "-v", action="store_true",
-                       help="Show low-priority events alongside the priority defaults "
-                            "(daemon lifecycle, shutdown triggers, power transitions). "
-                            "Applies to both --once and the interactive TUI; toggle "
-                            "in-session with <V>")
+        p.add_argument("--verbose", "-v", action="count", default=0,
+                       help="Increase event verbosity. Default shows Power Events only; "
+                            "-v adds Diagnostics; -vv adds Lifecycle. Applies to both "
+                            "--once and the interactive TUI; cycle in-session with <V>")
         p.add_argument("--length", type=_non_negative_int, default=30,
                        metavar="N",
                        help="With --once: max events to print (default: 30, 0 = no cap). "
-                            "Power events are always preserved within the cap; daemon-"
-                            "lifecycle events fill remaining slots")
+                            "Power events are always preserved within the cap; diagnostics "
+                            "fill next, lifecycle fills last")
         p.set_defaults(func=_cmd_monitor)
 
     mon_parser = subparsers.add_parser("monitor", help="Launch real-time TUI dashboard")

--- a/src/eneru/completion/eneru.bash
+++ b/src/eneru/completion/eneru.bash
@@ -17,7 +17,7 @@ _eneru() {
     local subcommands="run validate monitor tui test-notifications completion version"
     local global_opts="-h --help"
     local config_opts="-c --config"
-    local monitor_opts="--once --interval --graph --time --events-only"
+    local monitor_opts="--once --interval --graph --time --events-only -v --verbose --length"
     local run_opts="--dry-run --exit-after-shutdown"
     local graph_choices="charge load voltage runtime"
     local time_choices="1h 6h 24h 7d 30d"
@@ -50,7 +50,7 @@ _eneru() {
             COMPREPLY=( $(compgen -W "$time_choices" -- "$cur") )
             return 0
             ;;
-        --interval)
+        --interval|--length)
             # Numeric; offer common defaults but allow free input.
             COMPREPLY=( $(compgen -W "1 2 5 10 30 60" -- "$cur") )
             return 0

--- a/src/eneru/completion/eneru.fish
+++ b/src/eneru/completion/eneru.fish
@@ -67,6 +67,8 @@ for sub in monitor tui
     complete -c eneru -n "__eneru_using $sub" -l graph -r -fa 'charge load voltage runtime' -d 'Metric to graph'
     complete -c eneru -n "__eneru_using $sub" -l time -r -fa '1h 6h 24h 7d 30d' -d 'Time range'
     complete -c eneru -n "__eneru_using $sub" -l events-only -d 'Print only the events list'
+    complete -c eneru -n "__eneru_using $sub" -s v -l verbose -d 'Increase event verbosity'
+    complete -c eneru -n "__eneru_using $sub" -l length -r -fa '0 10 30 60 100 500' -d 'Max events to print with --once'
 end
 
 # `completion` argument.

--- a/src/eneru/completion/eneru.zsh
+++ b/src/eneru/completion/eneru.zsh
@@ -55,7 +55,9 @@ _eneru() {
                         '--interval[refresh interval in seconds]:seconds:(1 2 5 10 30 60)' \
                         "--graph[render graph for metric]:metric:($graph_choices)" \
                         "--time[time range]:range:($time_choices)" \
-                        '--events-only[print only the events list]'
+                        '--events-only[print only the events list]' \
+                        '(-v --verbose)'{-v,--verbose}'[increase event verbosity]' \
+                        '--length[max events to print with --once]:rows:(0 10 30 60 100 500)'
                     ;;
                 completion)
                     _values 'shell' $completion_shells

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -588,6 +588,17 @@ def query_events_for_display(
         return [_format_event_line(ts, label, etype, detail, multi_ups)
                 for ts, label, etype, detail in rows]
 
+    # Grouped mode renders one header per non-empty tier, so a section needs
+    # at least 2 lines (1 header + 1 row) to display without an orphan header.
+    # At max_events == 1 there is no room for both, so fall back to the single
+    # most-recent row -- the tier-priority trim above already guarantees it
+    # is the highest-priority survivor (Power before Diagnostics before
+    # Lifecycle), preserving the "Power events are never evicted within the
+    # cap" docstring contract at length=1.
+    if max_events == 1:
+        return [_format_event_line(ts, label, etype, detail, multi_ups)
+                for ts, label, etype, detail in rows]
+
     grouped_lines: List[str] = []
     sections = (
         (EVENT_SECTION_POWER, lambda r: r[2] in POWER_EVENTS),
@@ -601,8 +612,10 @@ def query_events_for_display(
             continue
         if max_events:
             remaining_lines = max_events - len(grouped_lines)
-            # Headers consume live-panel rows too. Avoid rendering an orphan
-            # section header with no room for at least one event below it.
+            # Headers consume live-panel rows too. Need >= 2 (1 header +
+            # 1 row) to render this section without an orphan header.
+            # The max_events == 1 degenerate case is handled above as a
+            # fallback to the trimmed single row.
             if remaining_lines < 2:
                 break
             section_rows = section_rows[-(remaining_lines - 1):]

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -78,6 +78,8 @@ POWER_EVENTS = frozenset({
     "VOLTAGE_HIGH",
     "BROWNOUT_DETECTED",
     "OVER_VOLTAGE_DETECTED",
+    "BYPASS_MODE_ACTIVE",
+    "OVERLOAD_ACTIVE",
     "OVERLOAD_DETECTED",
     "BATTERY_LOW",
     "FSD_DETECTED",
@@ -596,7 +598,7 @@ def query_events_for_display(
             # section header with no room for at least one event below it.
             if remaining_lines < 2:
                 break
-            section_rows = section_rows[:remaining_lines - 1]
+            section_rows = section_rows[-(remaining_lines - 1):]
         grouped_lines.append(section)
         grouped_lines.extend(
             _format_event_line(ts, label, etype, detail, multi_ups)

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -590,6 +590,13 @@ def query_events_for_display(
         section_rows = [r for r in rows if predicate(r)]
         if not section_rows:
             continue
+        if max_events:
+            remaining_lines = max_events - len(grouped_lines)
+            # Headers consume live-panel rows too. Avoid rendering an orphan
+            # section header with no room for at least one event below it.
+            if remaining_lines < 2:
+                break
+            section_rows = section_rows[:remaining_lines - 1]
         grouped_lines.append(section)
         grouped_lines.extend(
             _format_event_line(ts, label, etype, detail, multi_ups)
@@ -1463,7 +1470,7 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
 
     ``length`` caps the events list (default :data:`EVENTS_MAX_ROWS_NORMAL`,
     set to 0 for no cap). Tiered preservation: power events always
-    survive the cap; daemon-lifecycle events fill remaining slots.
+    survive the cap; diagnostics fill next, lifecycle fills last.
     """
     verbose = _events_verbosity(verbose)
     # length=0 means "no cap" -- pass None through to the query.

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -1553,13 +1553,8 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
             print()
 
     # Snapshot path: same flag semantics as the events-only branch above.
-    # --verbose increments enabled tiers; --length caps the row count. The
-    # snapshot tail is a small summary under the status block -- it always
-    # caps at 10 even when --length is higher (or 0/unbounded), so an
-    # operator asking for "all events" gets that via --events-only, not via
-    # the snapshot tail drowning the status header it was designed to
-    # summarize.
-    snapshot_cap = 10 if events_cap is None else min(events_cap, 10)
+    # --verbose increments enabled tiers; --length caps the row count.
+    snapshot_cap = events_cap
     events = query_events_for_display(
         config, max_events=snapshot_cap,
         verbosity=verbose,

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -54,22 +54,21 @@ TIME_RANGE_SECONDS = {
 EVENTS_MAX_ROWS_NORMAL = 30  # default cap; matches CLI --length default
 EVENTS_MAX_ROWS_MORE = 500   # <M> "More logs" toggle cap
 
-# Two tiers of priority. The events table accumulates power transitions
-# (operator's reason for opening the panel), daemon lifecycle (useful
-# context but high-volume during testing or rapid restarts), and chatter
-# that's only relevant when debugging.
+# Three display tiers. The events table accumulates power transitions
+# (operator's reason for opening the panel), diagnostics that help explain
+# electrical / UPS behavior, and daemon lifecycle rows that are useful
+# context but high-volume during testing or rapid restarts.
 #
 # POWER_EVENTS are *always* preserved within the row cap -- never
-# evicted by daemon noise. LIFECYCLE_EVENTS fill the remaining slots
-# with the most-recent rows. Anything outside both sets is "verbose"
-# chatter, surfaced only when ``--verbose`` / ``<V>`` is on.
+# evicted by daemon noise. DIAGNOSTIC_EVENTS are implicit: anything
+# outside POWER_EVENTS and LIFECYCLE_EVENTS. They surface at ``-v`` /
+# first ``<V>``. LIFECYCLE_EVENTS surface last at ``-vv`` / second
+# ``<V>``.
 #
-# Without this tiering, a homelab user who hits a real outage 4 days
-# ago and then iterates on the daemon today sees 20 rows of
-# DAEMON_RESTARTED / DAEMON_UPGRADED in the panel and the actual
-# ON_BATTERY rows are pushed off-screen. (Bug surfaced in 5.2.2 by
-# the maintainer's own data: 65 daemon-lifecycle rows vs 5 power-event
-# rows in the events table.)
+# Without this tiering, a homelab user who hits a real outage 4 days ago
+# and then iterates on the daemon today sees daemon rows instead of the
+# actual ON_BATTERY rows. (Bug surfaced in 5.2.2 by the maintainer's own
+# data: 65 daemon-lifecycle rows vs 5 power-event rows in the events table.)
 POWER_EVENTS = frozenset({
     "ON_BATTERY",
     "POWER_RESTORED",
@@ -94,9 +93,64 @@ LIFECYCLE_EVENTS = frozenset({
     "DAEMON_RECOVERED",
 })
 
-# Union for backwards compatibility with callers / tests that grep for
-# "is this row in the priority set" without caring about the tier split.
+# Union for callers / tests that grep for "is this row in the priority set"
+# without caring about the tier split.
 PRIORITY_EVENTS = POWER_EVENTS | LIFECYCLE_EVENTS
+
+EVENTS_VERBOSITY_POWER = 0
+EVENTS_VERBOSITY_DIAGNOSTICS = 1
+EVENTS_VERBOSITY_ALL = 2
+
+EVENT_SECTION_POWER = "Power Events"
+EVENT_SECTION_DIAGNOSTICS = "Diagnostics"
+EVENT_SECTION_LIFECYCLE = "Lifecycle"
+
+
+def _events_verbosity(value) -> int:
+    """Normalize legacy bools and count-style verbosity to 0..2."""
+    if isinstance(value, bool):
+        return (EVENTS_VERBOSITY_DIAGNOSTICS if value
+                else EVENTS_VERBOSITY_POWER)
+    try:
+        return max(EVENTS_VERBOSITY_POWER, min(int(value), EVENTS_VERBOSITY_ALL))
+    except (TypeError, ValueError):
+        return EVENTS_VERBOSITY_POWER
+
+
+def _event_tier(event_type: str) -> str:
+    """Return the user-facing display tier for an event type."""
+    if event_type in POWER_EVENTS:
+        return EVENT_SECTION_POWER
+    if event_type in LIFECYCLE_EVENTS:
+        return EVENT_SECTION_LIFECYCLE
+    return EVENT_SECTION_DIAGNOSTICS
+
+
+def _event_enabled(event_type: str, verbosity: int) -> bool:
+    """Return whether an event type is visible at the current verbosity."""
+    tier = _event_tier(event_type)
+    if tier == EVENT_SECTION_POWER:
+        return True
+    if tier == EVENT_SECTION_DIAGNOSTICS:
+        return verbosity >= EVENTS_VERBOSITY_DIAGNOSTICS
+    return verbosity >= EVENTS_VERBOSITY_ALL
+
+
+def _events_verbosity_label(verbosity: int) -> str:
+    """Short label for the live TUI footer."""
+    verbosity = _events_verbosity(verbosity)
+    if verbosity == EVENTS_VERBOSITY_POWER:
+        return "power"
+    if verbosity == EVENTS_VERBOSITY_DIAGNOSTICS:
+        return "+diag"
+    return "all"
+
+
+def _no_events_message(verbosity: int) -> str:
+    """Placeholder text when the enabled tiers have no rows."""
+    if _events_verbosity(verbosity) == EVENTS_VERBOSITY_POWER:
+        return "(no power events recorded)"
+    return "(no events)"
 
 # Map graph modes to (column, unit_suffix, y_min, y_max, value_formatter).
 # value_formatter takes a float and returns the user-facing display
@@ -360,6 +414,22 @@ def parse_log_events(log_path: str,
         return []
 
 
+def events_db_available(config: Config) -> bool:
+    """Return True when at least one per-UPS events DB can be opened."""
+    for group in config.ups_groups:
+        conn = StatsStore.open_readonly(stats_db_path_for(group, config))
+        if conn is None:
+            continue
+        try:
+            return True
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    return False
+
+
 def _sanitize_event_detail(detail: str) -> str:
     """Strip markdown formatting and collapse newlines so the detail
     fits on a single row of the events panel.
@@ -407,7 +477,9 @@ def query_events_for_display(
     config: Config,
     *,
     max_events: Optional[int] = EVENTS_MAX_ROWS_NORMAL,
-    priority_only: bool = True,
+    verbosity: int = EVENTS_VERBOSITY_POWER,
+    priority_only: Optional[bool] = None,
+    grouped: bool = False,
 ) -> List[str]:
     """Pull events from each UPS's SQLite store, sorted by timestamp.
 
@@ -422,19 +494,22 @@ def query_events_for_display(
     panel. Returns an empty list when no per-UPS DB exists -- callers
     should fall back to ``parse_log_events`` in that case.
 
-    ``priority_only=True`` (default) limits the result to event types in
-    :data:`PRIORITY_EVENTS` so the panel surfaces daemon and power
-    transitions instead of being crowded out by per-condition chatter.
-    Pass ``False`` (CLI ``--verbose`` / TUI ``<V>``) to include all rows.
+    ``verbosity`` selects enabled tiers: ``0`` shows Power Events only,
+    ``1`` adds Diagnostics, and ``2`` adds Lifecycle. ``priority_only`` is
+    accepted as a legacy shim for tests / older internal callers.
 
     ``max_events=None`` (or 0) disables the row cap entirely.
 
     Trim is **3-tier**: POWER_EVENTS always survive the cap; remaining
-    slots are filled first with most-recent LIFECYCLE_EVENTS, then with
-    chatter (only reachable when ``priority_only=False`` widens the
-    upstream filter). Power events are never evicted; lifecycle context
-    outranks voltage-flap chatter when the cap is hit in verbose mode.
+    slots are filled first with most-recent Diagnostics, then with
+    Lifecycle. Power events are never evicted; diagnostics outrank daemon
+    lifecycle context when the cap is hit in verbose mode.
     """
+    if priority_only is not None:
+        # Legacy compatibility: the old boolean API had priority_only=False
+        # mean "show every event type".
+        verbosity = EVENTS_VERBOSITY_POWER if priority_only else EVENTS_VERBOSITY_ALL
+    verbosity = _events_verbosity(verbosity)
     multi_ups = config.multi_ups
     rows: List[tuple] = []  # (ts, label, event_type, detail)
     any_db_seen = False
@@ -456,7 +531,7 @@ def query_events_for_display(
             finally:
                 store._conn = None
             for ts, etype, detail in events:
-                if priority_only and etype not in PRIORITY_EVENTS:
+                if not _event_enabled(etype, verbosity):
                     continue
                 rows.append((int(ts), group.ups.label, etype, detail or ""))
         finally:
@@ -471,36 +546,56 @@ def query_events_for_display(
     rows.sort(key=lambda r: r[0])
 
     # Three-tier trim: POWER_EVENTS always survive; if room left,
-    # LIFECYCLE_EVENTS fill next; only then chatter (other rows that
-    # made it through ``priority_only=False``). This matches the
-    # priority hierarchy users care about: power transitions are
-    # never evicted, daemon-lifecycle context is preferred over
-    # voltage-flap chatter, and chatter rounds out the cap when
-    # ``--verbose`` is on. ``max_events`` in (None, 0) means no cap.
+    # Diagnostics fill next; only then Lifecycle. This matches the
+    # operator-facing hierarchy: power transitions are never evicted,
+    # electrical / UPS diagnostics explain what is happening, and daemon
+    # lifecycle context rounds out the cap at the highest verbosity.
+    # ``max_events`` in (None, 0) means no cap.
     if max_events and len(rows) > max_events:
         power = [r for r in rows if r[2] in POWER_EVENTS]
         lifecycle = [r for r in rows if r[2] in LIFECYCLE_EVENTS]
-        chatter = [r for r in rows
-                   if r[2] not in POWER_EVENTS and r[2] not in LIFECYCLE_EVENTS]
+        diagnostics = [
+            r for r in rows
+            if r[2] not in POWER_EVENTS and r[2] not in LIFECYCLE_EVENTS
+        ]
         if len(power) >= max_events:
             # Pathological: more power events than the cap. Show the
             # most-recent N -- still better than evicting them.
             kept = power[-max_events:]
         else:
             remaining = max_events - len(power)
-            # Lifecycle fills first; chatter only if room remains.
-            kept_lifecycle = lifecycle[-remaining:]
-            remaining -= len(kept_lifecycle)
-            kept_chatter = chatter[-remaining:] if remaining > 0 else []
+            # Diagnostics fill first; lifecycle only if room remains.
+            kept_diagnostics = diagnostics[-remaining:]
+            remaining -= len(kept_diagnostics)
+            kept_lifecycle = lifecycle[-remaining:] if remaining > 0 else []
             # Re-sort by ts so the panel never displays out-of-time-order
             # rows after the tier merge. Python's sort is stable, so
             # equal-timestamp rows preserve insertion order.
-            kept = sorted(power + kept_lifecycle + kept_chatter,
+            kept = sorted(power + kept_diagnostics + kept_lifecycle,
                           key=lambda r: r[0])
         rows = kept
 
-    return [_format_event_line(ts, label, etype, detail, multi_ups)
-            for ts, label, etype, detail in rows]
+    if not grouped:
+        return [_format_event_line(ts, label, etype, detail, multi_ups)
+                for ts, label, etype, detail in rows]
+
+    grouped_lines: List[str] = []
+    sections = (
+        (EVENT_SECTION_POWER, lambda r: r[2] in POWER_EVENTS),
+        (EVENT_SECTION_DIAGNOSTICS,
+         lambda r: r[2] not in POWER_EVENTS and r[2] not in LIFECYCLE_EVENTS),
+        (EVENT_SECTION_LIFECYCLE, lambda r: r[2] in LIFECYCLE_EVENTS),
+    )
+    for section, predicate in sections:
+        section_rows = [r for r in rows if predicate(r)]
+        if not section_rows:
+            continue
+        grouped_lines.append(section)
+        grouped_lines.extend(
+            _format_event_line(ts, label, etype, detail, multi_ups)
+            for ts, label, etype, detail in section_rows
+        )
+    return grouped_lines
 
 
 # ==============================================================================
@@ -827,7 +922,8 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
                        events: List[str], show_more: bool,
                        *, graph_mode: str = "off", time_range: str = "1h",
                        ups_index: int = 0, ups_total: int = 1,
-                       scroll_offset: int = 0, verbose: bool = False):
+                       scroll_offset: int = 0,
+                       verbosity: int = EVENTS_VERBOSITY_POWER):
     """Render the logs panel with yellow/gold background, edge to edge.
 
     The bottom-row key hints reflect the *current* graph mode, time
@@ -850,7 +946,7 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
     y += 1
 
     if not events:
-        safe_addstr(win, y, 0, "   (no recent events)", gold_attr)
+        safe_addstr(win, y, 0, f"   {_no_events_message(verbosity)}", gold_attr)
         y += 1
     else:
         footer_lines = 2
@@ -871,6 +967,11 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
         for event in display_events:
             if y >= y_end - footer_lines:
                 break
+            is_section = event in (
+                EVENT_SECTION_POWER,
+                EVENT_SECTION_DIAGNOSTICS,
+                EVENT_SECTION_LIFECYCLE,
+            )
             # Account for the right-edge gutter and the leading 3-space
             # indent. Use display-cell width (handles emoji + CJK) so
             # lines never spill past the panel edge.
@@ -885,7 +986,8 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
             # cell width than display_width predicts; without this pad,
             # any miscount leaves cells with stale or unpainted bg.
             pad_cells = max(0, width - display_width(display))
-            safe_addstr(win, y, 0, display + (" " * pad_cells), gold_attr)
+            attr = gold_bold if is_section else gold_attr
+            safe_addstr(win, y, 0, display + (" " * pad_cells), attr)
             y += 1
 
     # Key hints at the bottom of the gold panel.
@@ -908,7 +1010,7 @@ def render_logs_panel(win, y_start: int, y_end: int, width: int,
         ("<G>", f"Graph: {graph_mode}"),
         ("<T>", f"Time: {time_range}"),
         ("<U>", ups_descr),
-        ("<V>", f"Verb: {'on' if verbose else 'off'}"),
+        ("<V>", f"Events: {_events_verbosity_label(verbosity)}"),
     )
     for label, descr in hints:
         if x + len(label) + len(descr) + 6 > width:
@@ -1091,7 +1193,7 @@ def run_tui(config: Config, interval: int = 5, *,
             initial_graph: Optional[str] = None,
             initial_time_range: str = "1h",
             initial_ups_index: int = 0,
-            verbose: bool = False):
+            verbose: int = EVENTS_VERBOSITY_POWER):
     """Run the curses TUI dashboard.
 
     Optional kwargs let the CLI pre-seed the cycle state so flags like
@@ -1099,8 +1201,8 @@ def run_tui(config: Config, interval: int = 5, *,
     requested view, instead of starting on the default (graph off) and
     forcing the operator to press <G>/<T> to get there.
 
-    ``verbose=True`` opens the events panel showing all event types
-    (matching ``--verbose`` on the CLI). The ``<V>`` key toggles this
+    ``verbose`` is a count-style event verbosity: 0 shows Power Events,
+    1 adds Diagnostics, and 2 adds Lifecycle. The ``<V>`` key cycles this
     in-session.
     """
     def _main(stdscr):
@@ -1125,7 +1227,7 @@ def run_tui(config: Config, interval: int = 5, *,
         ups_index = max(
             0, min(int(initial_ups_index or 0), max(0, len(config.ups_groups) - 1))
         )
-        events_verbose = bool(verbose)
+        events_verbosity = _events_verbosity(verbose)
         events_scroll = 0            # ↑/↓ scrolls events panel; 0 = bottom
 
         while True:
@@ -1200,9 +1302,10 @@ def run_tui(config: Config, interval: int = 5, *,
                 events_cap = min(EVENTS_MAX_ROWS_NORMAL, visible_estimate)
             log_events = query_events_for_display(
                 config, max_events=events_cap,
-                priority_only=not events_verbose,
+                verbosity=events_verbosity,
+                grouped=True,
             )
-            if not log_events:
+            if not log_events and not events_db_available(config):
                 log_events = parse_log_events(
                     config.logging.file or "",
                     max_events=events_cap,
@@ -1231,7 +1334,7 @@ def run_tui(config: Config, interval: int = 5, *,
                               ups_index=ups_index,
                               ups_total=len(config.ups_groups) or 1,
                               scroll_offset=events_scroll,
-                              verbose=events_verbose)
+                              verbosity=events_verbosity)
 
             # Move cursor to bottom-right to avoid visual artifacts
             try:
@@ -1251,7 +1354,9 @@ def run_tui(config: Config, interval: int = 5, *,
             elif key in (ord('m'), ord('M')):
                 show_more = not show_more
             elif key in (ord('v'), ord('V')):
-                events_verbose = not events_verbose
+                events_verbosity = (
+                    events_verbosity + 1
+                ) % (EVENTS_VERBOSITY_ALL + 1)
                 events_scroll = 0  # reset so the new (longer/shorter) list anchors at bottom
             elif key in (ord('g'), ord('G')):
                 graph_mode = cycle(GRAPH_MODES, graph_mode)
@@ -1341,7 +1446,8 @@ def render_graph_text(
 
 def run_once(config: Config, *, graph_metric: Optional[str] = None,
              time_range: str = "1h", events_only: bool = False,
-             verbose: bool = False, length: int = EVENTS_MAX_ROWS_NORMAL):
+             verbose: int = EVENTS_VERBOSITY_POWER,
+             length: int = EVENTS_MAX_ROWS_NORMAL):
     """Print a status snapshot to stdout and exit.
 
     With ``events_only=True`` the status / resource summary and graph
@@ -1352,29 +1458,30 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
     list. Events are sparse and a fixed window made the panel silently
     empty for normal homelab usage.
 
-    ``verbose=True`` includes low-priority chatter alongside the
-    :data:`PRIORITY_EVENTS` defaults.
+    ``verbose`` is a count-style event verbosity: 0 shows Power Events,
+    1 adds Diagnostics, and 2 adds Lifecycle.
 
     ``length`` caps the events list (default :data:`EVENTS_MAX_ROWS_NORMAL`,
     set to 0 for no cap). Tiered preservation: power events always
     survive the cap; daemon-lifecycle events fill remaining slots.
     """
+    verbose = _events_verbosity(verbose)
     # length=0 means "no cap" -- pass None through to the query.
     events_cap = None if length == 0 else length
 
     if events_only:
         events = query_events_for_display(
             config, max_events=events_cap,
-            priority_only=not verbose,
+            verbosity=verbose,
         )
-        if not events:
+        if not events and not events_db_available(config):
             events = parse_log_events(config.logging.file or "",
                                       max_events=events_cap)
         if events:
             for line in events:
                 print(line)
         else:
-            print("(no events)")
+            print(_no_events_message(verbose))
         return
 
     print(f"Eneru v{__version__}")
@@ -1415,19 +1522,19 @@ def run_once(config: Config, *, graph_metric: Optional[str] = None,
         if i < group_count - 1:
             print()
 
-    # Snapshot path: same flag semantics as the events-only branch
-    # above. --verbose drops the priority filter; --length caps the
-    # row count. The snapshot tail is a small summary under the
-    # status block -- it always caps at 10 even when --length is
-    # higher (or 0/unbounded), so an operator asking for "all events"
-    # gets that via --events-only, not via the snapshot tail
-    # drowning the status header it was designed to summarize.
+    # Snapshot path: same flag semantics as the events-only branch above.
+    # --verbose increments enabled tiers; --length caps the row count. The
+    # snapshot tail is a small summary under the status block -- it always
+    # caps at 10 even when --length is higher (or 0/unbounded), so an
+    # operator asking for "all events" gets that via --events-only, not via
+    # the snapshot tail drowning the status header it was designed to
+    # summarize.
     snapshot_cap = 10 if events_cap is None else min(events_cap, 10)
     events = query_events_for_display(
         config, max_events=snapshot_cap,
-        priority_only=not verbose,
+        verbosity=verbose,
     )
-    if not events:
+    if not events and not events_db_available(config):
         events = parse_log_events(config.logging.file or "",
                                   max_events=snapshot_cap)
     if events:

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -7,6 +7,7 @@ Two-panel layout:
 """
 
 import curses
+import os
 import sys
 import time
 from collections import deque
@@ -103,13 +104,16 @@ EVENTS_VERBOSITY_POWER = 0
 EVENTS_VERBOSITY_DIAGNOSTICS = 1
 EVENTS_VERBOSITY_ALL = 2
 
+GHOSTTY_TERMS = frozenset({"ghostty", "xterm-ghostty"})
+GHOSTTY_FALLBACK_TERM = "xterm-256color"
+
 EVENT_SECTION_POWER = "Power Events"
 EVENT_SECTION_DIAGNOSTICS = "Diagnostics"
 EVENT_SECTION_LIFECYCLE = "Lifecycle"
 
 
 def _events_verbosity(value) -> int:
-    """Normalize legacy bools and count-style verbosity to 0..2."""
+    """Normalize count-style verbosity to the supported 0..2 display tiers."""
     if isinstance(value, bool):
         return (EVENTS_VERBOSITY_DIAGNOSTICS if value
                 else EVENTS_VERBOSITY_POWER)
@@ -117,6 +121,15 @@ def _events_verbosity(value) -> int:
         return max(EVENTS_VERBOSITY_POWER, min(int(value), EVENTS_VERBOSITY_ALL))
     except (TypeError, ValueError):
         return EVENTS_VERBOSITY_POWER
+
+
+def _missing_ghostty_terminfo(term: str, exc: curses.error) -> bool:
+    """Return True when curses failed only because Ghostty terminfo is absent."""
+    return (
+        term in GHOSTTY_TERMS
+        and "setupterm" in str(exc)
+        and "could not find terminal" in str(exc)
+    )
 
 
 def _event_tier(event_type: str) -> str:
@@ -1394,7 +1407,21 @@ def run_tui(config: Config, interval: int = 5, *,
             elif key == curses.KEY_END:
                 events_scroll = 0
 
-    curses.wrapper(_main)
+    try:
+        curses.wrapper(_main)
+    except curses.error as exc:
+        original_term = os.environ.get("TERM", "")
+        if not _missing_ghostty_terminfo(original_term, exc):
+            raise
+
+        os.environ["TERM"] = GHOSTTY_FALLBACK_TERM
+        try:
+            curses.wrapper(_main)
+        finally:
+            if original_term:
+                os.environ["TERM"] = original_term
+            else:
+                os.environ.pop("TERM", None)
 
 
 # ==============================================================================

--- a/src/eneru/tui.py
+++ b/src/eneru/tui.py
@@ -480,7 +480,6 @@ def query_events_for_display(
     *,
     max_events: Optional[int] = EVENTS_MAX_ROWS_NORMAL,
     verbosity: int = EVENTS_VERBOSITY_POWER,
-    priority_only: Optional[bool] = None,
     grouped: bool = False,
 ) -> List[str]:
     """Pull events from each UPS's SQLite store, sorted by timestamp.
@@ -497,8 +496,7 @@ def query_events_for_display(
     should fall back to ``parse_log_events`` in that case.
 
     ``verbosity`` selects enabled tiers: ``0`` shows Power Events only,
-    ``1`` adds Diagnostics, and ``2`` adds Lifecycle. ``priority_only`` is
-    accepted as a legacy shim for tests / older internal callers.
+    ``1`` adds Diagnostics, and ``2`` adds Lifecycle.
 
     ``max_events=None`` (or 0) disables the row cap entirely.
 
@@ -507,10 +505,6 @@ def query_events_for_display(
     Lifecycle. Power events are never evicted; diagnostics outrank daemon
     lifecycle context when the cap is hit in verbose mode.
     """
-    if priority_only is not None:
-        # Legacy compatibility: the old boolean API had priority_only=False
-        # mean "show every event type".
-        verbosity = EVENTS_VERBOSITY_POWER if priority_only else EVENTS_VERBOSITY_ALL
     verbosity = _events_verbosity(verbosity)
     multi_ups = config.multi_ups
     rows: List[tuple] = []  # (ts, label, event_type, detail)

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.3.0-rc0"
+__version__ = "5.3.0-rc1"

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.2.2"
+__version__ = "5.3.0-rc0"

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -224,8 +224,8 @@ fi
 # Power/Lifecycle sets); ON_BATTERY is Power. The daemon's own DAEMON_START
 # row covers Lifecycle when -vv is enabled.
 NOW=$(date +%s)
-sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($NOW, 'TEST31_MARKER', 'e2e injected');"
-sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($((NOW + 1)), 'ON_BATTERY', 'e2e power');"
+sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($((NOW - 2)), 'TEST31_MARKER', 'e2e injected');"
+sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($((NOW - 1)), 'ON_BATTERY', 'e2e power');"
 
 # 5.3.0: --time is graph-only; --length sizes the events list.
 # TEST31_MARKER is a Diagnostic row, so -v must surface it while the

--- a/tests/e2e/groups/stats.sh
+++ b/tests/e2e/groups/stats.sh
@@ -219,17 +219,17 @@ if [ ! -f "$DB" ]; then
   exit 1
 fi
 
-# Inject a known event row directly so we have something to assert.
-# TEST31_MARKER is not a priority event type (5.2.2+ default filter), so
-# verify with --verbose -- the test scope is "events panel reads from
-# SQLite", not "the priority filter is correct".
+# Inject known event rows directly so we have each display tier to assert.
+# TEST31_MARKER is a Diagnostic event type (anything outside the explicit
+# Power/Lifecycle sets); ON_BATTERY is Power. The daemon's own DAEMON_START
+# row covers Lifecycle when -vv is enabled.
 NOW=$(date +%s)
 sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($NOW, 'TEST31_MARKER', 'e2e injected');"
+sqlite3 "$DB" "INSERT INTO events (ts, event_type, detail) VALUES ($((NOW + 1)), 'ON_BATTERY', 'e2e power');"
 
-# 5.2.2: --time is graph-only; --length sizes the events list.
-# TEST31_MARKER is not a priority event type so verify with --verbose --
-# the test scope is "events panel reads from SQLite", not the priority
-# filter itself.
+# 5.3.0: --time is graph-only; --length sizes the events list.
+# TEST31_MARKER is a Diagnostic row, so -v must surface it while the
+# default Power-only view keeps it hidden.
 eneru monitor --once --events-only --verbose --config "$E2E_DIR/config-e2e-stats.yaml" 2>&1 | tee /tmp/test31.log
 
 if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31.log; then
@@ -239,31 +239,58 @@ if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31.log; then
 fi
 echo "PASS: events panel reads from SQLite"
 
-# ----- 5.2.2: priority filter + --length -----
+# ----- 5.3.0: event tiers + --length -----
 # Assert:
-#   1. Default (no --verbose) hides TEST31_MARKER but shows DAEMON_START.
-#   2. --length 5 caps output at 5 rows.
-#   3. --length -1 is rejected (argparse type validator).
+#   1. Default (no --verbose) shows Power and hides Diagnostics/Lifecycle.
+#   2. -v shows Diagnostics but still hides Lifecycle.
+#   3. -vv shows Lifecycle.
+#   4. --length 5 caps output at 5 rows.
+#   5. --length -1 is rejected (argparse type validator).
 
 echo ""
-echo "  --- 5.2.2 events filter + length checks ---"
+echo "  --- 5.3.0 event tier + length checks ---"
 
 eneru monitor --once --events-only --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-priority.log 2>&1
 if grep -q "TEST31_MARKER" /tmp/test31-priority.log; then
-  echo "FAIL: priority-only default leaked TEST31_MARKER"
+  echo "FAIL: Power-only default leaked TEST31_MARKER"
   cat /tmp/test31-priority.log
   exit 1
 fi
-if ! grep -q "DAEMON_START" /tmp/test31-priority.log; then
-  echo "FAIL: priority-only default dropped DAEMON_START"
+if grep -q "DAEMON_START" /tmp/test31-priority.log; then
+  echo "FAIL: Power-only default leaked DAEMON_START"
   cat /tmp/test31-priority.log
   exit 1
 fi
-echo "  PASS: priority-only filter hides chatter, keeps DAEMON_START"
+if ! grep -q "ON_BATTERY: e2e power" /tmp/test31-priority.log; then
+  echo "FAIL: Power-only default dropped ON_BATTERY"
+  cat /tmp/test31-priority.log
+  exit 1
+fi
+echo "  PASS: Power-only default hides Diagnostics/Lifecycle and keeps Power"
 
-# --length 5 caps output. There's only one daemon-lifecycle event in the
-# stats DB at this point (from the daemon's own DAEMON_START), so we
-# can't easily count to 5 here -- just confirm --length runs cleanly.
+eneru monitor --once --events-only -v --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-diag.log 2>&1
+if ! grep -q "TEST31_MARKER: e2e injected" /tmp/test31-diag.log; then
+  echo "FAIL: -v did not surface Diagnostic TEST31_MARKER"
+  cat /tmp/test31-diag.log
+  exit 1
+fi
+if grep -q "DAEMON_START" /tmp/test31-diag.log; then
+  echo "FAIL: -v leaked Lifecycle DAEMON_START"
+  cat /tmp/test31-diag.log
+  exit 1
+fi
+echo "  PASS: -v shows Diagnostics without Lifecycle"
+
+eneru monitor --once --events-only -vv --config "$E2E_DIR/config-e2e-stats.yaml" > /tmp/test31-all.log 2>&1
+if ! grep -q "DAEMON_START" /tmp/test31-all.log; then
+  echo "FAIL: -vv did not surface Lifecycle DAEMON_START"
+  cat /tmp/test31-all.log
+  exit 1
+fi
+echo "  PASS: -vv shows Lifecycle"
+
+# --length 5 caps output. The test scope here is argparse/query plumbing;
+# tier-specific behavior is asserted above.
 # Wrap the invocation in the `if` directly: under `set -e` a separate
 # `[ $? -ne 0 ]` branch would never run because the script aborts on
 # the first non-zero exit, masking any regression with no log dump.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,8 +147,7 @@ class TestCLIMonitorFlags:
 
     @pytest.mark.unit
     def test_verbose_short_form_accepted(self, tmp_path):
-        """``-v`` is the short form of ``--verbose`` and reaches
-        run_once with verbose=True."""
+        """``-v`` adds Diagnostics and reaches run_once as verbose=1."""
         from eneru.tui import run_once
         with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
             config_file = self._minimal_config(tmp_path)
@@ -157,7 +156,20 @@ class TestCLIMonitorFlags:
                                             "--once", "--events-only", "-v"]):
                 main()
             mock_once.assert_called_once()
-            assert mock_once.call_args.kwargs.get("verbose") is True
+            assert mock_once.call_args.kwargs.get("verbose") == 1
+
+    @pytest.mark.unit
+    def test_verbose_double_short_form_accepted(self, tmp_path):
+        """``-vv`` adds Lifecycle and reaches run_once as verbose=2."""
+        from eneru.tui import run_once
+        with patch("eneru.tui.run_once", wraps=run_once) as mock_once:
+            config_file = self._minimal_config(tmp_path)
+            with patch.object(sys, "argv", ["eneru", "tui",
+                                            "-c", str(config_file),
+                                            "--once", "--events-only", "-vv"]):
+                main()
+            mock_once.assert_called_once()
+            assert mock_once.call_args.kwargs.get("verbose") == 2
 
     @pytest.mark.unit
     def test_length_default_is_30(self, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,6 +125,20 @@ class TestCLICompletion:
         assert "_filedir" not in code
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+    def test_completion_lists_monitor_event_flags(self, shell, capsys):
+        """Packaged completion scripts must track monitor/tui event flags."""
+        with patch.object(sys, "argv", ["eneru", "completion", shell]):
+            main()
+        out = capsys.readouterr().out
+        if shell == "fish":
+            assert "-l verbose" in out
+            assert "-l length" in out
+        else:
+            assert "--verbose" in out
+            assert "--length" in out
+
+    @pytest.mark.unit
     def test_invalid_shell_rejected(self):
         """`eneru completion ksh` must fail at argparse, not at file-read."""
         with patch.object(sys, "argv", ["eneru", "completion", "ksh"]):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1086,13 +1086,13 @@ class TestQueryEventsForDisplay:
         config = _events_config(tmp_path,
                                 ups_names=("UPS1@h", "UPS2@h"))
         now = int(_time.time())
-        # priority_only=False — this test exercises sort/interleave for
-        # arbitrary event types, not the priority filter itself.
+        # verbosity=1 — this test exercises sort/interleave for arbitrary
+        # diagnostics, not the default Power-only filter itself.
         _seed_events(config, config.ups_groups[0],
                      [(now - 100, "A", ""), (now - 20, "C", "")])
         _seed_events(config, config.ups_groups[1],
                      [(now - 60, "B", "")])
-        lines = query_events_for_display(config, priority_only=False)
+        lines = query_events_for_display(config, verbosity=1)
         # Order: A (UPS1), B (UPS2), C (UPS1)
         assert "[UPS1@h] A" in lines[0]
         assert "[UPS2@h] B" in lines[1]
@@ -1107,9 +1107,9 @@ class TestQueryEventsForDisplay:
         _seed_events(config, config.ups_groups[0], [
             (now - i, f"EVT{i}", "") for i in range(1, 11)
         ])
-        # priority_only=False — testing the row cap, not the type filter.
+        # verbosity=1 — testing the row cap, not the type filter.
         lines = query_events_for_display(
-            config, max_events=3, priority_only=False,
+            config, max_events=3, verbosity=1,
         )
         # Most recent 3 events.
         assert len(lines) == 3
@@ -1147,34 +1147,30 @@ class TestQueryEventsForDisplay:
         assert line.startswith("????-??-?? ??:??:??")
 
     @pytest.mark.unit
-    def test_priority_only_default_filters_chatter(self, tmp_path):
-        """Default ``priority_only=True`` keeps the panel focused on
-        daemon-lifecycle and power transitions even when the events
-        table is full of low-priority chatter."""
+    def test_default_filters_to_power_events(self, tmp_path):
+        """Default verbosity keeps the panel focused on power transitions."""
         from eneru.tui import query_events_for_display
         import time as _time
         config = _events_config(tmp_path)
         now = int(_time.time())
         events = []
-        # 30 chatter rows that should be filtered.
+        # 30 diagnostics rows that should be filtered.
         for i in range(30):
             events.append(
                 (now - 100 + i, "VOLTAGE_FLAP_SUPPRESSED", f"flap {i}")
             )
-        # 2 priority rows that must survive the filter.
+        # Lifecycle and Power rows; only Power should survive the default filter.
         events.append((now - 50, "DAEMON_START", "v1"))
         events.append((now - 5, "POWER_RESTORED", "Outage 12s"))
         _seed_events(config, config.ups_groups[0], events)
         lines = query_events_for_display(config, max_events=8)
-        # Both priority rows present, no VOLTAGE_FLAP_SUPPRESSED lines.
-        assert any("DAEMON_START" in line for line in lines)
+        assert all("DAEMON_START" not in line for line in lines)
         assert any("POWER_RESTORED" in line for line in lines)
         assert all("VOLTAGE_FLAP_SUPPRESSED" not in line for line in lines)
 
     @pytest.mark.unit
-    def test_verbose_includes_low_priority(self, tmp_path):
-        """``priority_only=False`` (set by ``--verbose`` / ``<V>``)
-        widens the filter to all event types."""
+    def test_verbose_includes_diagnostics_not_lifecycle(self, tmp_path):
+        """``-v`` adds Diagnostics while keeping Lifecycle hidden."""
         from eneru.tui import query_events_for_display
         import time as _time
         config = _events_config(tmp_path)
@@ -1183,8 +1179,26 @@ class TestQueryEventsForDisplay:
             (now - 100, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
             (now - 50, "DAEMON_START", "v1"),
         ])
-        lines = query_events_for_display(config, priority_only=False)
-        assert len(lines) == 2
+        lines = query_events_for_display(config, verbosity=1)
+        assert len(lines) == 1
+        assert any("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines)
+        assert all("DAEMON_START" not in line for line in lines)
+
+    @pytest.mark.unit
+    def test_double_verbose_includes_all_tiers(self, tmp_path):
+        """``-vv`` includes Power, Diagnostics, and Lifecycle."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 100, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
+            (now - 50, "DAEMON_START", "v1"),
+            (now - 25, "ON_BATTERY", "outage"),
+        ])
+        lines = query_events_for_display(config, verbosity=2)
+        assert len(lines) == 3
+        assert any("ON_BATTERY" in line for line in lines)
         assert any("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines)
         assert any("DAEMON_START" in line for line in lines)
 
@@ -1198,9 +1212,9 @@ class TestQueryEventsForDisplay:
         import time as _time
         config = _events_config(tmp_path)
         now = int(_time.time())
-        # Seed 600 priority events -- comfortably above the new default cap of 30.
+        # Seed 600 power events -- comfortably above the default cap of 30.
         _seed_events(config, config.ups_groups[0], [
-            (now - 600 + i, "DAEMON_START", f"row-{i}")
+            (now - 600 + i, "ON_BATTERY", f"row-{i}")
             for i in range(600)
         ])
         # Default cap (EVENTS_MAX_ROWS_NORMAL=30) drops the oldest 570.
@@ -1237,7 +1251,7 @@ class TestQueryEventsForDisplay:
         events.append((now - 86400 * 7, "EMERGENCY_SHUTDOWN_INITIATED", "low batt"))
         _seed_events(config, config.ups_groups[0], events)
 
-        lines = query_events_for_display(config, max_events=20)
+        lines = query_events_for_display(config, max_events=20, verbosity=2)
         # All 3 power-event rows MUST survive the cap.
         assert any("ON_BATTERY: real outage" in line for line in lines), (
             f"ON_BATTERY pushed off by daemon noise -- tiered trim regressed. "
@@ -1276,19 +1290,15 @@ class TestQueryEventsForDisplay:
         assert any("outage-40" in line for line in lines)  # 10th-latest
 
     @pytest.mark.unit
-    def test_tiered_trim_lifecycle_outranks_chatter(self, tmp_path):
-        """5.2.2 (CodeRabbit refinement): in --verbose mode (priority_only
-        =False), chatter rows reach the trim layer alongside lifecycle
-        rows. Lifecycle is more important than per-condition chatter --
-        when the cap evicts non-power rows, lifecycle should survive
-        first, then chatter fills any leftover slots."""
+    def test_tiered_trim_diagnostics_outrank_lifecycle(self, tmp_path):
+        """In -vv mode, diagnostics fill cap slots before lifecycle rows."""
         from eneru.tui import query_events_for_display
         import time as _time
         config = _events_config(tmp_path)
         now = int(_time.time())
-        # 1 power event + 30 chatter rows + 4 lifecycle rows.
-        # Cap = 7. Result must be: 1 power + 4 lifecycle + 2 chatter,
-        # NOT: 1 power + 6 chatter (chatter evicting lifecycle).
+        # 1 power event + 30 diagnostic rows + 4 lifecycle rows.
+        # Cap = 7. Result must be: 1 power + 6 diagnostics, with lifecycle
+        # evicted because it is the noisiest tier.
         events = [(now - 5000, "ON_BATTERY", "outage")]
         for i in range(30):
             events.append(
@@ -1301,18 +1311,58 @@ class TestQueryEventsForDisplay:
         _seed_events(config, config.ups_groups[0], events)
 
         lines = query_events_for_display(
-            config, max_events=7, priority_only=False,
+            config, max_events=7, verbosity=2,
         )
         assert len(lines) == 7
         assert sum("ON_BATTERY" in line for line in lines) == 1, (
             f"power event must survive: {lines}"
         )
-        assert sum("DAEMON_RESTARTED" in line for line in lines) == 4, (
-            f"all 4 lifecycle rows must outrank chatter; got: {lines}"
+        assert sum("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines) == 6, (
+            f"diagnostics must fill before lifecycle; got: {lines}"
         )
-        assert sum("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines) == 2, (
-            f"chatter fills only the 2 leftover slots; got: {lines}"
+        assert sum("DAEMON_RESTARTED" in line for line in lines) == 0, (
+            f"lifecycle should be evicted before diagnostics; got: {lines}"
         )
+
+    @pytest.mark.unit
+    def test_grouped_output_orders_sections_for_live_tui(self, tmp_path):
+        """Live TUI groups enabled tiers as Power, Diagnostics, Lifecycle."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "DAEMON_START", "start"),
+            (now - 20, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
+            (now - 10, "ON_BATTERY", "outage"),
+        ])
+
+        lines = query_events_for_display(config, verbosity=2, grouped=True)
+        assert lines[0] == "Power Events"
+        assert any("ON_BATTERY" in line for line in lines[1:])
+        assert lines.index("Diagnostics") < lines.index("Lifecycle")
+        assert any("VOLTAGE_FLAP_SUPPRESSED" in line for line in lines)
+        assert any("DAEMON_START" in line for line in lines)
+
+    @pytest.mark.unit
+    def test_crash_restart_events_are_diagnostics(self, tmp_path):
+        """Crash/restart classifiers are diagnostics, not lifecycle."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "DAEMON_RESTARTED_AFTER_FATAL", "fatal"),
+            (now - 20, "DAEMON_AFTER_CRASH", "crash"),
+            (now - 10, "DAEMON_START", "start"),
+        ])
+
+        default = query_events_for_display(config)
+        verbose = query_events_for_display(config, verbosity=1)
+        assert default == []
+        assert any("DAEMON_RESTARTED_AFTER_FATAL" in line for line in verbose)
+        assert any("DAEMON_AFTER_CRASH" in line for line in verbose)
+        assert all("DAEMON_START" not in line for line in verbose)
 
 
 class TestRobustBounds:
@@ -1495,15 +1545,59 @@ class TestRunOnceEventsOnly:
         config = _events_config(tmp_path)
         run_once(config, events_only=True)
         out = capsys.readouterr().out
-        assert "(no events)" in out
+        assert "(no power events recorded)" in out
 
     @pytest.mark.unit
-    def test_snapshot_path_honours_verbose_flag(self, tmp_path, capsys):
+    def test_events_only_db_with_no_power_does_not_fallback_to_log(
+        self, tmp_path, capsys
+    ):
+        """A DB with only hidden tiers should say no power events, not parse logs."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
+        ])
+        Path(config.logging.file).write_text(
+            "2026-04-20 10:00:00 - ⚡ POWER EVENT: ON_BATTERY - stale log\n"
+        )
+
+        run_once(config, events_only=True)
+        out = capsys.readouterr().out
+        assert "(no power events recorded)" in out
+        assert "stale log" not in out
+
+    @pytest.mark.unit
+    def test_events_only_flat_time_sorted_with_enabled_tiers(
+        self, tmp_path, capsys
+    ):
+        """--once output remains flat and timestamp-sorted across enabled tiers."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "DAEMON_START", "start"),
+            (now - 20, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
+            (now - 10, "ON_BATTERY", "outage"),
+        ])
+
+        run_once(config, events_only=True, verbose=2)
+        lines = capsys.readouterr().out.splitlines()
+        assert all(line not in ("Power Events", "Diagnostics", "Lifecycle")
+                   for line in lines)
+        assert "DAEMON_START" in lines[0]
+        assert "VOLTAGE_FLAP_SUPPRESSED" in lines[1]
+        assert "ON_BATTERY" in lines[2]
+
+    @pytest.mark.unit
+    def test_snapshot_path_honours_verbose_level(self, tmp_path, capsys):
         """5.2.2 (cubic.dev / CodeRabbit P1): the non-events-only branch
         of run_once also reads events for its tail block. Pre-fix it
         used the default ``priority_only=True`` and silently ignored
-        ``--verbose``, so chatter never surfaced even when the user
-        explicitly asked for it."""
+        ``--verbose``, so diagnostics never surfaced even when the user
+        explicitly asked for them."""
         from eneru.tui import run_once
         import time as _time
         config = _events_config(tmp_path)
@@ -1512,24 +1606,28 @@ class TestRunOnceEventsOnly:
             (now - 60, "VOLTAGE_FLAP_SUPPRESSED", "low-prio chatter"),
             (now - 30, "DAEMON_START", "high-prio"),
         ])
-        # Default snapshot path: chatter hidden.
+        # Default snapshot path: diagnostics and lifecycle hidden.
         run_once(config, events_only=False)
         out_default = capsys.readouterr().out
-        assert "DAEMON_START" in out_default
+        assert "DAEMON_START" not in out_default
         assert "VOLTAGE_FLAP_SUPPRESSED" not in out_default
-        # --verbose: chatter must surface.
-        run_once(config, events_only=False, verbose=True)
+        # -v: diagnostics surface, lifecycle remains hidden.
+        run_once(config, events_only=False, verbose=1)
         out_verbose = capsys.readouterr().out
-        assert "DAEMON_START" in out_verbose
+        assert "DAEMON_START" not in out_verbose
         assert "VOLTAGE_FLAP_SUPPRESSED" in out_verbose, (
-            "snapshot path must honour --verbose; pre-5.2.2 the events "
-            "tail in the snapshot block silently ignored the flag"
+            "snapshot path must honour -v; the events tail in the snapshot "
+            "block must include diagnostics"
         )
+        # -vv: lifecycle joins the flat, timestamp-sorted tail.
+        run_once(config, events_only=False, verbose=2)
+        out_all = capsys.readouterr().out
+        assert "DAEMON_START" in out_all
 
     @pytest.mark.unit
     def test_snapshot_path_no_time_window_for_events(self, tmp_path, capsys):
         """5.2.2: events have no time window -- ``--time`` only affects
-        graphs. The snapshot tail must surface old DAEMON rows even
+        graphs. The snapshot tail must surface old power rows even
         though they fall outside any ``--time`` choice."""
         from eneru.tui import run_once
         import time as _time
@@ -1537,8 +1635,8 @@ class TestRunOnceEventsOnly:
         now = int(_time.time())
         old_ts = now - 90 * 86400  # 3 months ago
         _seed_events(config, config.ups_groups[0], [
-            (old_ts, "DAEMON_START", "ancient"),
-            (now - 60, "DAEMON_START", "recent"),
+            (old_ts, "ON_BATTERY", "ancient"),
+            (now - 60, "POWER_RESTORED", "recent"),
         ])
         run_once(config, events_only=False)
         out = capsys.readouterr().out
@@ -1558,29 +1656,29 @@ class TestRunOnceEventsOnly:
         config = _events_config(tmp_path)
         now = int(_time.time())
         _seed_events(config, config.ups_groups[0], [
-            (now - 100 + i, "DAEMON_START", f"row-{i}") for i in range(50)
+            (now - 100 + i, "ON_BATTERY", f"row-{i}") for i in range(50)
         ])
         run_once(config, events_only=True, length=5)
         out = capsys.readouterr().out
-        # Should see exactly 5 lines -- the most-recent 5 DAEMON_START rows.
-        lines = [l for l in out.splitlines() if "DAEMON_START" in l]
+        # Should see exactly 5 lines -- the most-recent 5 ON_BATTERY rows.
+        lines = [l for l in out.splitlines() if "ON_BATTERY" in l]
         assert len(lines) == 5
         assert "row-49" in lines[-1]
         assert "row-45" in lines[0]
 
     @pytest.mark.unit
     def test_events_only_length_zero_means_no_cap(self, tmp_path, capsys):
-        """``--length 0`` returns every priority row."""
+        """``--length 0`` returns every enabled row."""
         from eneru.tui import run_once
         import time as _time
         config = _events_config(tmp_path)
         now = int(_time.time())
         _seed_events(config, config.ups_groups[0], [
-            (now - 100 + i, "DAEMON_START", f"row-{i}") for i in range(40)
+            (now - 100 + i, "ON_BATTERY", f"row-{i}") for i in range(40)
         ])
         run_once(config, events_only=True, length=0)
         out = capsys.readouterr().out
-        lines = [l for l in out.splitlines() if "DAEMON_START" in l]
+        lines = [l for l in out.splitlines() if "ON_BATTERY" in l]
         assert len(lines) == 40, f"length=0 must show all rows; got {len(lines)}"
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1728,6 +1728,24 @@ class TestRunOnceEventsOnly:
         )
 
     @pytest.mark.unit
+    def test_snapshot_path_honours_length(self, tmp_path, capsys):
+        """``--once --length N`` must size the Recent Events block too."""
+        from eneru.tui import run_once
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 100 + i, "DAEMON_START", f"row-{i}") for i in range(20)
+        ])
+
+        run_once(config, events_only=False, verbose=2, length=15)
+        out = capsys.readouterr().out
+        lines = [line for line in out.splitlines() if "DAEMON_START" in line]
+        assert len(lines) == 15
+        assert "row-5" in lines[0]
+        assert "row-19" in lines[-1]
+
+    @pytest.mark.unit
     def test_events_only_length_caps_output(self, tmp_path, capsys):
         """``--length N`` (events_only=True path) caps output to N rows."""
         from eneru.tui import run_once

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1345,6 +1345,28 @@ class TestQueryEventsForDisplay:
         assert any("DAEMON_START" in line for line in lines)
 
     @pytest.mark.unit
+    def test_grouped_cap_counts_headers_and_preserves_power(self, tmp_path):
+        """Grouped live output must not add headers after the row cap."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        events = [(now - 5000, "ON_BATTERY", "outage")]
+        events.extend(
+            (now - 100 + i, "VOLTAGE_FLAP_SUPPRESSED", f"diag-{i}")
+            for i in range(20)
+        )
+        _seed_events(config, config.ups_groups[0], events)
+
+        lines = query_events_for_display(
+            config, max_events=5, verbosity=1, grouped=True,
+        )
+        assert len(lines) <= 5
+        assert lines[0] == "Power Events"
+        assert any("ON_BATTERY: outage" in line for line in lines)
+        assert lines.count("Diagnostics") == 1
+
+    @pytest.mark.unit
     def test_crash_restart_events_are_diagnostics(self, tmp_path):
         """Crash/restart classifiers are diagnostics, not lifecycle."""
         from eneru.tui import query_events_for_display

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1443,6 +1443,72 @@ class TestQueryEventsForDisplay:
         assert any("DAEMON_AFTER_CRASH" in line for line in verbose)
         assert all("DAEMON_START" not in line for line in verbose)
 
+    @pytest.mark.unit
+    def test_grouped_length_one_keeps_power_event(self, tmp_path):
+        """``max_events=1`` in grouped mode must still render the single
+        most-recent Power event. The cap is too small to fit a section
+        header *and* a row, so the header is dropped and the surviving
+        row is rendered bare -- preserving the docstring contract that
+        Power events are never evicted within the cap."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "DAEMON_START", "boot"),
+            (now - 20, "ON_BATTERY", "outage"),
+            (now - 10, "DAEMON_RESTARTED", "restart"),
+        ])
+
+        out = query_events_for_display(
+            config, max_events=1, verbosity=2, grouped=True,
+        )
+        assert len(out) == 1
+        assert "ON_BATTERY" in out[0]
+        # Bare row, no section header (no room for header + row at length=1).
+        assert out[0] != "Power Events"
+
+    @pytest.mark.unit
+    def test_ungrouped_length_one_keeps_power_event(self, tmp_path):
+        """Non-grouped path at length=1 returns the single most-recent
+        Power event (regression guard alongside the grouped fallback)."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 20, "ON_BATTERY", "outage"),
+            (now - 10, "DAEMON_START", "boot"),
+        ])
+
+        out = query_events_for_display(
+            config, max_events=1, verbosity=2, grouped=False,
+        )
+        assert len(out) == 1
+        assert "ON_BATTERY" in out[0]
+
+    @pytest.mark.unit
+    def test_grouped_length_one_falls_back_to_diagnostic_when_no_power(
+            self, tmp_path):
+        """At length=1 with no Power events, the grouped fallback must
+        surface the most-recent Diagnostic survivor -- the second tier
+        in the tier-priority order (Power -> Diagnostics -> Lifecycle)."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "DAEMON_START", "boot"),
+            (now - 20, "VOLTAGE_FLAP_SUPPRESSED", "flap"),
+            (now - 10, "DAEMON_RESTARTED", "restart"),
+        ])
+
+        out = query_events_for_display(
+            config, max_events=1, verbosity=2, grouped=True,
+        )
+        assert len(out) == 1
+        assert "VOLTAGE_FLAP_SUPPRESSED" in out[0]
+
 
 class TestRobustBounds:
     """``_robust_bounds`` keeps a single 0V outlier from squashing the

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -150,6 +150,43 @@ class TestKeypadEnabled:
         )
 
 
+class TestGhosttyTerminfoFallback:
+    """Ghostty can advertise xterm-ghostty before host terminfo is installed."""
+
+    @pytest.mark.unit
+    def test_xterm_ghostty_missing_terminfo_retries_with_xterm_256color(self):
+        from eneru import tui as tui_mod
+
+        config = Config()
+        with patch.dict(os.environ, {"TERM": "xterm-ghostty"}):
+            with patch.object(tui_mod.curses, "wrapper") as wrapper:
+                wrapper.side_effect = [
+                    curses.error("setupterm: could not find terminal"),
+                    None,
+                ]
+
+                tui_mod.run_tui(config)
+
+                assert wrapper.call_count == 2
+                assert os.environ["TERM"] == "xterm-ghostty"
+
+    @pytest.mark.unit
+    def test_non_ghostty_curses_error_is_not_retried(self):
+        from eneru import tui as tui_mod
+
+        config = Config()
+        with patch.dict(os.environ, {"TERM": "ansi"}):
+            with patch.object(tui_mod.curses, "wrapper") as wrapper:
+                wrapper.side_effect = curses.error(
+                    "setupterm: could not find terminal"
+                )
+
+                with pytest.raises(curses.error):
+                    tui_mod.run_tui(config)
+
+                assert wrapper.call_count == 1
+
+
 class TestEventsScrollAutoPromote:
     """5.1.1 (CodeRabbit): scrolling toward older history while in
     normal-cap mode (8 rows) used to be a silent no-op because the

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1636,10 +1636,10 @@ class TestRunOnceEventsOnly:
     @pytest.mark.unit
     def test_snapshot_path_honours_verbose_level(self, tmp_path, capsys):
         """5.2.2 (cubic.dev / CodeRabbit P1): the non-events-only branch
-        of run_once also reads events for its tail block. Pre-fix it
-        used the default ``priority_only=True`` and silently ignored
-        ``--verbose``, so diagnostics never surfaced even when the user
-        explicitly asked for them."""
+        of run_once also reads events for its tail block. Pre-fix it used
+        the default event query and silently ignored ``--verbose``, so
+        diagnostics never surfaced even when the user explicitly asked for
+        them."""
         from eneru.tui import run_once
         import time as _time
         config = _events_config(tmp_path)
@@ -1703,7 +1703,7 @@ class TestRunOnceEventsOnly:
         run_once(config, events_only=True, length=5)
         out = capsys.readouterr().out
         # Should see exactly 5 lines -- the most-recent 5 ON_BATTERY rows.
-        lines = [l for l in out.splitlines() if "ON_BATTERY" in l]
+        lines = [line for line in out.splitlines() if "ON_BATTERY" in line]
         assert len(lines) == 5
         assert "row-49" in lines[-1]
         assert "row-45" in lines[0]
@@ -1720,7 +1720,7 @@ class TestRunOnceEventsOnly:
         ])
         run_once(config, events_only=True, length=0)
         out = capsys.readouterr().out
-        lines = [l for l in out.splitlines() if "ON_BATTERY" in l]
+        lines = [line for line in out.splitlines() if "ON_BATTERY" in line]
         assert len(lines) == 40, f"length=0 must show all rows; got {len(lines)}"
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1169,6 +1169,24 @@ class TestQueryEventsForDisplay:
         assert all("VOLTAGE_FLAP_SUPPRESSED" not in line for line in lines)
 
     @pytest.mark.unit
+    def test_safety_critical_health_events_are_power_tier(self, tmp_path):
+        """Default output includes safety-critical event names the daemon emits."""
+        from eneru.tui import query_events_for_display
+        import time as _time
+        config = _events_config(tmp_path)
+        now = int(_time.time())
+        _seed_events(config, config.ups_groups[0], [
+            (now - 30, "BYPASS_MODE_ACTIVE", "bypass"),
+            (now - 20, "OVERLOAD_ACTIVE", "overload"),
+            (now - 10, "BYPASS_MODE_INACTIVE", "resolved"),
+        ])
+
+        lines = query_events_for_display(config)
+        assert any("BYPASS_MODE_ACTIVE" in line for line in lines)
+        assert any("OVERLOAD_ACTIVE" in line for line in lines)
+        assert all("BYPASS_MODE_INACTIVE" not in line for line in lines)
+
+    @pytest.mark.unit
     def test_verbose_includes_diagnostics_not_lifecycle(self, tmp_path):
         """``-v`` adds Diagnostics while keeping Lifecycle hidden."""
         from eneru.tui import query_events_for_display
@@ -1365,6 +1383,8 @@ class TestQueryEventsForDisplay:
         assert lines[0] == "Power Events"
         assert any("ON_BATTERY: outage" in line for line in lines)
         assert lines.count("Diagnostics") == 1
+        assert any("diag-19" in line for line in lines)
+        assert all("diag-0" not in line for line in lines)
 
     @pytest.mark.unit
     def test_crash_restart_events_are_diagnostics(self, tmp_path):


### PR DESCRIPTION
## Summary
- Change monitor event verbosity to Power-only by default, Diagnostics with `-v` / first `<V>`, and Lifecycle with `-vv` / second `<V>`.
- Group live TUI events by tier while keeping `--once` flat and timestamp-sorted.
- Preserve event caps in Power, Diagnostics, Lifecycle order and update unit/E2E coverage.

## Verification
- `bash -n tests/e2e/groups/stats.sh`
- `pytest tests/test_tui.py tests/test_cli.py` (`134 passed`)
- `pytest` (`990 passed`)
- Local `agent-skills:code-reviewer` pass: APPROVE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event display now uses tier-based presentation: Power events show by default, Diagnostics via `-v`, and Lifecycle via `-vv`.
  * Live TUI events are grouped by tier; `--once` output remains timestamp-sorted.
  * Event cap now preserves higher tiers first.

* **Documentation**
  * Updated changelog with 5.3.0-rc0 release notes describing new event tier behavior.
  * Refined testing documentation for event tier filtering and TUI grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->