### PR TITLE
fix: harden redundancy guards for rc4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ env:
 # of the previous ~6+ minute single sequential job.
 #
 # v5.1.2 split the previous `Redundancy and Stats` job into two
-# (`Redundancy` runs tests 21-27 + 37 + R1/R2, `Stats` runs tests
+# (`Redundancy` runs tests 21-27 + 37/38 + R1/R2, `Stats` runs tests
 # 28-32 + 34/35) so the heaviest group no longer gates the matrix on
 # its own.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ README.md                       # Project overview
 - **Adding a new file under `src/eneru/`?** Also add a matching `contents:` entry in `nfpm.yaml`. The deb/rpm builds enumerate every module file explicitly — they do NOT glob. The pip path uses pyproject.toml autodiscovery, so a missing entry passes pip CI silently and only fails at deb/rpm install time with `ModuleNotFoundError`. Triple-checking via the isolated-interpreter package-layout simulation (see `src/eneru/AGENTS.md`) before push is the way to catch this.
 - **Adding state to the SQLite stats DB?** Bump `SCHEMA_VERSION` in `src/eneru/stats.py` and add an idempotent `ALTER TABLE` migration in `_init_schema._migrate_schema` keyed off `meta.schema_version`. Migrations are append-only — never modify a previous version's block. Every `ALTER` is wrapped via `_safe_alter` so duplicate-column errors are benign. The version is bumped *after* the migration succeeds, so a crash mid-migration is replayed safely. See `src/eneru/AGENTS.md` "Stats schema evolution" for the full pattern + when-to-add-a-column guidance. New event types (rows in `events`) do NOT need a schema bump — only new columns or tables do.
 
-## Working efficiently in Claude Code
+## Working efficiently
 
 This repo deliberately keeps individual files small (`monitor.py` is now ~830 lines after the v5.1 mixin decomposition; the largest test file is ~735 lines). To stay within the 200k context window during longer sessions:
 
@@ -253,16 +253,20 @@ Tags are the immutable release snapshots. No release branches -- tags are suffic
 
 ## Code review workflow (manual AI invocation)
 
-This repo uses **three layers of AI review**: a Claude-side pre-push review via the `agent-skills:code-reviewer` subagent, plus two GitHub-side reviewers (`coderabbitai` and `cubic-dev-ai`) invoked manually after CI is green. All three are configured for **manual invocation** rather than reviewing every PR commit automatically.
+This repo uses **three layers of AI review**: a pre-push review via the `agent-skills:code-reviewer` subagent, plus two GitHub-side reviewers (`coderabbitai` and `cubic-dev-ai`) invoked manually after CI is green. All three are configured for **manual invocation** rather than reviewing every PR commit automatically.
 
 **Why manual:**
 - **CodeRabbit** free tier allows one review per 45 minutes. Per-commit auto-review burns the quota fast and produces noisy partial reviews against intermediate diffs.
 - **cubic.dev** free tier allows 40 reviews per month. Same problem.
 - We deliberately push commits early so the GitHub Actions E2E suite (`E2E CLI`, `E2E UPS Single`, `E2E UPS Multi`, `E2E Redundancy`, `E2E Stats`) gates work-in-progress and gives feedback fast on real-world scenarios. That CI feedback loop must stay cheap; AI review should not bottleneck it.
 
-**Pre-push: spawn `agent-skills:code-reviewer` as a SUBAGENT (model=opus).**
+**Pre-push: spawn `agent-skills:code-reviewer` as a SUBAGENT**
 
-Before pushing a substantive feature branch, the Claude session running the work MUST spawn the `agent-skills:code-reviewer` skill via the `Agent` tool with `subagent_type: agent-skills:code-reviewer` and `model: opus`. Two reasons:
+Before pushing a substantive feature branch, you MUST spawn the `agent-skills:code-reviewer` skill via the `Agent` tool with `subagent_type: agent-skills:code-reviewer` and:
+- if you're Claude Code, you must leverage the `model: opus`.
+- if you're Codex, you must leverage the `model: gpt-5.5` with `reasoning_effort: high`.
+
+Two reasons:
 
 1. **Minimal context = efficient.** The reviewer runs in a fresh context; the main session's token budget stays unaffected.
 2. **Minimal context = independent opinion.** The reviewer doesn't see what the main session decided, defended, or rationalized. That separation is the whole value — a same-session review is biased toward defending its own choices. Findings come back categorized P0/P1/P2/P3; triage and fix before pushing.
