### PR TITLE
fix(redundancy): daemon owns shutdown flag lifecycle (issue #4)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,8 +23,9 @@ env:
 # of the previous ~6+ minute single sequential job.
 #
 # v5.1.2 split the previous `Redundancy and Stats` job into two
-# (`Redundancy` runs tests 21-27, `Stats` runs tests 28-32) so the
-# heaviest group no longer gates the matrix on its own.
+# (`Redundancy` runs tests 21-27 + 37 + R1/R2, `Stats` runs tests
+# 28-32 + 34/35) so the heaviest group no longer gates the matrix on
+# its own.
 #
 # OPERATOR ACTION REQUIRED when this PR's branch protection updates:
 # the required checks on `main` are now FIVE E2E jobs (was four).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 Intelligent UPS monitoring daemon for NUT (Network UPS Tools). Orchestrates graceful shutdown of VMs, containers, remote servers, and local systems during power events.
 
+## Primary Directives
+
+These apply to every task in this repo, ahead of any section-specific guidance below.
+
+1. **Be brief.**
+2. **Decide locally. Flag assumptions only when the choice is non-obvious or hard to reverse.**
+3. **No speculative complexity. Build for the problem in front of you, not the one you imagine next.**
+4. **Define success criteria. Loop until verified.**
+5. **Touch only what you must. Clean up only your own mess.**
+
 ## Development Setup
 
 **CRITICAL: NEVER run `pip`, `pip3`, `python -m pip`, `python`, `pytest`, or any other dev/Python tooling directly against the system Python. ALL Python work — install, uninstall, run, test, version-check — MUST happen inside a `uv` virtualenv. No exceptions.**

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@
 
 <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-e8e8ed?style=for-the-badge&labelColor=090909" alt="MIT"></a>
 <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.9+-e8e8ed?style=for-the-badge&labelColor=090909" alt="Python 3.9+"></a>
-<a href="https://networkupstools.org/"><img src="https://img.shields.io/badge/NUT-compatible-e8e8ed?style=for-the-badge&labelColor=090909" alt="NUT compatible"></a>
 <a href="https://codecov.io/gh/m4r1k/Eneru"><img src="https://img.shields.io/codecov/c/github/m4r1k/Eneru?style=for-the-badge&labelColor=090909&color=e8e8ed&label=Coverage" alt="Coverage"></a>
 <a href="https://eneru.readthedocs.io/"><img src="https://img.shields.io/badge/Docs-Read%20The%20Docs-e8e8ed?style=for-the-badge&labelColor=090909" alt="Documentation"></a>
 <a href="https://pypi.org/project/eneru/"><img src="https://img.shields.io/pypi/v/eneru?style=for-the-badge&labelColor=090909&color=e8e8ed&label=PyPI" alt="PyPI"></a>
-<a href="https://buymeacoffee.com/m4r1k"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-e8e8ed?style=for-the-badge&labelColor=090909&logo=buymeacoffee&logoColor=e8e8ed" alt="Buy Me a Coffee"></a>
+<a href="https://buymeacoffee.com/m4r1k"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?style=for-the-badge&labelColor=090909&logo=buymeacoffee&logoColor=e8e8ed" alt="Buy Me a Coffee"></a>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/m4r1k/Eneru/main/docs/images/eneru-diagram.svg" alt="Eneru Architecture" width="600">
@@ -160,7 +159,7 @@ See the [full documentation](https://eneru.readthedocs.io/) for complete configu
 - Notifications to 100+ services (Discord, Slack, Telegram, ntfy, email) via [Apprise](https://github.com/caronc/apprise/wiki)
 - Power quality monitoring: voltage, AVR, bypass, overload
 - Dry-run mode for safe testing
-- 300 tests, 9 Linux distros, E2E tests with real NUT/SSH/Docker on every commit
+- Comprehensive test suite across multiple Linux distros, with E2E tests against real NUT, SSH, Docker, and libvirt on every commit
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.3.0] - Unreleased
 
+### Behavior change — daemon owns redundancy flag lifecycle
+- **The redundancy executor's flag file
+  (`/var/run/ups-shutdown-redundancy-{group}`) is now daemon-managed.**
+  Old contract (≤5.2.2): the flag persisted across daemon restarts and
+  across quorum-recovery events; once any redundancy shutdown ran without
+  the host actually halting (`is_local: false` rack topology, sandboxed
+  test environments, dummy-UPS rigs), the flag stayed on disk and silently
+  blocked every subsequent redundancy shutdown until manually deleted. New contract
+  (5.3.0+): the flag is unconditionally cleared at three points —
+  coordinator startup, quorum recovery, and graceful signal exit. Its
+  only role is now in-flight re-entry protection within a single
+  quorum-loss event. Reported by ckrevel in
+  [issue #4](https://github.com/m4r1k/Eneru/issues/4#issuecomment-4375517607).
+  No user action required; if you had been deleting
+  `/var/run/ups-shutdown-redundancy-*` manually as a workaround, you can
+  stop. This mirrors the per-UPS path's behavior since the bug #4 fix in
+  5.2.2.
+- **Diagnostic warning when the contract is bypassed.** If the executor
+  ever sees the flag at first call (someone touched it manually, the
+  startup-cleanup hook was bypassed, `/var/run` is read-only), a
+  one-line `⚠️ Redundancy shutdown for '{group}' suppressed: …` warning
+  now fires. Pre-5.3.0 the suppression was silent.
+
 ### Fixed
+- **Redundancy shutdown no longer pinned at "fired" after first event.**
+  Companion to the contract change above: the evaluator now resets its
+  `_fired` flag and clears the executor's re-entry guard on the
+  quorum-loss → recovered transition, so the next quorum loss fires its
+  own shutdown sequence. New `quorum restored -- re-armed for next event`
+  log line marks the transition. Direct fix for the symptom in issue #4.
 - **Redundancy runtime NUT visibility now honors connection grace.**
   Issue #4 exposed a path where both redundancy members could turn brief
   stale/lost NUT data into `UNKNOWN` before the per-UPS connection grace
@@ -46,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `unknown_counts_as: critical` still triggers quorum loss after connection
   grace expires. The change only prevents transient runtime NUT visibility
   loss from bypassing the existing grace window.
+- The redundancy flag lifecycle change is also drop-in. Anyone who was
+  deleting `/var/run/ups-shutdown-redundancy-*` manually as a workaround
+  for the issue #4 symptom can stop — the daemon now owns it.
 
 ---
 

--- a/docs/redundancy-groups.md
+++ b/docs/redundancy-groups.md
@@ -179,6 +179,39 @@ Good targets:
 
 If the surviving UPS overloads, software cannot save the rack. Fix the load or UPS sizing.
 
+## Operational notes
+
+### Re-entry guard / flag-file lifecycle
+
+Each redundancy group has a flag at `/var/run/ups-shutdown-redundancy-{group}` that
+prevents a single quorum-loss event from firing the shutdown sequence twice. From
+**5.3.0** onward the daemon owns this flag's lifecycle:
+
+- Cleared at coordinator **startup** so a stale flag from a prior daemon
+  instance can't silently block the next quorum loss. **This is the
+  load-bearing guarantee**; the next two clears are optimizations.
+- Cleared on **quorum recovery** so the next quorum loss can fire its own
+  shutdown without waiting for a daemon restart. Look for `quorum restored
+  -- re-armed for next event` in the log.
+- Cleared on **graceful exit via SIGINT / SIGTERM** so the next start is
+  clean. A non-graceful exit (crash, SIGKILL, OOM) leaves the flag on
+  disk, but the next coordinator startup re-clears it.
+
+The flag's only role is in-flight re-entry protection within a single
+quorum-loss event. It never persists across runs or across events.
+
+If the daemon ever sees the flag at first call (someone touched it manually,
+`/var/run` is read-only, the startup-cleanup hook was bypassed) it logs the
+exact line below — operators can grep their journal for it verbatim:
+
+```
+⚠️ Redundancy shutdown for '{group}' suppressed: flag /var/run/ups-shutdown-redundancy-{group} already present at first call (startup cleanup bypassed). Will re-arm when quorum recovers.
+```
+
+Pre-5.3.0 the suppression was silent and cost some operators (issue #4) hours of
+debugging. If you see the warning, check for stuck SSH sessions, stale lock
+files, or a previous instance that didn't exit cleanly.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
@@ -187,10 +220,5 @@ If the surviving UPS overloads, software cannot save the rack. Fix the load or U
 | On-battery member still counts healthy | `degraded_counts_as: healthy` is the default |
 | Advisory log appears but no shutdown | Another member still satisfies quorum |
 | Group never starts | `ups_sources` names do not match exactly |
-| Repeated tests do not fire | A previous dry-run or killed process left `/var/run/ups-shutdown-redundancy-*` |
-
-Clear stale redundancy flags only after confirming no real shutdown is in progress:
-
-```bash
-sudo rm -f /var/run/ups-shutdown-redundancy-*
-```
+| Repeated tests do not fire | Pre-5.3.0 only: stale `/var/run/ups-shutdown-redundancy-*` from a prior run. 5.3.0+ clears these automatically at startup |
+| `⚠️ Redundancy shutdown … suppressed` log line | The startup-cleanup contract was bypassed — see Operational notes above |

--- a/docs/redundancy-groups.md
+++ b/docs/redundancy-groups.md
@@ -204,7 +204,7 @@ If the daemon ever sees the flag at first call (someone touched it manually,
 `/var/run` is read-only, the startup-cleanup hook was bypassed) it logs the
 exact line below — operators can grep their journal for it verbatim:
 
-```
+```text
 ⚠️ Redundancy shutdown for '{group}' suppressed: flag /var/run/ups-shutdown-redundancy-{group} already present at first call (startup cleanup bypassed). Will re-arm when quorum recovers.
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -111,7 +111,7 @@ The scenario files simulate online, on-battery, low-battery, FSD, brownout, over
 
 ### E2E test inventory
 
-The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 36 numbered tests, two redundancy runtime regression cases, plus one CLI completion smoke check.
+The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 37 numbered tests, two redundancy runtime regression cases, plus one CLI completion smoke check.
 
 | Test | Group | What it proves |
 |------|-------|----------------|
@@ -153,6 +153,7 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 36 numb
 | 34 | Stats | Pending on-battery and restored notifications coalesce into one brief-outage summary |
 | 35 | Stats | Single-UPS restart lifecycle sends one restart notification instead of stop/start noise |
 | 36 | UPS Multi | Multi-UPS coordinator applies the same single-restart-notification contract across per-UPS stores |
+| 37 | Redundancy | Two consecutive quorum-loss events both fire shutdown — proves the daemon-managed flag-file lifecycle (issue #4) |
 | E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |
 
 Every commit on the protected workflow has to prove the daemon works against real services, not just isolated Python assertions: real NUT sockets, Dockerized SSH targets, a live SQLite database, rendered TUI output, validated production-shaped configs, and a full shutdown orchestration run. None of it depends on local developer state.

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -304,6 +304,11 @@ class MultiUPSCoordinator:
                     notification_worker=self._notification_worker,
                     local_shutdown_callback=self._handle_local_shutdown,
                 )
+                # 5.3.0 contract: daemon owns the redundancy flag's
+                # lifecycle. Clear any stale flag from a prior daemon
+                # instance so the executor starts from a known-clean
+                # state. Mirrors the per-UPS unlink at line 95 above.
+                executor.clear_shutdown_state()
                 self._redundancy_executors[rg.name] = executor
                 evaluator = RedundancyGroupEvaluator(
                     rg,
@@ -607,6 +612,20 @@ class MultiUPSCoordinator:
             )
 
         self._global_shutdown_flag.unlink(missing_ok=True)
+        # 5.3.0 contract: clear redundancy executor flags too on
+        # graceful exit so the next daemon instance starts from a
+        # known-clean state. Defensive try-block: a flag-cleanup
+        # failure must NOT block process exit. Log a breadcrumb so
+        # operators have something to grep when a non-graceful exit
+        # leaves a flag the next startup-cleanup then has to handle.
+        for name, executor in self._redundancy_executors.items():
+            try:
+                executor.clear_shutdown_state()
+            except Exception as e:
+                self._log(
+                    f"⚠️ Failed to clear redundancy flag for '{name}' "
+                    f"during exit: {e}. Next startup will re-clear."
+                )
         sys.exit(0)
 
     def _log(self, message: str):

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -204,19 +204,28 @@ class RedundancyGroupExecutor(
         with self._lock:
             if self._shutdown_done:
                 return False
-            if self._shutdown_flag_path.exists():
+            # Atomic flag acquisition. ``exists()`` + ``touch()`` was a
+            # TOCTOU window: two daemons (operator mistake, systemd
+            # restart race, container test rig) could both see the flag
+            # missing and both enter the shutdown path before either
+            # marked it. ``touch(exist_ok=False)`` collapses check +
+            # create into one ``open(O_CREAT|O_EXCL)`` syscall so the
+            # filesystem itself arbitrates. self._lock still covers
+            # intra-process atomicity for ``_shutdown_done``.
+            try:
+                self._shutdown_flag_path.touch(exist_ok=False)
+            except FileExistsError:
                 # 5.3.0: should never happen on a healthy install --
                 # startup cleanup unconditionally removes any stale flag.
                 # Reaching here means startup-cleanup was bypassed (file
                 # owned by another user, /var/run remounted read-only,
-                # someone touched the flag manually). Surface it so the
-                # operator sees the diagnostic the pre-5.3.0 silent
-                # no-op never gave them.
+                # someone touched the flag manually, peer daemon won the
+                # race). Surface it so the operator sees the diagnostic
+                # the pre-5.3.0 silent no-op never gave them.
                 self._shutdown_done = True
                 suppressed_by_stale_flag = True
             else:
                 self._shutdown_done = True
-                self._shutdown_flag_path.touch()
 
         if suppressed_by_stale_flag:
             # Logged outside the lock: the logger may block on disk and
@@ -405,14 +414,20 @@ class RedundancyGroupEvaluator(threading.Thread):
             )
         elif (not quorum_lost) and self._was_quorum_lost:
             tally = ", ".join(f"{name}={h.value}" for name, h in per_ups.items())
+            # 5.3.0 contract: ALWAYS clear the executor's re-entry
+            # guard on lost->recovered. The ``_fired == True`` case is
+            # the common one (shutdown ran but the host stayed up --
+            # is_local: false rack topology, sandbox, dummy-UPS rig).
+            # The ``_fired == False`` case covers the stale-flag
+            # suppression path: ``shutdown()`` returned False because
+            # the flag already existed, ``_fired`` never flipped, but
+            # the executor's ``_shutdown_done`` is still latched True
+            # -- skipping the clear here would silently block every
+            # subsequent quorum loss for the rest of this daemon's
+            # life, exactly the issue #4 symptom this PR fixes.
+            # ``clear_shutdown_state()`` is idempotent.
+            self._executor.clear_shutdown_state()
             if self._fired:
-                # 5.3.0 contract: shutdown ran but the host stayed up
-                # (custom command, sandbox, is_local: false rack
-                # topology, dummy-UPS rig, non-root invocation). Clear
-                # the executor's re-entry guard so the next quorum loss
-                # can re-trigger. Mirrors the per-UPS POWER_RESTORED
-                # re-arm shipped for bug #4 in 5.2.2.
-                self._executor.clear_shutdown_state()
                 self._fired = False
                 self._log(
                     f"✅ Redundancy group '{self._group.name}' quorum restored "

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -169,20 +169,68 @@ class RedundancyGroupExecutor(
 
     # ----- public API -----
 
+    def clear_shutdown_state(self) -> None:
+        """Reset the in-process and on-disk re-entry guards.
+
+        5.3.0 contract: the daemon owns the redundancy flag's lifecycle.
+        Cleared at coordinator startup, on quorum recovery, and on
+        graceful signal exit. The flag's only role is in-flight
+        re-entry protection within a single quorum-loss event -- it
+        never persists across runs or events. Mirrors the per-UPS
+        re-arm path added for bug #4 in 5.2.2.
+
+        Both the in-memory bool flip AND the on-disk unlink happen
+        under ``self._lock`` so the two halves of "guard is cleared"
+        stay atomic w.r.t. ``shutdown()``. A future caller from a
+        third thread (e.g. a control plane) won't be able to observe
+        a torn pair.
+        """
+        with self._lock:
+            self._shutdown_done = False
+            self._shutdown_flag_path.unlink(missing_ok=True)
+
     def shutdown(self, reason: str) -> bool:
         """Run the redundancy group's shutdown sequence (idempotent).
 
         Returns ``True`` if this call performed the shutdown,
         ``False`` if a previous call (or external flag file) already did.
+
+        Within a single quorum-loss event the in-memory ``_shutdown_done``
+        + the on-disk flag prevent double-fire. Across events / restarts,
+        :meth:`clear_shutdown_state` (called by the coordinator at
+        startup and by the evaluator on quorum recovery) re-arms both.
         """
+        suppressed_by_stale_flag = False
         with self._lock:
             if self._shutdown_done:
                 return False
             if self._shutdown_flag_path.exists():
+                # 5.3.0: should never happen on a healthy install --
+                # startup cleanup unconditionally removes any stale flag.
+                # Reaching here means startup-cleanup was bypassed (file
+                # owned by another user, /var/run remounted read-only,
+                # someone touched the flag manually). Surface it so the
+                # operator sees the diagnostic the pre-5.3.0 silent
+                # no-op never gave them.
                 self._shutdown_done = True
-                return False
-            self._shutdown_done = True
-            self._shutdown_flag_path.touch()
+                suppressed_by_stale_flag = True
+            else:
+                self._shutdown_done = True
+                self._shutdown_flag_path.touch()
+
+        if suppressed_by_stale_flag:
+            # Logged outside the lock: the logger may block on disk and
+            # we never want diagnostic I/O to widen ``self._lock``'s
+            # critical section. The bool was set inside the lock so this
+            # branch executes at most once per process per stale-flag
+            # observation.
+            self._log_message(
+                f"⚠️ Redundancy shutdown for '{self._group.name}' "
+                f"suppressed: flag {self._shutdown_flag_path} already "
+                f"present at first call (startup cleanup bypassed). "
+                f"Will re-arm when quorum recovers."
+            )
+            return False
 
         self._log_message(
             f"🚨 REDUNDANCY GROUP SHUTDOWN: {self._group.name}"
@@ -355,12 +403,27 @@ class RedundancyGroupEvaluator(threading.Thread):
                 f"🚨 Redundancy group '{self._group.name}' quorum LOST "
                 f"(healthy={healthy_count}, min_healthy={self._group.min_healthy}; {tally})"
             )
-        elif (not quorum_lost) and self._was_quorum_lost and not self._fired:
+        elif (not quorum_lost) and self._was_quorum_lost:
             tally = ", ".join(f"{name}={h.value}" for name, h in per_ups.items())
-            self._log(
-                f"✅ Redundancy group '{self._group.name}' quorum restored "
-                f"(healthy={healthy_count}, min_healthy={self._group.min_healthy}; {tally})"
-            )
+            if self._fired:
+                # 5.3.0 contract: shutdown ran but the host stayed up
+                # (custom command, sandbox, is_local: false rack
+                # topology, dummy-UPS rig, non-root invocation). Clear
+                # the executor's re-entry guard so the next quorum loss
+                # can re-trigger. Mirrors the per-UPS POWER_RESTORED
+                # re-arm shipped for bug #4 in 5.2.2.
+                self._executor.clear_shutdown_state()
+                self._fired = False
+                self._log(
+                    f"✅ Redundancy group '{self._group.name}' quorum restored "
+                    f"-- re-armed for next event "
+                    f"(healthy={healthy_count}, min_healthy={self._group.min_healthy}; {tally})"
+                )
+            else:
+                self._log(
+                    f"✅ Redundancy group '{self._group.name}' quorum restored "
+                    f"(healthy={healthy_count}, min_healthy={self._group.min_healthy}; {tally})"
+                )
 
         self._was_quorum_lost = quorum_lost
 

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.3.0-rc2"
+__version__ = "5.3.0-rc3"

--- a/tests/e2e/groups/redundancy.sh
+++ b/tests/e2e/groups/redundancy.sh
@@ -8,6 +8,18 @@
 # workflow had per-step shell isolation -- we preserve it here).
 # Each group runs as a separate parallel matrix job (see
 # .github/workflows/e2e.yml).
+#
+# 5.3.0 contract note: pre-5.3.0 every test body opened with
+#   rm -f /tmp/eneru-e2e-redundancy*-shutdown-flag* \
+#         /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
+# to scrub stale flags between tests. The redundancy executor's flag
+# is now daemon-managed -- coordinator startup, quorum recovery, and
+# graceful exit each clear it -- so those rm lines became redundant
+# and were removed. With them gone, every existing test doubles as a
+# regression catch for the startup-cleanup contract; Test 37 below
+# is the explicit fire->recover->fire-again scenario. Do NOT add the
+# rm lines back without first confirming the contract is intentionally
+# being inverted.
 
 set -euo pipefail
 
@@ -103,9 +115,6 @@ echo ""
 echo ">>> Running: Test 21: Redundancy quorum holds when 1 of 2 healthy"
 
 echo "=== Test 21: Quorum holds ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 # UPS1 critical (low battery), UPS2 healthy
 cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS1.dev
 cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
@@ -144,9 +153,6 @@ echo ""
 echo ">>> Running: Test 22: Both UPSes critical → redundancy shutdown fires"
 
 echo "=== Test 22: Quorum exhausted ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS1.dev
 cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS2.dev
 sleep 3
@@ -179,9 +185,6 @@ echo ""
 echo ">>> Running: Test 23: unknown_counts_as=critical surfaces UNKNOWN as failure"
 
 echo "=== Test 23: UNKNOWN handling ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 # UPS1 healthy; UPS2 health UNKNOWN (we'll just keep it online --
 # the goal is to confirm UNKNOWN is *handled*, not to force it).
 # We assert the handling indirectly via Test 22's matching log lines
@@ -216,9 +219,6 @@ echo ""
 echo ">>> Running: Test 24: Both UPSes UNKNOWN -> fail-safe shutdown"
 
 echo "=== Test 24: Both UNKNOWN ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 # Both UPSes go on-battery + low; on top, the failsafe-relevant
 # combination "OB + dropped data" is hard to provoke with the
 # dummy. We rely on the same low-battery scenario as Test 22,
@@ -249,9 +249,6 @@ echo ""
 echo ">>> Running: Test 25: Cross-group cascade (UPS in both tiers)"
 
 echo "=== Test 25: Cross-group cascade ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 # UPS1 critical -- it appears in both an independent group AND
 # the redundancy group. UPS2 is healthy. The redundancy evaluator
 # must NOT fire (1 of 2 healthy >= min_healthy=1) regardless of
@@ -282,9 +279,6 @@ echo ""
 echo ">>> Running: Test 26: Advisory-mode log signature"
 
 echo "=== Test 26: Advisory-mode log signature ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 # UPS1 critical (only it is in the redundancy group); UPS2 healthy.
 cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS1.dev
 cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
@@ -318,9 +312,6 @@ echo ""
 echo ">>> Running: Test 27: Separate-Eneru-UPS topology"
 
 echo "=== Test 27: Separate-Eneru-UPS ==="
-rm -f /tmp/eneru-e2e-redundancy-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 # TestUPS healthy (powers Eneru host); UPS1 + UPS2 critical
 # (powers remote rack). The redundancy shutdown must fire for
 # the rack, but TestUPS is unaffected, so the Eneru host stays
@@ -357,6 +348,103 @@ echo "PASS: Separate-Eneru-UPS topology verified"
 )
 
 # ======================================================================
+# Test 37: Re-arm after quorum recovery (issue #4)
+# ======================================================================
+#
+# Pre-5.3.0: once a redundancy group fired a shutdown, the evaluator
+# pinned ``_fired = True`` for the lifetime of the daemon AND the
+# executor's on-disk flag survived restarts. Result: every quorum
+# loss after the first one silently no-op'd, even after power was
+# restored. Reported by ckrevel in
+# github.com/m4r1k/Eneru/issues/4#issuecomment-4375517607.
+#
+# This test drives two consecutive quorum-loss events back-to-back
+# and asserts the second one fires its own shutdown sequence.
+(
+echo ""
+echo ">>> Running: Test 37: Redundancy re-arm after quorum recovery (issue #4)"
+
+echo "=== Test 37: re-arm ==="
+
+# Start from a known-healthy quorum so the evaluator's startup grace
+# elapses without firing.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 2
+
+# Run eneru in background -- we need to drive scenarios in flight,
+# so --exit-after-shutdown is intentionally omitted. Budget: 13s
+# startup grace + three 8s phase sleeps + dry-run shutdown sequence
+# overhead per phase = ~50s expected. 90s leaves headroom for slow
+# CI runners (matches the safety margin of R1/R2 below).
+timeout 90s eneru run --config $E2E_DIR/config-e2e-redundancy.yaml \
+  > /tmp/test37.log 2>&1 &
+ENERU_PID=$!
+trap 'kill "$ENERU_PID" 2>/dev/null || true' EXIT
+
+# Clear evaluator startup grace (~10s for check_interval=1).
+sleep 13
+
+# Phase 1: drop both UPSes critical -> first quorum-loss shutdown.
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 8
+
+# Phase 2: restore both -> evaluator must log "quorum restored -- re-armed"
+# AND clear the executor's re-entry guard.
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 8
+
+# Phase 3: drop both critical again -> SECOND quorum-loss shutdown.
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 8
+
+kill "$ENERU_PID" 2>/dev/null || true
+wait "$ENERU_PID" 2>/dev/null || true
+trap - EXIT
+
+t37_fail() {
+  echo "$1"
+  echo "----- /tmp/test37.log (full) -----"
+  cat /tmp/test37.log
+  echo "----- /tmp/test37.log end -----"
+  exit 1
+}
+
+# 1. Quorum LOST must appear at least twice (once per phase).
+LOST_COUNT=$(grep -c "rack-1-dual-psu.* quorum LOST" /tmp/test37.log || true)
+if [ "$LOST_COUNT" -lt 2 ]; then
+  t37_fail "FAIL: expected >=2 'quorum LOST' lines, got $LOST_COUNT"
+fi
+
+# 2. Re-arm log line must appear between the two losses.
+if ! grep -q "quorum restored -- re-armed" /tmp/test37.log; then
+  t37_fail "FAIL: expected 'quorum restored -- re-armed' log line after first shutdown"
+fi
+
+# 3. The load-bearing assertion: TWO shutdowns must have actually fired.
+SHUTDOWN_COUNT=$(grep -c "REDUNDANCY GROUP SHUTDOWN: rack-1-dual-psu" /tmp/test37.log || true)
+if [ "$SHUTDOWN_COUNT" -lt 2 ]; then
+  t37_fail "FAIL: expected 2 'REDUNDANCY GROUP SHUTDOWN' lines (re-arm broken, issue #4 regression), got $SHUTDOWN_COUNT"
+fi
+
+# 4. The pre-5.3.0 silent-no-op path must NOT have surfaced. Its
+#    presence here would mean the startup-cleanup contract failed to
+#    clean a leftover flag.
+if grep -q "suppressed: flag .* startup cleanup bypassed" /tmp/test37.log; then
+  t37_fail "FAIL: stale-flag suppression warning fired -- startup cleanup contract violated"
+fi
+
+# Restore for downstream tests
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 2
+echo "PASS: redundancy re-arm verified across two consecutive quorum-loss events"
+)
+
+# ======================================================================
 # Regression R1: Runtime transient NUT loss stays inside redundancy grace
 # ======================================================================
 (
@@ -364,9 +452,6 @@ echo ""
 echo ">>> Running: Regression R1: Runtime transient NUT loss stays inside redundancy grace"
 
 echo "=== Regression R1: transient runtime NUT visibility loss ==="
-rm -f /tmp/eneru-e2e-redundancy-grace-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 dbg "R1 step 1/8: pre-test restart_redundancy_nut_server"
 restart_redundancy_nut_server
 dump_redundancy_nut_state "R1 after first restart"
@@ -432,9 +517,6 @@ echo ""
 echo ">>> Running: Regression R2: Runtime persistent NUT loss fails safe after grace"
 
 echo "=== Regression R2: persistent runtime NUT visibility loss ==="
-rm -f /tmp/eneru-e2e-redundancy-grace-shutdown-flag* \
-      /tmp/ups-shutdown-redundancy-* 2>/dev/null || true
-
 dbg "R2 step 1/8: pre-test restart_redundancy_nut_server"
 restart_redundancy_nut_server
 dump_redundancy_nut_state "R2 after first restart"

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1725,3 +1725,56 @@ class TestCoordinatorRedundancyWiring:
         with pytest.raises(SystemExit):
             coord._handle_signal(15, None)
         assert len(joined_evals) == 2
+
+    @pytest.mark.unit
+    def test_start_monitors_clears_redundancy_executor_state_at_startup(self, tmp_path):
+        """5.3.0 contract: the daemon owns the redundancy flag's
+        lifecycle. The coordinator must call clear_shutdown_state() on
+        every freshly constructed executor so a stale on-disk flag from
+        a prior daemon instance can't silently block the next quorum
+        loss (issue #4)."""
+        config = self._config_with_redundancy(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+
+        with patch("eneru.multi_ups.threading.Thread"), \
+             patch("eneru.multi_ups.UPSGroupMonitor") as mock_monitor_cls, \
+             patch("eneru.multi_ups.RedundancyGroupExecutor") as mock_executor_cls, \
+             patch("eneru.multi_ups.RedundancyGroupEvaluator") as mock_eval_cls:
+            mock_monitor_cls.return_value = MagicMock()
+            mock_eval_cls.return_value = MagicMock()
+            coord._start_monitors()
+
+        # The executor mock's clear_shutdown_state must have been called
+        # exactly once -- before the evaluator started polling.
+        mock_executor_cls.return_value.clear_shutdown_state.assert_called_once()
+
+    @pytest.mark.unit
+    def test_handle_signal_clears_redundancy_executor_state(self, tmp_path):
+        """5.3.0 contract: graceful exit clears redundancy flags too,
+        not just the per-UPS coordinator flag."""
+        coord = MultiUPSCoordinator(self._config_with_redundancy(tmp_path))
+        coord._logger = MagicMock()
+        ex_a, ex_b = MagicMock(), MagicMock()
+        coord._redundancy_executors = {"rg-A": ex_a, "rg-B": ex_b}
+
+        with pytest.raises(SystemExit):
+            coord._handle_signal(15, None)
+
+        ex_a.clear_shutdown_state.assert_called_once()
+        ex_b.clear_shutdown_state.assert_called_once()
+
+    @pytest.mark.unit
+    def test_handle_signal_swallows_redundancy_clear_failures(self, tmp_path):
+        """A flag-cleanup failure in one executor must NOT block exit
+        nor stop other executors from being cleared."""
+        coord = MultiUPSCoordinator(self._config_with_redundancy(tmp_path))
+        coord._logger = MagicMock()
+        bad = MagicMock()
+        bad.clear_shutdown_state.side_effect = OSError("flag dir gone")
+        good = MagicMock()
+        coord._redundancy_executors = {"rg-bad": bad, "rg-good": good}
+
+        with pytest.raises(SystemExit):
+            coord._handle_signal(15, None)
+        good.clear_shutdown_state.assert_called_once()

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -442,28 +442,42 @@ class TestEvaluatorIdempotency:
         executor.shutdown.assert_called_once()
 
     @pytest.mark.unit
-    def test_recovery_then_re_loss_keeps_fired_state(self):
-        """Once fired, the evaluator stays "fired" -- recovery is informational only."""
+    def test_quorum_recovery_re_arms_for_next_event(self):
+        """5.3.0 contract: recovery re-arms the evaluator + executor.
+
+        Pre-5.3.0 the evaluator stayed pinned at ``_fired = True`` after
+        the first quorum loss, so subsequent quorum losses silently
+        no-op'd. With the per-UPS bug-#4 analog now wired in, the
+        evaluator clears its own ``_fired`` AND calls
+        ``executor.clear_shutdown_state()`` on the lost->recovered
+        transition.
+        """
         group = _redundancy_group(min_healthy=1)
         monitors = {
             "UPS-A": _FakeMonitor("UPS-A", _snap(trigger_active=True, trigger_reason="x")),
             "UPS-B": _FakeMonitor("UPS-B", _snap(trigger_active=True, trigger_reason="x")),
         }
         ev, executor = self._make(group, monitors)
-        ev.evaluate_once()  # fires
-        # Snap UPS-A back to healthy
-        with monitors["UPS-A"].state._lock:
-            monitors["UPS-A"].state.trigger_active = False
-            monitors["UPS-A"].state.trigger_reason = ""
-            monitors["UPS-A"].state.latest_status = "OL"
-        ev.evaluate_once()  # quorum recovered, no extra calls
-        # UPS-A drops again
-        with monitors["UPS-A"].state._lock:
-            monitors["UPS-A"].state.trigger_active = True
-            monitors["UPS-A"].state.trigger_reason = "x"
-            monitors["UPS-A"].state.latest_status = "OB FSD"
-        ev.evaluate_once()  # would fire again but already fired
-        executor.shutdown.assert_called_once()
+        ev.evaluate_once()  # fires once
+        assert ev._fired is True
+        # Snap both back to healthy -- quorum recovers
+        for name in ("UPS-A", "UPS-B"):
+            with monitors[name].state._lock:
+                monitors[name].state.trigger_active = False
+                monitors[name].state.trigger_reason = ""
+                monitors[name].state.latest_status = "OL"
+        ev.evaluate_once()  # recovery re-arms
+        executor.clear_shutdown_state.assert_called_once()
+        assert ev._fired is False
+        # Both drop again -- second quorum loss must fire a new shutdown
+        for name in ("UPS-A", "UPS-B"):
+            with monitors[name].state._lock:
+                monitors[name].state.trigger_active = True
+                monitors[name].state.trigger_reason = "x"
+                monitors[name].state.latest_status = "OB FSD"
+        ev.evaluate_once()
+        assert executor.shutdown.call_count == 2
+        assert ev._fired is True
 
 
 class TestEvaluatorThreadLifecycle:
@@ -646,12 +660,62 @@ class TestExecutorShutdown:
 
     @pytest.mark.unit
     def test_idempotent_against_existing_flag_file(self, tmp_path):
+        # Defense-in-depth: even though the 5.3.0 contract has the
+        # coordinator clear the flag at startup, the executor itself
+        # still refuses to re-fire if it observes a flag at first call.
+        # This covers the contract-violation case (flag owned by another
+        # user, /var/run remounted RO mid-run, manual touch).
         cfg = _base_config(dry_run=False, tmp_path=tmp_path)
         ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
         # Pre-create the flag file as if a previous Eneru run left it behind.
         ex._shutdown_flag_path.touch()
         assert ex.shutdown(reason="x") is False
         assert ex._shutdown_done is True
+
+    @pytest.mark.unit
+    def test_stale_flag_emits_warning_log(self, tmp_path):
+        """5.3.0: the silent no-op path now surfaces a warning so the
+        operator sees what the pre-5.3.0 silent suppression hid."""
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(name="rg-x"),
+                                      base_config=cfg)
+        ex.logger = MagicMock()
+        ex._shutdown_flag_path.touch()  # simulate startup-cleanup bypassed
+        assert ex.shutdown(reason="x") is False
+        logged = " ".join(call.args[0] for call in ex.logger.log.call_args_list)
+        assert "suppressed" in logged
+        assert "rg-x" in logged
+        assert "startup cleanup bypassed" in logged
+
+    @pytest.mark.unit
+    def test_clear_shutdown_state_unlinks_flag_and_resets_done(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        # Explicit is_local=False so this test stays correct even if the
+        # _redundancy_group() default ever flips -- the local resource
+        # mixins (_shutdown_vms, _unmount_filesystems) would otherwise
+        # try to run for real with dry_run=False.
+        ex = RedundancyGroupExecutor(_redundancy_group(is_local=False),
+                                     base_config=cfg)
+        # Fire a shutdown so the flag is on disk and _shutdown_done is True.
+        assert ex.shutdown(reason="x") is True
+        assert ex._shutdown_flag_path.exists()
+        assert ex._shutdown_done is True
+        # Clear: both must be reset.
+        ex.clear_shutdown_state()
+        assert not ex._shutdown_flag_path.exists()
+        assert ex._shutdown_done is False
+        # Re-fire is now possible.
+        assert ex.shutdown(reason="y") is True
+
+    @pytest.mark.unit
+    def test_clear_shutdown_state_is_idempotent(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+        # No fire yet -- flag absent. Clear must not raise.
+        ex.clear_shutdown_state()
+        ex.clear_shutdown_state()
+        assert not ex._shutdown_flag_path.exists()
+        assert ex._shutdown_done is False
 
     @pytest.mark.unit
     def test_remote_shutdown_called_in_dry_run(self, tmp_path):

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -442,6 +442,40 @@ class TestEvaluatorIdempotency:
         executor.shutdown.assert_called_once()
 
     @pytest.mark.unit
+    def test_recovery_clears_executor_state_even_when_never_fired(self):
+        """5.3.0 contract regression: when ``shutdown()`` is suppressed
+        by a stale flag (CodeRabbit P1 #2), ``_fired`` never flips to
+        True. Pre-fix, the recovery branch only cleared executor state
+        when ``_fired`` was True, so the executor's ``_shutdown_done``
+        stayed latched and silently blocked every subsequent quorum
+        loss for the rest of the daemon's life. The recovery branch
+        must always call ``clear_shutdown_state()``.
+        """
+        group = _redundancy_group(min_healthy=1)
+        monitors = {
+            "UPS-A": _FakeMonitor("UPS-A", _snap(trigger_active=True, trigger_reason="x")),
+            "UPS-B": _FakeMonitor("UPS-B", _snap(trigger_active=True, trigger_reason="x")),
+        }
+        executor = MagicMock()
+        executor.shutdown.return_value = False  # simulate stale-flag suppression
+        ev = RedundancyGroupEvaluator(
+            group, monitors, executor,
+            stop_event=threading.Event(), logger=None,
+        )
+        ev.evaluate_once()  # quorum lost, shutdown suppressed
+        assert ev._fired is False  # never flipped because shutdown returned False
+        executor.clear_shutdown_state.assert_not_called()
+        # Both back to healthy -- recovery must clear executor state
+        # even though _fired is False.
+        for name in ("UPS-A", "UPS-B"):
+            with monitors[name].state._lock:
+                monitors[name].state.trigger_active = False
+                monitors[name].state.trigger_reason = ""
+                monitors[name].state.latest_status = "OL"
+        ev.evaluate_once()
+        executor.clear_shutdown_state.assert_called_once()
+
+    @pytest.mark.unit
     def test_quorum_recovery_re_arms_for_next_event(self):
         """5.3.0 contract: recovery re-arms the evaluator + executor.
 


### PR DESCRIPTION
## Summary

- **Behavior change**: redundancy executor's flag at `/var/run/ups-shutdown-redundancy-{group}` is now daemon-managed. Cleared at coordinator startup (load-bearing), on quorum recovery, and on graceful SIGINT/SIGTERM exit. Pre-5.3.0 the flag persisted indefinitely; once any redundancy shutdown ran without halting the host (`is_local: false` rack topology, sandbox, dummy-UPS rig), the flag silently blocked every subsequent redundancy shutdown across daemon restarts.
- **Direct fix for issue #4** ([comment 4375517607](https://github.com/m4r1k/Eneru/issues/4#issuecomment-4375517607)): the evaluator now resets `_fired = False` and clears the executor's re-entry guard on the lost→recovered transition. Mirrors the per-UPS bug #4 fix shipped in 5.2.2 (`38ada61`).
- **Diagnostic surface**: new `⚠️ Redundancy shutdown for '{group}' suppressed: …` warning if the executor ever sees the flag at first call (contract violation: manual touch, RO `/var/run`, etc). Pre-5.3.0 the suppression was silent.

## Why CI didn't catch it

Every E2E redundancy test opened with `rm -f /tmp/(ups|eneru-e2e)-shutdown-redundancy-*` to scrub stale flags between runs. Those `rm` lines are now redundant with the daemon-managed lifecycle and have been removed (9 deletions); each existing test now doubles as regression coverage. New **Test 37** is the explicit fire→recover→fire-again scenario across two consecutive quorum-loss events on the same daemon process — the assertion that `SHUTDOWN_COUNT >= 2` would have failed on pre-fix code because the evaluator's `_fired` was pinned True forever.

## Test plan

- [x] `pytest -m unit` — 1017 passed (was 1014; +3 redundancy unit tests, +3 multi_ups coordinator tests)
- [x] `bash -n tests/e2e/groups/*.sh` — all syntactically valid
- [ ] CI: 11 required checks (validate × 6, E2E × 5)
- [ ] Test 37 in the **E2E Redundancy** matrix step is the load-bearing assertion

## Files

| Surface | Files |
|---|---|
| Implementation | `src/eneru/redundancy.py`, `src/eneru/multi_ups.py` |
| Unit tests | `tests/test_redundancy.py`, `tests/test_multi_ups.py` |
| E2E | `tests/e2e/groups/redundancy.sh`, `.github/workflows/e2e.yml` (comment) |
| Docs | `docs/changelog.md` (Behavior change callout), `docs/redundancy-groups.md` (new Operational notes / Re-entry guard subsection), `docs/testing.md` (T37 row, count 36→37) |

Plus a small chore commit adding the five Primary Directives to `AGENTS.md`.

## Migration notes

Drop-in upgrade. Anyone manually deleting `/var/run/ups-shutdown-redundancy-*` as a workaround for issue #4 can stop — the daemon now does it for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the daemon own the redundancy shutdown flag so stale flags can’t block future shutdowns. Re-arms redundancy after quorum recovery, adds a warning on stale flags, and fixes a race that could double-fire across parallel daemons.

- **Bug Fixes**
  - Clear `/var/run/ups-shutdown-redundancy-{group}` at startup, on quorum recovery, and on graceful exit; the flag now guards only a single event.
  - Always re-arm on lost→recovered: reset `_fired` and call `executor.clear_shutdown_state()` even if the first fire was suppressed by a stale flag. Fixes issue #4.
  - Make flag acquisition atomic with `touch(exist_ok=False)` to remove the TOCTOU race between daemons and prevent double-fire on restart races.
  - Log a warning if a stale flag is present at first call instead of silently suppressing shutdown.
  - Clear each group's executor state on coordinator startup; clear all on exit without blocking on errors.
  - E2E: removed manual flag cleanup; added Test 37 to prove fire → recover → fire again.

- **Docs**
  - README: updated badges and softened the test-count line.

<sup>Written for commit 49c8f7b5399ecd4bd776bf7c5911a9cbaa5ff30e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redundancy flag lifecycle is now automatically managed by the daemon at startup, quorum recovery, and graceful exit.

* **Bug Fixes**
  * Improved redundancy re-entry handling across quorum-loss and recovery transitions to ensure proper state reset.

* **Documentation**
  * Added operational notes on redundancy shutdown behavior and updated troubleshooting guidance.
  * Clarified that manual flag file cleanup is no longer necessary.

* **Tests**
  * Added comprehensive test coverage for redundancy re-entry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->