@@ -270,7 +274,7 @@ Before pushing a substantive feature branch, the Claude session running the work
 **Workflow on every non-trivial PR:**
 ```
 1. Implement the change. Run pytest in the uv venv. Iterate.
-2. PRE-PUSH: spawn agent-skills:code-reviewer subagent (opus) with the
+2. PRE-PUSH: spawn agent-skills:code-reviewer subagent with the
    diff, the plan file, and any specific concerns. Triage findings.
 3. Push commits. Let CI run on each push (E2E especially). Iterate on
    CI failures.
@@ -345,7 +349,7 @@ When releasing a new version, update `docs/changelog.md` with the comparison tab
 
 ### Changelog workflow: verbose during dev, trim before release
 
-The `[Unreleased]` section is a **working surface, not a published artifact**. During development add detail freely — per-rc breakouts (`rc6 — added X`, `rc7 — fixed Y`), file references, code snippets, design rationale. The reasoning: future Claude sessions pick up context cheaper from a single long file than by reading individual commits with `git log -p` (one paragraph in a markdown file ≪ one full diff). Trade a fat `[Unreleased]` block for fewer tokens spent reconstructing what changed.
+The `[Unreleased]` section is a **working surface, not a published artifact**. During development add detail freely — per-rc breakouts (`rc6 — added X`, `rc7 — fixed Y`), file references, code snippets, design rationale. The reasoning: future sessions pick up context cheaper from a single long file than by reading individual commits with `git log -p` (one paragraph in a markdown file ≪ one full diff). Trade a fat `[Unreleased]` block for fewer tokens spent reconstructing what changed.
 
 **Before tagging the release**, consolidate the verbose `[Unreleased]` block into a published-quality entry that matches the size and density of prior shipped releases. Reference points: v5.0.0 was ~600 words; v5.1.0 was trimmed from ~2950 words (rc1 through rc9 accumulated) down to ~1100 words (the published entry). Reader-friendly always wins at release time.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,11 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   startup-cleanup hook was bypassed, `/var/run` is read-only), a
   one-line `⚠️ Redundancy shutdown for '{group}' suppressed: …` warning
   now fires. Pre-5.3.0 the suppression was silent.
-- **Redundancy flags now record PID ownership.** Startup still clears stale
-  redundancy flags from dead daemon sessions, but refuses to clear a flag
-  owned by a still-running PID. That turns overlapping daemon instances or
-  unreadable `/var/run` state into an immediate fatal startup error instead
-  of weakening the shutdown re-entry guard.
+- **Redundancy flags now record process ownership.** Startup still clears
+  stale redundancy flags from dead daemon sessions, but refuses to clear a flag
+  owned by a still-running process. On Linux the owner check includes process
+  start identity, so a stale flag is not confused with a reused PID. That turns
+  overlapping daemon instances or unreadable `/var/run` state into an
+  immediate fatal startup error instead of weakening the shutdown re-entry
+  guard.
 - **Unknown trigger/behavior keys are validation errors.** Typos in
   `behavior`, top-level and per-UPS `triggers`, and
   `redundancy_groups[*].triggers` now fail validation with a "did you mean"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   startup-cleanup hook was bypassed, `/var/run` is read-only), a
   one-line `⚠️ Redundancy shutdown for '{group}' suppressed: …` warning
   now fires. Pre-5.3.0 the suppression was silent.
+- **Redundancy flags now record PID ownership.** Startup still clears stale
+  redundancy flags from dead daemon sessions, but refuses to clear a flag
+  owned by a still-running PID. That turns overlapping daemon instances or
+  unreadable `/var/run` state into an immediate fatal startup error instead
+  of weakening the shutdown re-entry guard.
+- **Unknown trigger/behavior keys are validation errors.** Typos in
+  `behavior`, top-level and per-UPS `triggers`, and
+  `redundancy_groups[*].triggers` now fail validation with a "did you mean"
+  hint where possible. Legacy compatibility sections that still work,
+  including top-level `docker:` and Discord webhook config, remain accepted.
+  Malformed YAML is also fatal for `eneru run`, instead of falling through to
+  daemon startup with defaults.
 
 ### Fixed
 - **Redundancy shutdown no longer pinned at "fired" after first event.**
@@ -39,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quorum-loss → recovered transition, so the next quorum loss fires its
   own shutdown sequence. New `quorum restored -- re-armed for next event`
   log line marks the transition. Direct fix for the symptom in issue #4.
+- **Redundancy group-specific triggers now affect quorum evaluation.**
+  The evaluator applies `redundancy_groups[*].triggers` directly to each
+  member snapshot, so group-local thresholds work without mutating per-UPS
+  monitor configs.
 - **Redundancy runtime NUT visibility now honors connection grace.**
   Issue #4 exposed a path where both redundancy members could turn brief
   stale/lost NUT data into `UNKNOWN` before the per-UPS connection grace
@@ -61,6 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   notification behavior. The redundancy E2E group adds runtime cases for
   brief NUT visibility loss that recovers inside grace and persistent loss
   that still fails safe after grace.
+- **Redundancy flag hardening coverage.** Unit tests now prove two executor
+  instances cannot both acquire the same flag and that active PID-owned
+  flags are not cleared at startup. E2E Test 38 pre-creates a stale
+  redundancy flag before daemon startup and proves shutdown still fires.
 
 ### Changed
 - Event display now uses user-facing tiers: Power Events by default,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,11 @@ Features are off unless their section enables them, except `local_shutdown`, `fi
 
 The tables below cover every YAML key currently parsed by `ConfigLoader`, including the legacy `docker:` and `discord:` compatibility forms. The exhaustive commented sample is [`examples/config-reference.yaml`](https://github.com/m4r1k/Eneru/blob/main/examples/config-reference.yaml). Shorter starting points are in [`examples/`](https://github.com/m4r1k/Eneru/tree/main/examples).
 
+Eneru treats unknown keys in safety-sensitive sections as validation errors.
+This catches typos such as `behavior.dry-run` or `triggers.exteneded_time`
+before the daemon starts. Legacy compatibility forms that still work, such as
+top-level `docker:` and `discord:` webhook config, remain accepted.
+
 ## Single UPS example
 
 ```yaml
@@ -391,7 +396,7 @@ See [Remote servers](remote-servers.md) for SSH keys, sudoers, predefined action
 | `degraded_counts_as` | `healthy` | Count DEGRADED members as `healthy` or `critical` |
 | `unknown_counts_as` | `critical` | Count UNKNOWN members as `critical`, `degraded`, or `healthy` |
 | `is_local` | `false` | This redundancy group powers the Eneru host. At most one local group is allowed across all groups |
-| `triggers` | inherits | Per-group trigger overrides |
+| `triggers` | inherits | Per-group trigger overrides. `depletion.window` is not supported here; set it globally or on `ups[*].triggers` |
 | Resource sections | empty | Same resource surface as a UPS group |
 
 ## File locations

--- a/docs/redundancy-groups.md
+++ b/docs/redundancy-groups.md
@@ -95,6 +95,10 @@ Each UPS member is classified on every evaluator tick.
 
 Member UPS triggers still run. In a redundancy group they do not directly run the shutdown sequence. They mark the member as advisory-critical, then the group evaluator decides whether quorum is gone.
 
+Group-level `triggers:` are also evaluated by the redundancy evaluator itself. Use them when a shared resource has a different risk budget than the member UPS defaults; the group trigger can mark that member critical for quorum without changing the UPS monitor's own config.
+
+`depletion.critical_rate` and `depletion.grace_period` can be group-local. `depletion.window` cannot: the rolling depletion rate is calculated by each UPS monitor before the redundancy evaluator sees the snapshot. Configure `depletion.window` globally or on `ups[*].triggers` instead.
+
 You will see log lines like:
 
 ```text
@@ -189,7 +193,10 @@ prevents a single quorum-loss event from firing the shutdown sequence twice. Fro
 
 - Cleared at coordinator **startup** so a stale flag from a prior daemon
   instance can't silently block the next quorum loss. **This is the
-  load-bearing guarantee**; the next two clears are optimizations.
+  load-bearing guarantee**; the next two clears are optimizations. From
+  5.3.0-rc4 onward the flag records the owning PID, and startup refuses
+  to clear it if that PID is still running. That prevents two overlapping
+  daemon instances from erasing each other's in-flight guard.
 - Cleared on **quorum recovery** so the next quorum loss can fire its own
   shutdown without waiting for a daemon restart. Look for `quorum restored
   -- re-armed for next event` in the log.
@@ -198,7 +205,9 @@ prevents a single quorum-loss event from firing the shutdown sequence twice. Fro
   disk, but the next coordinator startup re-clears it.
 
 The flag's only role is in-flight re-entry protection within a single
-quorum-loss event. It never persists across runs or across events.
+quorum-loss event. It never persists across runs or across events. If the
+flag cannot be inspected or removed at startup, Eneru treats that as fatal
+and exits rather than starting with an unreliable shutdown guard.
 
 If the daemon ever sees the flag at first call (someone touched it manually,
 `/var/run` is read-only, the startup-cleanup hook was bypassed) it logs the

--- a/docs/redundancy-groups.md
+++ b/docs/redundancy-groups.md
@@ -194,9 +194,11 @@ prevents a single quorum-loss event from firing the shutdown sequence twice. Fro
 - Cleared at coordinator **startup** so a stale flag from a prior daemon
   instance can't silently block the next quorum loss. **This is the
   load-bearing guarantee**; the next two clears are optimizations. From
-  5.3.0-rc4 onward the flag records the owning PID, and startup refuses
-  to clear it if that PID is still running. That prevents two overlapping
-  daemon instances from erasing each other's in-flight guard.
+  5.3.0-rc4 onward the flag records the owning PID plus Linux process
+  start identity when available, and startup refuses to clear it if that
+  same process is still running. That prevents two overlapping daemon
+  instances from erasing each other's in-flight guard without confusing a
+  stale flag with a reused PID.
 - Cleared on **quorum recovery** so the next quorum loss can fire its own
   shutdown without waiting for a daemon restart. Look for `quorum restored
   -- re-armed for next event` in the log.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -111,7 +111,7 @@ The scenario files simulate online, on-battery, low-battery, FSD, brownout, over
 
 ### E2E test inventory
 
-The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 37 numbered tests, two redundancy runtime regression cases, plus one CLI completion smoke check.
+The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 38 numbered tests, two redundancy runtime regression cases, plus one CLI completion smoke check.
 
 | Test | Group | What it proves |
 |------|-------|----------------|
@@ -154,6 +154,7 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 37 numb
 | 35 | Stats | Single-UPS restart lifecycle sends one restart notification instead of stop/start noise |
 | 36 | UPS Multi | Multi-UPS coordinator applies the same single-restart-notification contract across per-UPS stores |
 | 37 | Redundancy | Two consecutive quorum-loss events both fire shutdown — proves the daemon-managed flag-file lifecycle (issue #4) |
+| 38 | Redundancy | A stale redundancy flag from a prior daemon start is cleared before quorum-loss shutdown |
 | E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |
 
 Every commit on the protected workflow has to prove the daemon works against real services, not just isolated Python assertions: real NUT sockets, Dockerized SSH targets, a live SQLite database, rendered TUI output, validated production-shaped configs, and a full shutdown orchestration run. None of it depends on local developer state.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,7 +171,7 @@ For a controlled test:
 
 ## Clear stale shutdown flags
 
-Eneru writes shutdown flag files so an interrupted process does not run the same sequence repeatedly. After a killed dry-run test, a flag can remain.
+Eneru writes shutdown flag files so an interrupted process does not run the same sequence repeatedly. Recent versions clear stale flags automatically at startup and after recovery, but manual cleanup is still useful when investigating an interrupted test.
 
 Single UPS flag:
 
@@ -216,9 +216,9 @@ Check these in order:
 |-------|-------------|
 | Quorum still holds | With `min_healthy: 1`, one healthy member keeps a two-UPS group online |
 | DEGRADED counts healthy | Default `degraded_counts_as: healthy` means on-battery warning state may still satisfy quorum |
-| Advisory trigger missing | Per-UPS thresholds may not have crossed yet |
+| Advisory trigger missing | Per-UPS or redundancy-group thresholds may not have crossed yet |
 | Unknown policy | Default `unknown_counts_as: critical`; custom policy may be more tolerant |
-| Stale flag | `/var/run/ups-shutdown-redundancy-*` may remain after killed tests |
+| Stale flag | Recent versions clear restart-stale redundancy flags automatically; an active PID-owned flag blocks startup instead of being ignored |
 | Wrong source name | `ups_sources` must exactly match `ups[].name` |
 
 Run validation to catch source and ownership errors:

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -492,6 +492,8 @@ statistics:
 #     # At most one group across the whole config may set is_local: true.
 #     is_local: false
 #     # Optional per-group triggers; inherits from top-level `triggers:` if omitted.
+#     # `depletion.window` is computed by each UPS monitor, so set it globally
+#     # or under `ups[*].triggers`, not here.
 #     # triggers:
 #     #   low_battery_threshold: 20
 #     #   critical_runtime_threshold: 600

--- a/src/eneru/AGENTS.md
+++ b/src/eneru/AGENTS.md
@@ -1,9 +1,9 @@
 # `src/eneru/` — package layout for agents
 
 This file gives session-local context when working inside the Eneru package.
-The root `/root/Workspace/Eneru/AGENTS.md` still applies — this one is **just
-the module map and the mixin pattern**, so a session can navigate without
-loading whole files first.
+The root `/root/Workspace/Eneru/AGENTS.md` still applies — including git,
+test, and AI-review workflow rules. This file is **just the module map and the
+mixin pattern**, so a session can navigate without loading whole files first.
 
 ## Module map
 

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -18,6 +18,10 @@ except ImportError:
     apprise = None
 
 
+class ConfigValidationLoadError(Exception):
+    """Raised when raw YAML cannot be loaded for startup validation."""
+
+
 def _non_negative_int(value: str) -> int:
     """argparse type for ``--length``: int >= 0 (0 = no cap)."""
     try:
@@ -38,12 +42,53 @@ def _load_config(args):
     return ConfigLoader.load(getattr(args, 'config', None))
 
 
+def _load_raw_config_for_validation(args):
+    """Load the YAML mapping used for unknown-key validation."""
+    config_path = getattr(args, 'config', None)
+    path = Path(config_path) if config_path else None
+    if path is None:
+        for candidate in ConfigLoader.DEFAULT_CONFIG_PATHS:
+            if candidate.exists():
+                path = candidate
+                break
+    if path is None or not path.exists():
+        return None
+    try:
+        import yaml
+        with open(path, 'r') as f:
+            return yaml.safe_load(f) or {}
+    except Exception as exc:
+        raise ConfigValidationLoadError(
+            f"ERROR: Failed to parse {path} for validation: {exc}"
+        ) from exc
+
+
+def _exit_on_config_errors(config, args):
+    """Prevent daemon startup when validation reports hard errors."""
+    try:
+        raw_data = _load_raw_config_for_validation(args)
+    except ConfigValidationLoadError as exc:
+        print(exc)
+        sys.exit(1)
+    messages = ConfigLoader.validate_config(
+        config, raw_data=raw_data,
+    )
+    errors = [m for m in messages if m.startswith("ERROR:")]
+    if not errors:
+        return
+    for msg in errors:
+        print(msg)
+    sys.exit(1)
+
+
 def _cmd_run(args):
     """Start the monitoring daemon."""
     config = _load_config(args)
 
     if args.dry_run:
         config.behavior.dry_run = True
+
+    _exit_on_config_errors(config, args)
 
     if config.multi_ups or config.redundancy_groups:
         coordinator = MultiUPSCoordinator(config, exit_after_shutdown=args.exit_after_shutdown)
@@ -217,23 +262,15 @@ def _cmd_validate(args):
     else:
         print(f"    Disabled")
 
-    # Run validation checks (pass raw YAML data for top-level resource warnings).
-    # Re-parse for both single-UPS and multi-UPS configs so the top-level
-    # warnings reach single-UPS users too. ConfigLoader.load already
-    # handles missing files gracefully and warned the user; only the
-    # "file exists but YAML is malformed" branch must surface the error
-    # here so it isn't silently swallowed.
+    # Re-parse the raw YAML so validation can catch misspelled safety keys
+    # that ConfigLoader intentionally ignores while building dataclasses.
     raw_data = None
-    if args.config and Path(args.config).exists():
-        try:
-            import yaml
-            with open(args.config, 'r') as f:
-                raw_data = yaml.safe_load(f) or {}
-        except Exception as exc:
-            print()
-            print(f"  ERROR: Failed to re-parse {args.config} for top-level "
-                  f"validation: {exc}")
-            exit_code = 1
+    try:
+        raw_data = _load_raw_config_for_validation(args)
+    except ConfigValidationLoadError as exc:
+        print()
+        print(f"  {exc}")
+        exit_code = 1
     messages = ConfigLoader.validate_config(config, raw_data=raw_data)
     if messages:
         print()

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -56,8 +56,17 @@ def _load_raw_config_for_validation(args):
     try:
         import yaml
         with open(path, 'r') as f:
-            return yaml.safe_load(f) or {}
+            raw_data = yaml.safe_load(f)
+        if raw_data is None:
+            return {}
+        if not isinstance(raw_data, dict):
+            raise ConfigValidationLoadError(
+                f"ERROR: Config root in {path} must be a YAML mapping."
+            )
+        return raw_data
     except Exception as exc:
+        if isinstance(exc, ConfigValidationLoadError):
+            raise
         raise ConfigValidationLoadError(
             f"ERROR: Failed to parse {path} for validation: {exc}"
         ) from exc

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -470,7 +470,15 @@ class ConfigLoader:
         # Load YAML
         try:
             with open(path, 'r') as f:
-                data = yaml.safe_load(f) or {}
+                raw_data = yaml.safe_load(f)
+            if raw_data is None:
+                data = {}
+            elif isinstance(raw_data, dict):
+                data = raw_data
+            else:
+                print(f"Error reading config file {path}: root must be a YAML mapping.")
+                print("Using default configuration.")
+                return config
         except Exception as e:
             print(f"Error reading config file {path}: {e}")
             print("Using default configuration.")

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1,6 +1,7 @@
 """Configuration classes and loader for Eneru."""
 
 from dataclasses import dataclass, field
+from difflib import get_close_matches
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -417,6 +418,26 @@ class ConfigLoader:
         Path("/etc/ups-monitor/config.yaml"),
         Path("/etc/ups-monitor/config.yml"),
     ]
+
+    @staticmethod
+    def _unknown_key_errors(section: str, data: Any,
+                            allowed: set) -> List[str]:
+        """Return ERROR lines for unknown YAML keys in one mapping.
+
+        Deprecated-but-supported aliases are included in ``allowed`` by the
+        caller. Everything else is a hard error because misspelled safety
+        settings should never be silently ignored.
+        """
+        if not isinstance(data, dict):
+            return []
+        errors = []
+        for key in sorted(data):
+            if key in allowed:
+                continue
+            suggestion = get_close_matches(str(key), sorted(allowed), n=1)
+            hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+            errors.append(f"ERROR: unknown config key '{section}.{key}'.{hint}")
+        return errors
 
     @classmethod
     def load(cls, config_path: Optional[str] = None) -> Config:
@@ -978,6 +999,69 @@ class ConfigLoader:
         from eneru.notifications import APPRISE_AVAILABLE
 
         messages = []
+
+        if raw_data:
+            trigger_keys = {
+                "low_battery_threshold", "critical_runtime_threshold",
+                "depletion", "extended_time", "voltage_sensitivity",
+            }
+            depletion_keys = {"window", "critical_rate", "grace_period"}
+            extended_time_keys = {"enabled", "threshold"}
+            messages.extend(cls._unknown_key_errors(
+                "behavior", raw_data.get("behavior", {}), {"dry_run"},
+            ))
+
+            def _validate_triggers(section: str, data: Any):
+                if not isinstance(data, dict):
+                    return
+                messages.extend(cls._unknown_key_errors(section, data, trigger_keys))
+                messages.extend(cls._unknown_key_errors(
+                    f"{section}.depletion",
+                    data.get("depletion", {}),
+                    depletion_keys,
+                ))
+                messages.extend(cls._unknown_key_errors(
+                    f"{section}.extended_time",
+                    data.get("extended_time", {}),
+                    extended_time_keys,
+                ))
+
+            _validate_triggers("triggers", raw_data.get("triggers", {}))
+            ups_raw = raw_data.get("ups")
+            if isinstance(ups_raw, list):
+                for idx, entry in enumerate(ups_raw):
+                    if not isinstance(entry, dict):
+                        continue
+                    label = entry.get("name", idx)
+                    _validate_triggers(
+                        f"ups[{label!r}].triggers",
+                        entry.get("triggers", {}),
+                    )
+            groups_raw = raw_data.get("redundancy_groups", []) or []
+            if isinstance(groups_raw, list):
+                for idx, entry in enumerate(groups_raw):
+                    if not isinstance(entry, dict):
+                        continue
+                    label = entry.get("name", idx)
+                    group_triggers = entry.get("triggers", {})
+                    _validate_triggers(
+                        f"redundancy_groups[{label!r}].triggers",
+                        group_triggers,
+                    )
+                    depletion = (
+                        group_triggers.get("depletion", {})
+                        if isinstance(group_triggers, dict)
+                        else {}
+                    )
+                    if isinstance(depletion, dict) and "window" in depletion:
+                        messages.append(
+                            "ERROR: "
+                            f"redundancy_groups[{label!r}].triggers."
+                            "depletion.window is not supported; depletion "
+                            "rate history is computed by each UPS monitor. "
+                            "Set triggers.depletion.window globally or on "
+                            "ups[*].triggers instead."
+                        )
 
         # Check Apprise availability
         if config.notifications.enabled and not APPRISE_AVAILABLE:

--- a/src/eneru/health_model.py
+++ b/src/eneru/health_model.py
@@ -73,9 +73,10 @@ def assess_health(
 
     Args:
         snapshot: ``HealthSnapshot`` from ``MonitorState.snapshot()``.
-        triggers: ``TriggersConfig`` for the member UPS. Reserved for
-            future extensions; the monitor itself owns threshold
-            evaluation, so the evaluator trusts ``snapshot.trigger_active``.
+        triggers: ``TriggersConfig`` for the evaluator's policy layer.
+            Per-UPS monitors still publish ``snapshot.trigger_active``, but
+            redundancy groups may override thresholds without mutating the
+            member monitor's own config.
         check_interval: The member's ``ups.check_interval`` in seconds.
             Used to compute the stale-snapshot threshold.
         max_stale_data_tolerance: Consecutive stale polls tolerated before
@@ -88,8 +89,6 @@ def assess_health(
             in seconds.
         now: Optional ``time.time()`` override -- only used by tests.
     """
-    del triggers  # Reserved for future use.
-
     current_time = now if now is not None else time.time()
     interval = max(1, int(check_interval) if check_interval else 1)
 
@@ -159,6 +158,43 @@ def assess_health(
     # 2. CRITICAL
     if snapshot.trigger_active:
         return UPSHealth.CRITICAL
+    # Group-local thresholds mirror monitor.py's T1-T4 checks, which run
+    # inside the on-battery handler. A recovering OL UPS may still have low
+    # charge; that should not by itself exhaust redundancy quorum.
+    if triggers is not None and "OB" in snapshot.status:
+        try:
+            battery = int(float(snapshot.battery_charge))
+        except (TypeError, ValueError):
+            battery = None
+        try:
+            runtime = int(float(snapshot.runtime))
+        except (TypeError, ValueError):
+            runtime = None
+        if (
+            battery is not None
+            and battery < getattr(triggers, "low_battery_threshold", 20)
+        ):
+            return UPSHealth.CRITICAL
+        if (
+            runtime is not None
+            and runtime < getattr(triggers, "critical_runtime_threshold", 600)
+        ):
+            return UPSHealth.CRITICAL
+        depletion = getattr(triggers, "depletion", None)
+        if depletion is not None:
+            rate = getattr(snapshot, "depletion_rate", 0.0) or 0.0
+            if (
+                rate > getattr(depletion, "critical_rate", 15.0)
+                and snapshot.time_on_battery >= getattr(depletion, "grace_period", 90)
+            ):
+                return UPSHealth.CRITICAL
+        extended_time = getattr(triggers, "extended_time", None)
+        if (
+            extended_time is not None
+            and getattr(extended_time, "enabled", True)
+            and snapshot.time_on_battery > getattr(extended_time, "threshold", 900)
+        ):
+            return UPSHealth.CRITICAL
     if "FSD" in snapshot.status:
         return UPSHealth.CRITICAL
 

--- a/src/eneru/health_model.py
+++ b/src/eneru/health_model.py
@@ -16,6 +16,9 @@ import time
 from enum import Enum
 from typing import Optional
 
+from eneru.config import TriggersConfig
+from eneru.state import HealthSnapshot
+
 
 class UPSHealth(str, Enum):
     """Per-UPS contribution to a redundancy group's quorum count.
@@ -42,8 +45,8 @@ STALE_RETRY_TOLERANCE_MULTIPLIER = 5
 
 
 def assess_health(
-    snapshot,
-    triggers=None,
+    snapshot: HealthSnapshot,
+    triggers: Optional[TriggersConfig] = None,
     check_interval: int = 1,
     *,
     max_stale_data_tolerance: int = 3,

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -308,7 +308,14 @@ class MultiUPSCoordinator:
                 # lifecycle. Clear any stale flag from a prior daemon
                 # instance so the executor starts from a known-clean
                 # state. Mirrors the per-UPS unlink at line 95 above.
-                executor.clear_shutdown_state()
+                try:
+                    executor.clear_shutdown_state(refuse_active_peer=True)
+                except Exception as e:
+                    self._log(
+                        f"❌ FATAL ERROR: Cannot clear redundancy shutdown flag "
+                        f"for '{rg.name}' at startup: {e}"
+                    )
+                    sys.exit(1)
                 self._redundancy_executors[rg.name] = executor
                 evaluator = RedundancyGroupEvaluator(
                     rg,

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -16,6 +16,7 @@ executor idempotent; the in-memory ``_lock`` + ``_shutdown_done`` pair
 catches concurrent calls inside one process.
 """
 
+import os
 import threading
 import time
 from pathlib import Path
@@ -169,7 +170,50 @@ class RedundancyGroupExecutor(
 
     # ----- public API -----
 
-    def clear_shutdown_state(self) -> None:
+    def _read_shutdown_flag_pid(self) -> Optional[int]:
+        """Return the PID recorded in the flag file, if it has one."""
+        try:
+            content = self._shutdown_flag_path.read_text()
+        except FileNotFoundError:
+            return None
+        for line in content.splitlines():
+            if line.startswith("pid="):
+                try:
+                    return int(line.split("=", 1)[1])
+                except ValueError:
+                    return None
+        return None
+
+    def _pid_is_running(self, pid: int) -> bool:
+        """Best-effort liveness check for a PID from the shutdown flag."""
+        if pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # A process exists but we cannot signal it. Treat as active.
+            return True
+        return True
+
+    def _verify_shutdown_flag_access(self) -> None:
+        """Prove startup can create and remove flag files in the target dir."""
+        probe = self._shutdown_flag_path.with_name(
+            f".{self._shutdown_flag_path.name}.startup-check.{os.getpid()}"
+        )
+        fd = None
+        try:
+            # Startup must fail fast if /var/run (or the configured flag
+            # directory) is not writable. Otherwise the first real quorum loss
+            # would discover that the cross-process guard cannot be acquired.
+            fd = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        finally:
+            if fd is not None:
+                os.close(fd)
+            probe.unlink(missing_ok=True)
+
+    def clear_shutdown_state(self, *, refuse_active_peer: bool = False) -> None:
         """Reset the in-process and on-disk re-entry guards.
 
         5.3.0 contract: the daemon owns the redundancy flag's lifecycle.
@@ -186,8 +230,17 @@ class RedundancyGroupExecutor(
         a torn pair.
         """
         with self._lock:
+            if refuse_active_peer and self._shutdown_flag_path.exists():
+                pid = self._read_shutdown_flag_pid()
+                if pid is not None and pid != os.getpid() and self._pid_is_running(pid):
+                    raise RuntimeError(
+                        f"active redundancy shutdown flag {self._shutdown_flag_path} "
+                        f"is owned by running PID {pid}"
+                    )
             self._shutdown_done = False
             self._shutdown_flag_path.unlink(missing_ok=True)
+            if refuse_active_peer:
+                self._verify_shutdown_flag_access()
 
     def shutdown(self, reason: str) -> bool:
         """Run the redundancy group's shutdown sequence (idempotent).
@@ -208,12 +261,17 @@ class RedundancyGroupExecutor(
             # TOCTOU window: two daemons (operator mistake, systemd
             # restart race, container test rig) could both see the flag
             # missing and both enter the shutdown path before either
-            # marked it. ``touch(exist_ok=False)`` collapses check +
-            # create into one ``open(O_CREAT|O_EXCL)`` syscall so the
-            # filesystem itself arbitrates. self._lock still covers
-            # intra-process atomicity for ``_shutdown_done``.
+            # marked it. ``os.open(... O_CREAT|O_EXCL)`` collapses
+            # check + create into one syscall, while the PID payload lets
+            # startup distinguish stale flags from a still-running peer.
             try:
-                self._shutdown_flag_path.touch(exist_ok=False)
+                fd = os.open(
+                    self._shutdown_flag_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o644,
+                )
+                with os.fdopen(fd, "w") as f:
+                    f.write(f"pid={os.getpid()}\ncreated_at={time.time():.3f}\n")
             except FileExistsError:
                 # 5.3.0: should never happen on a healthy install --
                 # startup cleanup unconditionally removes any stale flag.
@@ -390,10 +448,12 @@ class RedundancyGroupEvaluator(threading.Thread):
                     monitor.config.ups.max_stale_data_tolerance
                 )
                 grace_cfg = monitor.config.ups.connection_loss_grace_period
-                triggers = monitor.config.triggers
                 raw = assess_health(
                     snap,
-                    triggers,
+                    # Redundancy groups own their own trigger policy. Do not
+                    # reuse the member monitor's triggers here: the same UPS
+                    # may belong to multiple groups with different thresholds.
+                    self._group.triggers,
                     check_interval,
                     max_stale_data_tolerance=max_stale_data_tolerance,
                     connection_grace_enabled=grace_cfg.enabled,

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -170,31 +170,88 @@ class RedundancyGroupExecutor(
 
     # ----- public API -----
 
-    def _read_shutdown_flag_pid(self) -> Optional[int]:
-        """Return the PID recorded in the flag file, if it has one."""
+    @staticmethod
+    def _read_proc_start_time(pid: int) -> Optional[str]:
+        """Return Linux /proc starttime for PID reuse detection, if available."""
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text()
+        except (FileNotFoundError, OSError, PermissionError):
+            return None
+        fields = stat.rsplit(") ", 1)[-1].split()
+        # proc_pid_stat(5): starttime is field 22, which is index 19 after
+        # removing pid + comm. It stays stable for one process lifetime.
+        if len(fields) <= 19:
+            return None
+        return fields[19]
+
+    @staticmethod
+    def _read_boot_id() -> Optional[str]:
+        """Return the Linux boot ID, if available."""
+        try:
+            return Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+        except (FileNotFoundError, OSError, PermissionError):
+            return None
+
+    def _current_owner_identity(self) -> Dict[str, str]:
+        """Build the flag owner identity for this daemon process."""
+        pid = os.getpid()
+        owner = {"pid": str(pid)}
+        start_time = self._read_proc_start_time(pid)
+        boot_id = self._read_boot_id()
+        if start_time is not None:
+            owner["start_time"] = start_time
+        if boot_id is not None:
+            owner["boot_id"] = boot_id
+        return owner
+
+    def _read_shutdown_flag_owner(self) -> Dict[str, str]:
+        """Return owner metadata recorded in the flag file."""
         try:
             content = self._shutdown_flag_path.read_text()
         except FileNotFoundError:
-            return None
+            return {}
+        owner = {}
         for line in content.splitlines():
-            if line.startswith("pid="):
-                try:
-                    return int(line.split("=", 1)[1])
-                except ValueError:
-                    return None
-        return None
+            if "=" in line:
+                key, value = line.split("=", 1)
+                owner[key] = value
+        return owner
 
-    def _pid_is_running(self, pid: int) -> bool:
-        """Best-effort liveness check for a PID from the shutdown flag."""
+    def _read_shutdown_flag_pid(self) -> Optional[int]:
+        """Return the PID recorded in the flag file, if it has one."""
+        try:
+            return int(self._read_shutdown_flag_owner().get("pid", ""))
+        except ValueError:
+            return None
+
+    def _pid_is_running(
+        self,
+        pid: int,
+        *,
+        start_time: Optional[str] = None,
+        boot_id: Optional[str] = None,
+    ) -> bool:
+        """Best-effort liveness check for a flag owner identity."""
         if pid <= 0:
             return False
+        if boot_id is not None:
+            current_boot_id = self._read_boot_id()
+            if current_boot_id is not None and current_boot_id != boot_id:
+                return False
         try:
             os.kill(pid, 0)
         except ProcessLookupError:
             return False
         except PermissionError:
             # A process exists but we cannot signal it. Treat as active.
-            return True
+            pass
+        if start_time is not None:
+            current_start_time = self._read_proc_start_time(pid)
+            if (
+                current_start_time is not None
+                and current_start_time != start_time
+            ):
+                return False
         return True
 
     def _verify_shutdown_flag_access(self) -> None:
@@ -231,8 +288,20 @@ class RedundancyGroupExecutor(
         """
         with self._lock:
             if refuse_active_peer and self._shutdown_flag_path.exists():
-                pid = self._read_shutdown_flag_pid()
-                if pid is not None and pid != os.getpid() and self._pid_is_running(pid):
+                owner = self._read_shutdown_flag_owner()
+                try:
+                    pid = int(owner.get("pid", ""))
+                except ValueError:
+                    pid = None
+                if (
+                    pid is not None
+                    and pid != os.getpid()
+                    and self._pid_is_running(
+                        pid,
+                        start_time=owner.get("start_time"),
+                        boot_id=owner.get("boot_id"),
+                    )
+                ):
                     raise RuntimeError(
                         f"active redundancy shutdown flag {self._shutdown_flag_path} "
                         f"is owned by running PID {pid}"
@@ -271,7 +340,9 @@ class RedundancyGroupExecutor(
                     0o644,
                 )
                 with os.fdopen(fd, "w") as f:
-                    f.write(f"pid={os.getpid()}\ncreated_at={time.time():.3f}\n")
+                    for key, value in self._current_owner_identity().items():
+                        f.write(f"{key}={value}\n")
+                    f.write(f"created_at={time.time():.3f}\n")
             except FileExistsError:
                 # 5.3.0: should never happen on a healthy install --
                 # startup cleanup unconditionally removes any stale flag.

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.3.0-rc3"
+__version__ = "5.3.0-rc4"

--- a/tests/e2e/groups/redundancy.sh
+++ b/tests/e2e/groups/redundancy.sh
@@ -17,7 +17,8 @@
 # graceful exit each clear it -- so those rm lines became redundant
 # and were removed. With them gone, every existing test doubles as a
 # regression catch for the startup-cleanup contract; Test 37 below
-# is the explicit fire->recover->fire-again scenario. Do NOT add the
+# is the explicit fire->recover->fire-again scenario, and Test 38
+# pre-creates a restart-stale flag before daemon startup. Do NOT add the
 # rm lines back without first confirming the contract is intentionally
 # being inverted.
 
@@ -442,6 +443,47 @@ cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS1.dev
 cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
 sleep 2
 echo "PASS: redundancy re-arm verified across two consecutive quorum-loss events"
+)
+
+# ======================================================================
+# Test 38: Stale redundancy flag from prior daemon restart is cleared
+# ======================================================================
+(
+echo ""
+echo ">>> Running: Test 38: Stale redundancy flag across restart is cleared"
+
+echo "=== Test 38: stale flag restart ==="
+
+# Pre-5.3.0/rc4 regression: a stale flag from a prior daemon instance
+# suppressed the executor before it could log REDUNDANCY GROUP SHUTDOWN.
+# This uses the real redundancy flag path derived from
+# logging.shutdown_flag_file's parent plus the group name.
+printf "stale-pre-rc4-flag\n" > /tmp/ups-shutdown-redundancy-rack-1-dual-psu
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/low-battery.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 3
+
+timeout 30s eneru run --config $E2E_DIR/config-e2e-redundancy.yaml --exit-after-shutdown \
+  > /tmp/test38.log 2>&1 || true
+
+if ! grep -q "REDUNDANCY GROUP SHUTDOWN: rack-1-dual-psu" /tmp/test38.log; then
+  echo "FAIL: stale restart flag blocked redundancy shutdown"
+  echo "----- /tmp/test38.log (full) -----"
+  cat /tmp/test38.log
+  echo "----- /tmp/test38.log end -----"
+  exit 1
+fi
+if grep -q "suppressed: flag .* startup cleanup bypassed" /tmp/test38.log; then
+  echo "FAIL: stale flag suppression warning fired after startup cleanup"
+  cat /tmp/test38.log
+  exit 1
+fi
+
+# Restore for downstream tests
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS1.dev
+cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply-UPS2.dev
+sleep 2
+echo "PASS: stale restart flag was cleared before redundancy shutdown"
 )
 
 # ======================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -724,6 +724,16 @@ behavior:
         assert "must be a YAML mapping" in capsys.readouterr().out
 
     @pytest.mark.unit
+    def test_raw_config_validation_loads_empty_yaml_as_empty_mapping(self, tmp_path):
+        from eneru.cli import _load_raw_config_for_validation
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("")
+        args = type("Args", (), {"config": str(config_file)})()
+
+        assert _load_raw_config_for_validation(args) == {}
+
+    @pytest.mark.unit
     def test_validate_checks_unknown_keys_from_default_config_path(
         self, tmp_path, capsys
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -709,6 +709,21 @@ behavior:
         assert "Failed to parse" in capsys.readouterr().out
 
     @pytest.mark.unit
+    def test_run_refuses_non_mapping_yaml_root(self, tmp_path, capsys):
+        """A YAML list root is not a valid Eneru config document."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("- just\n- a\n- list\n")
+
+        with patch.object(sys, "argv", ["eneru", "run", "-c", str(config_file)]):
+            with patch("eneru.cli.UPSGroupMonitor") as mock_monitor:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 1
+        mock_monitor.assert_not_called()
+        assert "must be a YAML mapping" in capsys.readouterr().out
+
+    @pytest.mark.unit
     def test_validate_checks_unknown_keys_from_default_config_path(
         self, tmp_path, capsys
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -670,6 +670,67 @@ behavior:
         config.behavior.dry_run = True
         assert config.behavior.dry_run is True
 
+    @pytest.mark.unit
+    def test_run_refuses_unknown_safety_config_key(self, tmp_path, capsys):
+        """The daemon must not start when validation finds hard errors."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+ups:
+  name: "TestUPS@localhost"
+
+behavior:
+  dry-run: true
+""")
+
+        with patch.object(sys, "argv", ["eneru", "run", "-c", str(config_file)]):
+            with patch("eneru.cli.UPSGroupMonitor") as mock_monitor:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 1
+        mock_monitor.assert_not_called()
+        captured = capsys.readouterr()
+        assert "behavior.dry-run" in captured.out
+        assert "Did you mean 'dry_run'" in captured.out
+
+    @pytest.mark.unit
+    def test_run_refuses_malformed_yaml(self, tmp_path, capsys):
+        """Malformed YAML must not fall through to daemon startup defaults."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("ups: [broken\n")
+
+        with patch.object(sys, "argv", ["eneru", "run", "-c", str(config_file)]):
+            with patch("eneru.cli.UPSGroupMonitor") as mock_monitor:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 1
+        mock_monitor.assert_not_called()
+        assert "Failed to parse" in capsys.readouterr().out
+
+    @pytest.mark.unit
+    def test_validate_checks_unknown_keys_from_default_config_path(
+        self, tmp_path, capsys
+    ):
+        """`eneru validate` without -c still validates the loaded YAML."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+ups:
+  name: "TestUPS@localhost"
+
+behavior:
+  dry-run: true
+""")
+
+        with patch.object(ConfigLoader, "DEFAULT_CONFIG_PATHS", [config_file]):
+            with patch.object(sys, "argv", ["eneru", "validate"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "behavior.dry-run" in captured.out
+
 
 class TestCLIExitAfterShutdown:
     """Test --exit-after-shutdown CLI flag on run subcommand."""

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -172,6 +172,14 @@ local_shutdown:
         config = ConfigLoader.load(str(temp_config_file))
         assert config.ups.name == "UPS@localhost"
 
+    @pytest.mark.unit
+    def test_load_non_mapping_yaml_root_returns_defaults(self, temp_config_file, capsys):
+        """A YAML list root is invalid and should not reach config parsing."""
+        temp_config_file.write_text("- not\n- a\n- mapping\n")
+        config = ConfigLoader.load(str(temp_config_file))
+        assert config.ups.name == "UPS@localhost"
+        assert "root must be a YAML mapping" in capsys.readouterr().out
+
 
 class TestRedundancyGroupLoading:
     """Tests for the redundancy_groups YAML section."""
@@ -377,5 +385,4 @@ redundancy_groups:
         assert config.redundancy_groups[0].name == "12345"
         assert all(isinstance(s, str)
                    for s in config.redundancy_groups[0].ups_sources)
-
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -86,6 +86,85 @@ class TestConfigValidation:
             assert not any("trigger_on" in m for m in messages)
 
 
+class TestUnknownKeyValidation:
+    """Unknown safety keys are hard errors, with legacy aliases preserved."""
+
+    def _errors(self, raw_data):
+        config = ConfigLoader._parse_config(raw_data)
+        return [
+            m for m in ConfigLoader.validate_config(config, raw_data)
+            if m.startswith("ERROR:")
+        ]
+
+    @pytest.mark.unit
+    def test_behavior_dry_run_typo_is_error_with_hint(self):
+        errors = self._errors({
+            "ups": {"name": "UPS@localhost"},
+            "behavior": {"dry-run": True},
+        })
+        assert any("behavior.dry-run" in e for e in errors)
+        assert any("Did you mean 'dry_run'" in e for e in errors)
+
+    @pytest.mark.unit
+    def test_top_level_extended_time_typo_is_error_with_hint(self):
+        errors = self._errors({
+            "ups": {"name": "UPS@localhost"},
+            "triggers": {"exteneded_time": {"enabled": True}},
+        })
+        assert any("triggers.exteneded_time" in e for e in errors)
+        assert any("Did you mean 'extended_time'" in e for e in errors)
+
+    @pytest.mark.unit
+    def test_redundancy_group_trigger_typo_is_error(self):
+        errors = self._errors({
+            "ups": [{"name": "UPS-A"}, {"name": "UPS-B"}],
+            "redundancy_groups": [{
+                "name": "rack",
+                "ups_sources": ["UPS-A", "UPS-B"],
+                "triggers": {"critical_runtme_threshold": 1200},
+            }],
+        })
+        assert any("redundancy_groups['rack'].triggers" in e for e in errors)
+        assert any("critical_runtime_threshold" in e for e in errors)
+
+    @pytest.mark.unit
+    def test_multi_ups_trigger_typo_is_error(self):
+        errors = self._errors({
+            "ups": [{
+                "name": "UPS-A",
+                "triggers": {"exteneded_time": {"enabled": True}},
+            }],
+        })
+        assert any("ups['UPS-A'].triggers.exteneded_time" in e for e in errors)
+        assert any("Did you mean 'extended_time'" in e for e in errors)
+
+    @pytest.mark.unit
+    def test_redundancy_group_depletion_window_is_error(self):
+        errors = self._errors({
+            "ups": [{"name": "UPS-A"}, {"name": "UPS-B"}],
+            "redundancy_groups": [{
+                "name": "rack",
+                "ups_sources": ["UPS-A", "UPS-B"],
+                "triggers": {"depletion": {"window": 60}},
+            }],
+        })
+        assert any("redundancy_groups['rack'].triggers.depletion.window" in e
+                   for e in errors)
+
+    @pytest.mark.unit
+    def test_legacy_docker_and_discord_configs_are_not_unknown_key_errors(self):
+        raw_data = {
+            "ups": {"name": "UPS@localhost"},
+            "docker": {"enabled": True},
+            "discord": {"webhook_url": "https://discord.com/api/webhooks/1/a"},
+            "notifications": {
+                "discord": {"webhook_url": "https://discord.com/api/webhooks/2/b"},
+            },
+        }
+        errors = self._errors(raw_data)
+        assert not any("unknown config key" in e for e in errors)
+
+
 class TestNotificationsSuppressValidation:
     """Issue #27 / B3: per-event notification suppression with safety blocklist."""
 
@@ -966,5 +1045,3 @@ redundancy_groups:
         """Configs with no ``redundancy_groups`` section never reference them."""
         msgs = ConfigLoader.validate_config(default_config)
         assert not any("redundancy" in m.lower() for m in msgs)
-
-

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -153,6 +153,25 @@ class TestUnknownKeyValidation:
                    for e in errors)
 
     @pytest.mark.unit
+    def test_non_mapping_trigger_sections_are_ignored(self, default_config):
+        raw_data = {
+            "ups": [
+                {"name": "UPS-A", "triggers": []},
+                "not-a-mapping",
+            ],
+            "triggers": [],
+            "redundancy_groups": [
+                "not-a-mapping",
+                {"name": "rack", "triggers": []},
+            ],
+        }
+        errors = [
+            m for m in ConfigLoader.validate_config(default_config, raw_data)
+            if m.startswith("ERROR:")
+        ]
+        assert not any("unknown config key" in e for e in errors)
+
+    @pytest.mark.unit
     def test_legacy_docker_and_discord_configs_are_not_unknown_key_errors(self):
         raw_data = {
             "ups": {"name": "UPS@localhost"},

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -3,6 +3,7 @@
 import pytest
 import yaml
 from pathlib import Path
+from typing import Any, Mapping
 
 from eneru import (
     Config,
@@ -89,7 +90,7 @@ class TestConfigValidation:
 class TestUnknownKeyValidation:
     """Unknown safety keys are hard errors, with legacy aliases preserved."""
 
-    def _errors(self, raw_data):
+    def _errors(self, raw_data: Mapping[str, Any]) -> list[str]:
         config = ConfigLoader._parse_config(raw_data)
         return [
             m for m in ConfigLoader.validate_config(config, raw_data)

--- a/tests/test_health_model.py
+++ b/tests/test_health_model.py
@@ -4,7 +4,13 @@ import time
 
 import pytest
 
-from eneru import UPSHealth, assess_health
+from eneru import (
+    DepletionConfig,
+    ExtendedTimeConfig,
+    TriggersConfig,
+    UPSHealth,
+    assess_health,
+)
 from eneru.state import HealthSnapshot
 
 
@@ -70,6 +76,92 @@ class TestAssessHealthBasicTiers:
     def test_no_observations_is_unknown(self):
         snap = _snap(last_update_time=0.0)
         assert assess_health(snap, None, 1, now=NOW) == UPSHealth.UNKNOWN
+
+
+class TestAssessHealthGroupTriggers:
+    """Direct coverage for redundancy group-local trigger thresholds."""
+
+    @pytest.mark.unit
+    def test_group_low_battery_threshold_is_critical(self):
+        triggers = TriggersConfig(low_battery_threshold=50)
+        snap = _snap(status="OB", battery_charge="49")
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.CRITICAL
+
+    @pytest.mark.unit
+    def test_group_runtime_threshold_is_critical(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=1,
+            critical_runtime_threshold=1200,
+        )
+        snap = _snap(status="OB", runtime="1199")
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.CRITICAL
+
+    @pytest.mark.unit
+    def test_group_depletion_threshold_after_grace_is_critical(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=1,
+            critical_runtime_threshold=0,
+            depletion=DepletionConfig(critical_rate=10.0, grace_period=30),
+        )
+        snap = _snap(status="OB", depletion_rate=10.1, time_on_battery=30)
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.CRITICAL
+
+    @pytest.mark.unit
+    def test_group_extended_time_threshold_is_critical(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=1,
+            critical_runtime_threshold=0,
+            extended_time=ExtendedTimeConfig(enabled=True, threshold=30),
+        )
+        snap = _snap(status="OB", time_on_battery=31)
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.CRITICAL
+
+    @pytest.mark.unit
+    def test_group_threshold_edges_remain_degraded(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=50,
+            critical_runtime_threshold=1200,
+            depletion=DepletionConfig(critical_rate=10.0, grace_period=30),
+            extended_time=ExtendedTimeConfig(enabled=True, threshold=30),
+        )
+        snap = _snap(
+            status="OB",
+            battery_charge="50",
+            runtime="1200",
+            depletion_rate=10.0,
+            time_on_battery=30,
+        )
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.DEGRADED
+
+    @pytest.mark.unit
+    def test_group_thresholds_ignore_nonnumeric_battery_and_runtime(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=50,
+            critical_runtime_threshold=1200,
+            extended_time=ExtendedTimeConfig(enabled=True, threshold=900),
+        )
+        snap = _snap(status="OB", battery_charge="bad", runtime="bad")
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.DEGRADED
+
+    @pytest.mark.unit
+    def test_group_depletion_waits_for_grace_period(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=1,
+            critical_runtime_threshold=0,
+            depletion=DepletionConfig(critical_rate=10.0, grace_period=30),
+        )
+        snap = _snap(status="OB", depletion_rate=20.0, time_on_battery=29)
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.DEGRADED
+
+    @pytest.mark.unit
+    def test_group_extended_time_can_be_disabled(self):
+        triggers = TriggersConfig(
+            low_battery_threshold=1,
+            critical_runtime_threshold=0,
+            extended_time=ExtendedTimeConfig(enabled=False, threshold=30),
+        )
+        snap = _snap(status="OB", time_on_battery=300)
+        assert assess_health(snap, triggers, 1, now=NOW) == UPSHealth.DEGRADED
 
 
 class TestAssessHealthStaleness:
@@ -236,6 +328,19 @@ class TestAssessHealthStaleness:
         # Defensive: check_interval=0 must not divide-by-zero or be too tight.
         snap = _snap(last_update_time=NOW - 4)
         assert assess_health(snap, None, 0, now=NOW) == UPSHealth.HEALTHY
+
+    @pytest.mark.unit
+    def test_invalid_stale_options_fall_back_to_defaults(self):
+        snap = _snap(last_update_time=NOW - 4)
+        assert assess_health(
+            snap,
+            None,
+            1,
+            max_stale_data_tolerance="bad",
+            connection_grace_enabled=True,
+            connection_grace_duration="bad",
+            now=NOW,
+        ) == UPSHealth.HEALTHY
 
     @pytest.mark.unit
     def test_uses_real_clock_when_now_omitted(self):

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1747,7 +1747,35 @@ class TestCoordinatorRedundancyWiring:
 
         # The executor mock's clear_shutdown_state must have been called
         # exactly once -- before the evaluator started polling.
-        mock_executor_cls.return_value.clear_shutdown_state.assert_called_once()
+        mock_executor_cls.return_value.clear_shutdown_state.assert_called_once_with(
+            refuse_active_peer=True
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("exc", [
+        RuntimeError("active peer"),
+        PermissionError("/var/run/ups-shutdown-redundancy-rack"),
+        OSError("/var/run/ups-shutdown-redundancy-rack"),
+    ])
+    def test_start_monitors_exits_when_redundancy_flag_cannot_be_cleared(
+        self, tmp_path, exc
+    ):
+        """A startup flag-cleanup failure is fatal: running with a
+        possibly active peer would make the re-entry guard untrustworthy."""
+        config = self._config_with_redundancy(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        coord._log = MagicMock()
+
+        with patch("eneru.multi_ups.threading.Thread"), \
+             patch("eneru.multi_ups.UPSGroupMonitor") as mock_monitor_cls, \
+             patch("eneru.multi_ups.RedundancyGroupExecutor") as mock_executor_cls:
+            mock_monitor_cls.return_value = MagicMock()
+            mock_executor_cls.return_value.clear_shutdown_state.side_effect = exc
+            with pytest.raises(SystemExit):
+                coord._start_monitors()
+
+        assert any("FATAL ERROR" in call.args[0]
+                   for call in coord._log.call_args_list)
 
     @pytest.mark.unit
     def test_handle_signal_clears_redundancy_executor_state(self, tmp_path):

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -842,6 +842,16 @@ class TestExecutorShutdown:
         assert not ex._shutdown_flag_path.exists()
 
     @pytest.mark.unit
+    def test_clear_shutdown_state_ignores_invalid_pid_owner(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+        ex._shutdown_flag_path.write_text("pid=not-a-number\n")
+
+        ex.clear_shutdown_state(refuse_active_peer=True)
+
+        assert not ex._shutdown_flag_path.exists()
+
+    @pytest.mark.unit
     def test_clear_shutdown_state_probes_flag_directory_access(self, tmp_path):
         cfg = _base_config(dry_run=False, tmp_path=tmp_path)
         ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
@@ -849,6 +859,81 @@ class TestExecutorShutdown:
         with patch("eneru.redundancy.os.open", side_effect=PermissionError("denied")):
             with pytest.raises(PermissionError, match="denied"):
                 ex.clear_shutdown_state(refuse_active_peer=True)
+
+    @pytest.mark.unit
+    def test_read_shutdown_flag_pid_handles_missing_and_invalid_values(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+
+        assert ex._read_shutdown_flag_pid() is None
+        ex._shutdown_flag_path.write_text("pid=not-a-number\n")
+        assert ex._read_shutdown_flag_pid() is None
+        ex._shutdown_flag_path.write_text("created_at=1\n")
+        assert ex._read_shutdown_flag_pid() is None
+
+    @pytest.mark.unit
+    def test_pid_liveness_handles_missing_process_and_permission(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+
+        assert ex._pid_is_running(0) is False
+        with patch("eneru.redundancy.os.kill", side_effect=ProcessLookupError):
+            assert ex._pid_is_running(_IMPOSSIBLE_PID) is False
+        with patch("eneru.redundancy.os.kill", side_effect=PermissionError):
+            assert ex._pid_is_running(_IMPOSSIBLE_PID) is True
+
+    @pytest.mark.unit
+    def test_pid_liveness_rejects_mismatched_owner_identity(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+
+        with patch("eneru.redundancy.os.kill", return_value=None), \
+             patch.object(ex, "_read_boot_id", return_value="current"):
+            assert ex._pid_is_running(
+                _IMPOSSIBLE_PID, boot_id="previous"
+            ) is False
+
+        with patch("eneru.redundancy.os.kill", return_value=None), \
+             patch.object(ex, "_read_boot_id", return_value="boot"), \
+             patch.object(ex, "_read_proc_start_time", return_value="new"):
+            assert ex._pid_is_running(
+                _IMPOSSIBLE_PID, start_time="old", boot_id="boot"
+            ) is False
+
+    @pytest.mark.unit
+    def test_shutdown_flag_records_owner_identity(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(is_local=False),
+                                     base_config=cfg)
+
+        with patch.object(ex, "_read_proc_start_time", return_value="123"), \
+             patch.object(ex, "_read_boot_id", return_value="boot"):
+            assert ex.shutdown(reason="owner") is True
+
+        content = ex._shutdown_flag_path.read_text()
+        assert f"pid={os.getpid()}" in content
+        assert "start_time=123" in content
+        assert "boot_id=boot" in content
+
+    @pytest.mark.unit
+    def test_owner_identity_omits_unavailable_proc_fields(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+
+        with patch.object(ex, "_read_proc_start_time", return_value=None), \
+             patch.object(ex, "_read_boot_id", return_value=None):
+            assert ex._current_owner_identity() == {"pid": str(os.getpid())}
+
+    @pytest.mark.unit
+    def test_proc_start_time_parser_handles_missing_and_short_stat(self):
+        assert RedundancyGroupExecutor._read_proc_start_time(_IMPOSSIBLE_PID) is None
+        with patch("eneru.redundancy.Path.read_text", return_value="1 (x) S"):
+            assert RedundancyGroupExecutor._read_proc_start_time(os.getpid()) is None
+
+    @pytest.mark.unit
+    def test_boot_id_reader_handles_unavailable_proc(self):
+        with patch("eneru.redundancy.Path.read_text", side_effect=PermissionError):
+            assert RedundancyGroupExecutor._read_boot_id() is None
 
     @pytest.mark.unit
     def test_atomic_flag_acquisition_allows_only_one_executor(self, tmp_path):

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -1,15 +1,17 @@
 """Tests for the redundancy-group evaluator and shutdown executor."""
 
+import os
 import threading
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from eneru import (
     BehaviorConfig,
     Config,
+    ExtendedTimeConfig,
     LocalShutdownConfig,
     LoggingConfig,
     NotificationsConfig,
@@ -17,6 +19,7 @@ from eneru import (
     RedundancyGroupEvaluator,
     RedundancyGroupExecutor,
     RemoteServerConfig,
+    TriggersConfig,
     UPSConfig,
     UPSGroupConfig,
     UPSHealth,
@@ -133,6 +136,52 @@ class TestEvaluatorCounting:
         monitors = {
             "UPS-A": _FakeMonitor("UPS-A", _snap()),
             "UPS-B": _FakeMonitor("UPS-B", _snap()),
+        }
+        ev, executor = self._make_evaluator(group, monitors)
+        healthy, _ = ev.evaluate_once()
+        assert healthy == 2
+        executor.shutdown.assert_not_called()
+
+    @pytest.mark.unit
+    def test_group_specific_extended_time_trigger_drives_quorum(self):
+        """Redundancy-group triggers are evaluated at the group layer.
+
+        This avoids mutating member monitor configs, which matters when
+        one UPS participates in multiple redundancy groups with different
+        trigger thresholds.
+        """
+        group = _redundancy_group(
+            min_healthy=1,
+            triggers=TriggersConfig(
+                extended_time=ExtendedTimeConfig(enabled=True, threshold=30),
+            ),
+        )
+        monitors = {
+            "UPS-A": _FakeMonitor(
+                "UPS-A", _snap(status="OB", time_on_battery=31),
+            ),
+            "UPS-B": _FakeMonitor(
+                "UPS-B", _snap(status="OB", time_on_battery=31),
+            ),
+        }
+        ev, executor = self._make_evaluator(group, monitors)
+        healthy, _ = ev.evaluate_once()
+        assert healthy == 0
+        executor.shutdown.assert_called_once()
+
+    @pytest.mark.unit
+    def test_group_specific_thresholds_do_not_fire_while_online(self):
+        group = _redundancy_group(
+            min_healthy=1,
+            triggers=TriggersConfig(low_battery_threshold=90),
+        )
+        monitors = {
+            "UPS-A": _FakeMonitor(
+                "UPS-A", _snap(status="OL", battery_charge="50"),
+            ),
+            "UPS-B": _FakeMonitor(
+                "UPS-B", _snap(status="OL", battery_charge="50"),
+            ),
         }
         ev, executor = self._make_evaluator(group, monitors)
         healthy, _ = ev.evaluate_once()
@@ -750,6 +799,50 @@ class TestExecutorShutdown:
         ex.clear_shutdown_state()
         assert not ex._shutdown_flag_path.exists()
         assert ex._shutdown_done is False
+
+    @pytest.mark.unit
+    def test_clear_shutdown_state_refuses_running_peer_pid(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+        ex._shutdown_flag_path.write_text("pid=12345\n")
+
+        with patch.object(ex, "_pid_is_running", return_value=True):
+            with pytest.raises(RuntimeError, match="running PID 12345"):
+                ex.clear_shutdown_state(refuse_active_peer=True)
+
+        assert ex._shutdown_flag_path.exists()
+
+    @pytest.mark.unit
+    def test_clear_shutdown_state_removes_stale_peer_pid(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+        ex._shutdown_flag_path.write_text("pid=12345\n")
+
+        with patch.object(ex, "_pid_is_running", return_value=False):
+            ex.clear_shutdown_state(refuse_active_peer=True)
+
+        assert not ex._shutdown_flag_path.exists()
+
+    @pytest.mark.unit
+    def test_clear_shutdown_state_probes_flag_directory_access(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+
+        with patch("eneru.redundancy.os.open", side_effect=PermissionError("denied")):
+            with pytest.raises(PermissionError, match="denied"):
+                ex.clear_shutdown_state(refuse_active_peer=True)
+
+    @pytest.mark.unit
+    def test_atomic_flag_acquisition_allows_only_one_executor(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        group = _redundancy_group(is_local=False)
+        ex_a = RedundancyGroupExecutor(group, base_config=cfg)
+        ex_b = RedundancyGroupExecutor(group, base_config=cfg)
+
+        assert ex_a.shutdown(reason="first") is True
+        assert ex_b.shutdown(reason="second") is False
+        assert ex_b._shutdown_done is True
+        assert f"pid={os.getpid()}" in ex_a._shutdown_flag_path.read_text()
 
     @pytest.mark.unit
     def test_remote_shutdown_called_in_dry_run(self, tmp_path):

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -32,6 +32,9 @@ from eneru.state import HealthSnapshot, MonitorState
 from eneru.health_model import assess_health
 
 
+_IMPOSSIBLE_PID = 999_999_999
+
+
 def _snap(**overrides):
     """Build a fresh ``HealthSnapshot``; ``last_update_time`` defaults to now
     so the evaluator's stale-snapshot rule does not flip these to UNKNOWN."""
@@ -804,10 +807,10 @@ class TestExecutorShutdown:
     def test_clear_shutdown_state_refuses_running_peer_pid(self, tmp_path):
         cfg = _base_config(dry_run=False, tmp_path=tmp_path)
         ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
-        ex._shutdown_flag_path.write_text("pid=12345\n")
+        ex._shutdown_flag_path.write_text(f"pid={_IMPOSSIBLE_PID}\n")
 
         with patch.object(ex, "_pid_is_running", return_value=True):
-            with pytest.raises(RuntimeError, match="running PID 12345"):
+            with pytest.raises(RuntimeError, match=f"running PID {_IMPOSSIBLE_PID}"):
                 ex.clear_shutdown_state(refuse_active_peer=True)
 
         assert ex._shutdown_flag_path.exists()
@@ -816,9 +819,24 @@ class TestExecutorShutdown:
     def test_clear_shutdown_state_removes_stale_peer_pid(self, tmp_path):
         cfg = _base_config(dry_run=False, tmp_path=tmp_path)
         ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
-        ex._shutdown_flag_path.write_text("pid=12345\n")
+        ex._shutdown_flag_path.write_text(f"pid={_IMPOSSIBLE_PID}\n")
 
         with patch.object(ex, "_pid_is_running", return_value=False):
+            ex.clear_shutdown_state(refuse_active_peer=True)
+
+        assert not ex._shutdown_flag_path.exists()
+
+    @pytest.mark.unit
+    def test_clear_shutdown_state_removes_reused_pid_identity(self, tmp_path):
+        cfg = _base_config(dry_run=False, tmp_path=tmp_path)
+        ex = RedundancyGroupExecutor(_redundancy_group(), base_config=cfg)
+        ex._shutdown_flag_path.write_text(
+            f"pid={_IMPOSSIBLE_PID}\nstart_time=old\nboot_id=boot\n"
+        )
+
+        with patch("eneru.redundancy.os.kill", return_value=None), \
+             patch.object(ex, "_read_proc_start_time", return_value="new"), \
+             patch.object(ex, "_read_boot_id", return_value="boot"):
             ex.clear_shutdown_state(refuse_active_peer=True)
 
         assert not ex._shutdown_flag_path.exists()


### PR DESCRIPTION
## Summary
- add PID-owned atomic redundancy shutdown flags plus startup-fatal cleanup/access checks
- validate unknown safety keys in behavior, top-level/per-UPS triggers, and redundancy group triggers with suggestions
- evaluate redundancy group-local trigger thresholds and add stale-flag restart E2E coverage
- bump version/docs/changelog for 5.3.0-rc4

## Verification
- /tmp/eneru-venv/bin/pytest -m unit -q
- /tmp/eneru-venv/bin/pytest -m integration -q
- /tmp/eneru-venv/bin/pytest -m unit tests/test_cli.py tests/test_config_validation.py tests/test_redundancy.py tests/test_multi_ups.py -q
- /tmp/eneru-venv/bin/mkdocs build --strict
- for config in examples/*.yaml; do /tmp/eneru-venv/bin/python -m eneru validate --config ""; done
- bash -n tests/e2e/groups/cli.sh tests/e2e/groups/ups-single.sh tests/e2e/groups/ups-multi.sh tests/e2e/groups/redundancy.sh tests/e2e/groups/stats.sh

## Local AI review
- code-review-and-quality pass found four issues; all addressed
- follow-up independent review reported no blocking findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened redundancy shutdown guards and tightened safety validation for 5.3.0-rc4. PID-identity flag files prevent overlap (even with PID reuse), the daemon fails fast on invalid or non-mapping YAML, and redundancy group-local triggers now affect quorum.

- **New Features**
  - PID-owned redundancy shutdown flags with owner identity (`pid`, Linux `start_time`, `boot_id`). Startup clears stale flags, refuses to clear a live peer’s flag, verifies flag-dir write access, and exits on failure.
  - Strict safety-key validation. `eneru run` and `eneru validate` fail on unknown keys in `behavior`, top-level/per-UPS `triggers`, and `redundancy_groups[*].triggers` with “did you mean” hints. Malformed or non-mapping YAML aborts. `triggers.depletion.window` is forbidden in group triggers (set globally or on `ups[*].triggers`). Legacy `docker:` and `discord:` forms remain accepted.
  - Redundancy evaluator applies group-level triggers to member snapshots (e.g., `extended_time`, `depletion.critical_rate`, `grace_period`) without mutating per-UPS configs; only applied when on-battery. Docs/examples updated; version set to `5.3.0-rc4`.

- **Bug Fixes**
  - Redundancy group-specific triggers now properly influence quorum evaluation.
  - Added coverage for redundancy flag hardening: E2E Test 38 proves restart-stale flags are cleared; unit tests ensure atomic single-writer flag acquisition, active PID-owned flags are not cleared at startup, and owner identity prevents PID-reuse confusion.

<sup>Written for commit 24086a68be8c16450248e4ad0daf5c8db6bda583. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redundancy flags now track process ownership to prevent overlapping daemon instances.
  * Configuration validation provides "Did you mean" suggestions for typos in safety-critical settings.

* **Bug Fixes**
  * Malformed YAML now triggers fatal startup errors instead of falling back to defaults.
  * Stale redundancy flags are automatically cleared during startup.

* **Documentation**
  * Updated configuration and redundancy group guides with enhanced validation details and flag-clearing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->