### PR TITLE
v5.4.0-rc0: observability polish (events, API discovery, dashboard, SVG)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,13 +13,13 @@ Release candidate for the v5.4 observability polish pass.
 
 ### Changed
 - `/api/v1` now returns an endpoint index, and JSON 404 responses include the same available-endpoints list. When Prometheus is disabled, `/metrics` is omitted from both responses so clients don't see an endpoint advertised that genuinely returns 404.
-- The reference Grafana dashboard now renders power-quality state metrics as a timeline instead of a set of ambiguous stat values. Power, voltage, bypass, overload, AVR, shutdown-trigger, connection-failed, and remote-health-failed events are overlaid on every time-series panel via dashboard-wide Prometheus annotations, so operators can correlate a battery-charge inflection or voltage dip with the event that caused it without leaving Grafana.
-- The dashboard adds a Battery-charge / UPS-load / Runtime-remaining "now" row (gauge + sparkline stat) and a `$ups` multi-select template variable for filtering when many UPSes are configured. The standalone "Event signals" and "Remote health failures" panels were removed — annotations cover the same information in context.
-- The voltage panel now overlays the configured nominal voltage alongside the existing low/high warning thresholds.
+- The reference Grafana dashboard overlays power, voltage, bypass, overload, AVR, shutdown-trigger, connection-failed, and remote-health-failed events on every time-series panel via dashboard-wide Prometheus annotations, so operators can correlate a battery-charge inflection or voltage dip with the event that caused it without leaving Grafana. Each annotation carries a tooltip title and description text so the event name is visible on hover, and the toolbar toggles are hidden so the dashboard chrome stays clean.
+- The dashboard adds a Battery-charge / UPS-load / Runtime-remaining "now" row (gauge + sparkline stat) and a `$ups` multi-select template variable for filtering when many UPSes are configured.
+- The voltage panel overlays the configured nominal voltage alongside the existing low/high warning thresholds.
 
 ### Fixed
 - Remote-health startup probes no longer record a noisy `REMOTE_HEALTH_HEALTHY` event for the initial `UNKNOWN -> HEALTHY` baseline next to every `DAEMON_START`. Startup failures and later failure/recovery transitions are still recorded.
-- The SVG architecture diagram viewBox now matches the drawn content width (782×550 instead of 800×550), removing the residual blank right-side margin in rendered docs.
+- The SVG architecture diagram viewBox matches the drawn content width (782×550 instead of 960×550), removing the blank right-side margin in rendered docs.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.4.0-rc0] - 2026-05-14
+
+Release candidate for the v5.4 observability polish pass.
+
+### Changed
+- `/api/v1` now returns an endpoint index, and JSON 404 responses include the same available-endpoints list.
+- The reference Grafana dashboard now renders power-quality state metrics as a timeline instead of a set of ambiguous stat values, and adds Prometheus-backed event-signal coverage for shutdown triggers, failed UPS connections, and non-healthy remote targets.
+
+### Fixed
+- Remote-health startup probes no longer record a noisy `REMOTE_HEALTH_HEALTHY` event for the initial `UNKNOWN -> HEALTHY` baseline next to every `DAEMON_START`. Startup failures and later failure/recovery transitions are still recorded.
+- The SVG architecture diagram viewBox now matches the drawn content width, removing the blank right-side margin in rendered docs.
+
+---
+
 ## [5.3.0] - 2026-05-10
 
 Stable v5.3 release. Drop-in for v5.2 users in most cases — see Migration notes below for two behaviour changes that may need a small adjustment to existing dashboards or RPM-based MQTT setups.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Release candidate for the v5.4 observability polish pass.
 
 ### Changed
-- `/api/v1` now returns an endpoint index, and JSON 404 responses include the same available-endpoints list.
-- The reference Grafana dashboard now renders power-quality state metrics as a timeline instead of a set of ambiguous stat values, and adds Prometheus-backed event-signal coverage for shutdown triggers, failed UPS connections, and non-healthy remote targets.
+- `/api/v1` now returns an endpoint index, and JSON 404 responses include the same available-endpoints list. When Prometheus is disabled, `/metrics` is omitted from both responses so clients don't see an endpoint advertised that genuinely returns 404.
+- The reference Grafana dashboard now renders power-quality state metrics as a timeline instead of a set of ambiguous stat values. Power, voltage, bypass, overload, AVR, shutdown-trigger, connection-failed, and remote-health-failed events are overlaid on every time-series panel via dashboard-wide Prometheus annotations, so operators can correlate a battery-charge inflection or voltage dip with the event that caused it without leaving Grafana.
+- The dashboard adds a Battery-charge / UPS-load / Runtime-remaining "now" row (gauge + sparkline stat) and a `$ups` multi-select template variable for filtering when many UPSes are configured. The standalone "Event signals" and "Remote health failures" panels were removed — annotations cover the same information in context.
+- The voltage panel now overlays the configured nominal voltage alongside the existing low/high warning thresholds.
 
 ### Fixed
 - Remote-health startup probes no longer record a noisy `REMOTE_HEALTH_HEALTHY` event for the initial `UNKNOWN -> HEALTHY` baseline next to every `DAEMON_START`. Startup failures and later failure/recovery transitions are still recorded.
-- The SVG architecture diagram viewBox now matches the drawn content width, removing the blank right-side margin in rendered docs.
+- The SVG architecture diagram viewBox now matches the drawn content width (782×550 instead of 800×550), removing the residual blank right-side margin in rendered docs.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [5.4.0-rc0] - 2026-05-14
+## [5.4.0-rc1] - 2026-05-14
 
 Release candidate for the v5.4 observability polish pass.
 

--- a/docs/images/eneru-diagram.svg
+++ b/docs/images/eneru-diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 550">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 782 550">
   <title>Eneru Architecture Diagram</title>
   <defs>
     <marker id="arrow" viewBox="0 0 8 6" refX="0" refY="3" markerWidth="8" markerHeight="6" markerUnits="userSpaceOnUse" orient="auto">

--- a/docs/images/eneru-diagram.svg
+++ b/docs/images/eneru-diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 550">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 550">
   <title>Eneru Architecture Diagram</title>
   <defs>
     <marker id="arrow" viewBox="0 0 8 6" refX="0" refY="3" markerWidth="8" markerHeight="6" markerUnits="userSpaceOnUse" orient="auto">

--- a/docs/observability-api.md
+++ b/docs/observability-api.md
@@ -118,11 +118,17 @@ Useful metric names include:
 | `eneru_remote_health_status` | Last remote health state |
 
 `examples/grafana-dashboard.json` is a starting dashboard for these metrics.
-It uses Prometheus only, so it shows event-like signals such as active
-shutdown triggers, failed UPS connections, non-healthy remote SSH states, and
-power-quality state changes. Exact SQLite event rows remain available from
-`/api/v1/events`; use a Grafana JSON/API datasource plugin if you want those
-rows rendered as a table or annotations inside Grafana.
+It is Prometheus-only and ships with a `$ups` template variable plus
+dashboard-wide annotations sourced from existing Prometheus signals
+(`eneru_ups_time_on_battery_seconds > 0` for power cuts, the voltage /
+AVR / bypass / overload state metrics for power-quality events, plus
+`eneru_ups_trigger_active`, `eneru_ups_connection_failed`, and
+`eneru_remote_health_status{status="FAILED"} == 1`). Annotations render as
+coloured regions across every time-series panel, so a power cut is
+visible directly on the Battery-charge and Runtime-remaining curves and a
+brownout is visible directly on the Input/output voltage panel — no extra
+Grafana plugin required. Exact SQLite event rows with their full detail
+text remain available from `/api/v1/events` if you want a tabular feed.
 
 ## Remote SSH health
 

--- a/docs/observability-api.md
+++ b/docs/observability-api.md
@@ -1,6 +1,6 @@
 # Observability and API
 
-Eneru v5.3 adds read-only observability endpoints and outbound integrations. None of the API or MQTT surfaces here can trigger UPS shutdown, mutate state, or run commands you didn't already configure for the daemon. Note that **remote-health probes do execute SSH commands** against your configured remote servers — they're restricted to a deliberately-harmless `probe_command` (default `true`) that never touches your `pre_shutdown_commands` or `shutdown_command`. See "Remote SSH health" below for the safety contract.
+Eneru v5.3+ includes read-only observability endpoints and outbound integrations. None of the API or MQTT surfaces here can trigger UPS shutdown, mutate state, or run commands you didn't already configure for the daemon. Note that **remote-health probes do execute SSH commands** against your configured remote servers — they're restricted to a deliberately-harmless `probe_command` (default `true`) that never touches your `pre_shutdown_commands` or `shutdown_command`. See "Remote SSH health" below for the safety contract.
 
 ## API server
 
@@ -19,6 +19,7 @@ Endpoints:
 |----------|---------|--------------|
 | `/health` | API process is alive | 200 |
 | `/ready` | Monitoring has usable UPS visibility | 200 ready / 503 not ready |
+| `/api/v1` | API endpoint index | 200 |
 | `/api/v1/ups` | Current UPS/group status | 200 |
 | `/api/v1/ups/<name>` | One UPS status | 200 / 404 |
 | `/api/v1/ups/<name>/history` | SQLite metric history | 200 / 400 (bad metric) / 404 |
@@ -117,6 +118,11 @@ Useful metric names include:
 | `eneru_remote_health_status` | Last remote health state |
 
 `examples/grafana-dashboard.json` is a starting dashboard for these metrics.
+It uses Prometheus only, so it shows event-like signals such as active
+shutdown triggers, failed UPS connections, non-healthy remote SSH states, and
+power-quality state changes. Exact SQLite event rows remain available from
+`/api/v1/events`; use a Grafana JSON/API datasource plugin if you want those
+rows rendered as a table or annotations inside Grafana.
 
 ## Remote SSH health
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,8 +29,8 @@ Eneru uses unit tests, package-install tests, and end-to-end tests with real NUT
    ╱─────────────────────────────────────────────╲
 ```
 
-The pyramid is intentionally bottom-heavy. As of the v5.3 stable pass,
-the local pytest suite contains 1162 tests. E2E tests are fewer, but they
+The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc0 pass,
+the local pytest suite contains 1183 tests. E2E tests are fewer, but they
 exercise the real service boundaries where packaging, NUT, SSH, Docker,
 filesystem, and CLI assumptions meet.
 
@@ -163,7 +163,7 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 45 numb
 | 40 | UPS Single | Remote SSH healthcheck reaches the test target without sending shutdown commands |
 | 41 | CLI | Manual remote shutdown dry-run executes no configured remote commands |
 | 42 | CLI | Manual confirmed remote shutdown reaches only the selected target |
-| 43 | UPS Single | `/health`, `/ready`, and `/metrics` respond from the embedded API |
+| 43 | UPS Single | `/health`, `/ready`, `/metrics`, `/api/v1`, and JSON 404 endpoint discovery respond from the embedded API |
 | 44 | UPS Single | An unreachable remote target is reported as a bounded best-effort failure instead of stalling shutdown |
 | 45 | UPS Single | MQTT status publishing reaches the broker and includes power-quality fields |
 | E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ Eneru uses unit tests, package-install tests, and end-to-end tests with real NUT
 ```
 
 The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc0 pass,
-the local pytest suite contains 1183 tests. E2E tests are fewer, but they
+the local pytest suite contains 1179 tests. E2E tests are fewer, but they
 exercise the real service boundaries where packaging, NUT, SSH, Docker,
 filesystem, and CLI assumptions meet.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,7 +29,7 @@ Eneru uses unit tests, package-install tests, and end-to-end tests with real NUT
    ╱─────────────────────────────────────────────╲
 ```
 
-The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc0 pass,
+The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc1 pass,
 the local pytest suite contains 1179 tests. E2E tests are fewer, but they
 exercise the real service boundaries where packaging, NUT, SSH, Docker,
 filesystem, and CLI assumptions meet.

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -40,99 +40,135 @@
         "name": "On battery",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "red",
         "tags": ["power-cut"],
+        "tagKeys": "label",
+        "titleFormat": "On battery — {{label}}",
+        "textFormat": "{{label}} switched to battery",
         "target": {
           "expr": "eneru_ups_time_on_battery_seconds{label=~\"$ups\"} > 0",
-          "legendFormat": "{{label}} on battery"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "Brownout",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "orange",
         "tags": ["voltage"],
+        "tagKeys": "label,state",
+        "titleFormat": "Brownout — {{label}}",
+        "textFormat": "{{label}} input voltage below low warning threshold",
         "target": {
           "expr": "eneru_ups_voltage_state{state=\"LOW\",label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} brownout"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "Over-voltage",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "orange",
         "tags": ["voltage"],
+        "tagKeys": "label,state",
+        "titleFormat": "Over-voltage — {{label}}",
+        "textFormat": "{{label}} input voltage above high warning threshold",
         "target": {
           "expr": "eneru_ups_voltage_state{state=\"HIGH\",label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} over-voltage"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "AVR engaged",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "yellow",
         "tags": ["voltage"],
+        "tagKeys": "label,state",
+        "titleFormat": "AVR {{state}} — {{label}}",
+        "textFormat": "{{label}} AVR engaged ({{state}})",
         "target": {
           "expr": "eneru_ups_avr_state{state=~\"BOOST|TRIM\",label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} avr {{state}}"
+          "legendFormat": "{{label}} {{state}}"
         }
       },
       {
         "name": "Bypass active",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "purple",
         "tags": ["bypass"],
+        "tagKeys": "label",
+        "titleFormat": "Bypass active — {{label}}",
+        "textFormat": "{{label}} switched to bypass mode",
         "target": {
           "expr": "eneru_ups_bypass_state{state=\"ACTIVE\",label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} bypass"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "Overload",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "red",
         "tags": ["overload"],
+        "tagKeys": "label",
+        "titleFormat": "Overload — {{label}}",
+        "textFormat": "{{label}} load exceeded UPS rating",
         "target": {
           "expr": "eneru_ups_overload_state{state=\"ACTIVE\",label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} overload"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "Shutdown trigger",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "dark-red",
         "tags": ["trigger"],
+        "tagKeys": "label",
+        "titleFormat": "Shutdown trigger — {{label}}",
+        "textFormat": "{{label}} shutdown trigger active",
         "target": {
           "expr": "eneru_ups_trigger_active{label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} trigger"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "Connection failed",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "rgba(140, 140, 140, 1)",
         "tags": ["connection"],
+        "tagKeys": "label",
+        "titleFormat": "Connection failed — {{label}}",
+        "textFormat": "{{label}} NUT connection failed",
         "target": {
           "expr": "eneru_ups_connection_failed{label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} connection failed"
+          "legendFormat": "{{label}}"
         }
       },
       {
         "name": "Remote health failed",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "enable": true,
+        "hide": true,
         "iconColor": "dark-red",
         "tags": ["remote"],
+        "tagKeys": "server,host",
+        "titleFormat": "Remote health failed — {{server}}",
+        "textFormat": "{{server}} ({{host}}) remote SSH probe failed",
         "target": {
           "expr": "eneru_remote_health_status{status=\"FAILED\"} == 1",
-          "legendFormat": "{{server}} remote failed"
+          "legendFormat": "{{server}}"
         }
       }
     ]
@@ -326,7 +362,7 @@
       "type": "timeseries",
       "title": "Temperature and battery voltage",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 21},
       "targets": [
         {
           "refId": "A",
@@ -354,40 +390,6 @@
           }
         ]
       }
-    },
-    {
-      "type": "state-timeline",
-      "title": "Power-quality state timeline",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 21},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_voltage_state{label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} voltage {{state}}"
-        },
-        {
-          "refId": "B",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_avr_state{label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} avr {{state}}"
-        },
-        {
-          "refId": "C",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_bypass_state{label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} bypass {{state}}"
-        },
-        {
-          "refId": "D",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_overload_state{label=~\"$ups\"} == 1",
-          "legendFormat": "{{label}} overload {{state}}"
-        }
-      ],
-      "options": {"mergeValues": true, "showValue": "auto"},
-      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "max": 1}, "overrides": []}
     }
   ]
 }

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -1,7 +1,7 @@
 {
   "title": "Eneru UPS Overview",
   "schemaVersion": 39,
-  "version": 3,
+  "version": 4,
   "refresh": "15s",
   "time": {
     "from": "now-6h",
@@ -18,19 +18,224 @@
         "refresh": 1,
         "current": {},
         "options": []
+      },
+      {
+        "name": "ups",
+        "label": "UPS",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "query": {"qryType": 1, "query": "label_values(eneru_ups_battery_charge, label)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
+        "options": []
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "On battery",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "red",
+        "tags": ["power-cut"],
+        "target": {
+          "expr": "eneru_ups_time_on_battery_seconds{label=~\"$ups\"} > 0",
+          "legendFormat": "{{label}} on battery"
+        }
+      },
+      {
+        "name": "Brownout",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "orange",
+        "tags": ["voltage"],
+        "target": {
+          "expr": "eneru_ups_voltage_state{state=\"LOW\",label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} brownout"
+        }
+      },
+      {
+        "name": "Over-voltage",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "orange",
+        "tags": ["voltage"],
+        "target": {
+          "expr": "eneru_ups_voltage_state{state=\"HIGH\",label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} over-voltage"
+        }
+      },
+      {
+        "name": "AVR engaged",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "yellow",
+        "tags": ["voltage"],
+        "target": {
+          "expr": "eneru_ups_avr_state{state=~\"BOOST|TRIM\",label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} avr {{state}}"
+        }
+      },
+      {
+        "name": "Bypass active",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "purple",
+        "tags": ["bypass"],
+        "target": {
+          "expr": "eneru_ups_bypass_state{state=\"ACTIVE\",label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} bypass"
+        }
+      },
+      {
+        "name": "Overload",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "red",
+        "tags": ["overload"],
+        "target": {
+          "expr": "eneru_ups_overload_state{state=\"ACTIVE\",label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} overload"
+        }
+      },
+      {
+        "name": "Shutdown trigger",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "dark-red",
+        "tags": ["trigger"],
+        "target": {
+          "expr": "eneru_ups_trigger_active{label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} trigger"
+        }
+      },
+      {
+        "name": "Connection failed",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "rgba(140, 140, 140, 1)",
+        "tags": ["connection"],
+        "target": {
+          "expr": "eneru_ups_connection_failed{label=~\"$ups\"} == 1",
+          "legendFormat": "{{label}} connection failed"
+        }
+      },
+      {
+        "name": "Remote health failed",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "enable": true,
+        "iconColor": "dark-red",
+        "tags": ["remote"],
+        "target": {
+          "expr": "eneru_remote_health_status{status=\"FAILED\"} == 1",
+          "legendFormat": "{{server}} remote failed"
+        }
       }
     ]
   },
   "panels": [
     {
-      "type": "timeseries",
-      "title": "Battery charge",
+      "type": "gauge",
+      "title": "Battery charge (now)",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 0},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 0},
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_battery_charge",
+          "expr": "eneru_ups_battery_charge{label=~\"$ups\"}",
+          "legendFormat": "{{label}}"
+        }
+      ],
+      "options": {"showThresholdLabels": false, "showThresholdMarkers": true},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 20},
+              {"color": "green", "value": 50}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "UPS load (now)",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_ups_load_percent{label=~\"$ups\"}",
+          "legendFormat": "{{label}}"
+        }
+      ],
+      "options": {"showThresholdLabels": false, "showThresholdMarkers": true},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 70},
+              {"color": "red", "value": 90}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Runtime remaining (now)",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_ups_runtime_seconds{label=~\"$ups\"}",
+          "legendFormat": "{{label}}"
+        }
+      ],
+      "options": {"graphMode": "area", "colorMode": "value", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 120},
+              {"color": "green", "value": 600}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Battery charge",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 6},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_ups_battery_charge{label=~\"$ups\"}",
           "legendFormat": "{{label}}"
         }
       ],
@@ -40,11 +245,11 @@
       "type": "timeseries",
       "title": "Runtime remaining",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 0},
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 6},
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_runtime_seconds",
+          "expr": "eneru_ups_runtime_seconds{label=~\"$ups\"}",
           "legendFormat": "{{label}}"
         }
       ],
@@ -54,11 +259,11 @@
       "type": "timeseries",
       "title": "UPS load",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 0},
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 6},
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_load_percent",
+          "expr": "eneru_ups_load_percent{label=~\"$ups\"}",
           "legendFormat": "{{label}}"
         }
       ],
@@ -68,26 +273,31 @@
       "type": "timeseries",
       "title": "Input and output voltage",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 7},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_input_voltage",
+          "expr": "eneru_ups_input_voltage{label=~\"$ups\"}",
           "legendFormat": "{{label}} input"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_output_voltage",
+          "expr": "eneru_ups_output_voltage{label=~\"$ups\"}",
           "legendFormat": "{{label}} output"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_voltage_warning_low",
+          "expr": "eneru_ups_nominal_voltage{label=~\"$ups\"}",
+          "legendFormat": "{{label}} nominal"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_ups_voltage_warning_low{label=~\"$ups\"}",
           "legendFormat": "{{label}} low warning"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_voltage_warning_high",
+          "expr": "eneru_ups_voltage_warning_high{label=~\"$ups\"}",
           "legendFormat": "{{label}} high warning"
         }
       ],
@@ -97,16 +307,16 @@
       "type": "timeseries",
       "title": "Input and output frequency",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 7},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_input_frequency_hz",
+          "expr": "eneru_ups_input_frequency_hz{label=~\"$ups\"}",
           "legendFormat": "{{label}} input"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_output_frequency_hz",
+          "expr": "eneru_ups_output_frequency_hz{label=~\"$ups\"}",
           "legendFormat": "{{label}} output"
         }
       ],
@@ -116,18 +326,18 @@
       "type": "timeseries",
       "title": "Temperature and battery voltage",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
       "targets": [
         {
           "refId": "A",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_temperature_celsius",
+          "expr": "eneru_ups_temperature_celsius{label=~\"$ups\"}",
           "legendFormat": "{{label}} temperature"
         },
         {
           "refId": "B",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_battery_voltage",
+          "expr": "eneru_ups_battery_voltage{label=~\"$ups\"}",
           "legendFormat": "{{label}} battery voltage"
         }
       ],
@@ -149,76 +359,34 @@
       "type": "state-timeline",
       "title": "Power-quality state timeline",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 21},
       "targets": [
         {
           "refId": "A",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_voltage_state == 1",
+          "expr": "eneru_ups_voltage_state{label=~\"$ups\"} == 1",
           "legendFormat": "{{label}} voltage {{state}}"
         },
         {
           "refId": "B",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_avr_state == 1",
+          "expr": "eneru_ups_avr_state{label=~\"$ups\"} == 1",
           "legendFormat": "{{label}} avr {{state}}"
         },
         {
           "refId": "C",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_bypass_state == 1",
+          "expr": "eneru_ups_bypass_state{label=~\"$ups\"} == 1",
           "legendFormat": "{{label}} bypass {{state}}"
         },
         {
           "refId": "D",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_overload_state == 1",
+          "expr": "eneru_ups_overload_state{label=~\"$ups\"} == 1",
           "legendFormat": "{{label}} overload {{state}}"
         }
       ],
       "options": {"mergeValues": true, "showValue": "auto"},
-      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "max": 1}, "overrides": []}
-    },
-    {
-      "type": "stat",
-      "title": "Remote health failures",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 23},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "sum(eneru_remote_health_consecutive_failures)",
-          "legendFormat": "failures"
-        }
-      ],
-      "fieldConfig": {"defaults": {"unit": "short", "min": 0}, "overrides": []}
-    },
-    {
-      "type": "timeseries",
-      "title": "Event signals",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 7, "w": 16, "x": 8, "y": 23},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_trigger_active",
-          "legendFormat": "{{label}} trigger active"
-        },
-        {
-          "refId": "B",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_ups_connection_failed",
-          "legendFormat": "{{label}} connection failed"
-        },
-        {
-          "refId": "C",
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "eneru_remote_health_status{status!=\"HEALTHY\"}",
-          "legendFormat": "{{server}} remote {{status}}"
-        }
-      ],
       "fieldConfig": {"defaults": {"unit": "short", "min": 0, "max": 1}, "overrides": []}
     }
   ]

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -1,7 +1,7 @@
 {
   "title": "Eneru UPS Overview",
   "schemaVersion": 39,
-  "version": 2,
+  "version": 3,
   "refresh": "15s",
   "time": {
     "from": "now-6h",
@@ -146,47 +146,80 @@
       }
     },
     {
-      "type": "stat",
-      "title": "Power-quality states",
+      "type": "state-timeline",
+      "title": "Power-quality state timeline",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 6, "x": 12, "y": 15},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
       "targets": [
         {
+          "refId": "A",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "max by (state) (eneru_ups_voltage_state) > 0",
-          "legendFormat": "voltage {{state}}"
+          "expr": "eneru_ups_voltage_state == 1",
+          "legendFormat": "{{label}} voltage {{state}}"
         },
         {
+          "refId": "B",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "max by (state) (eneru_ups_avr_state) > 0",
-          "legendFormat": "avr {{state}}"
+          "expr": "eneru_ups_avr_state == 1",
+          "legendFormat": "{{label}} avr {{state}}"
         },
         {
+          "refId": "C",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "max by (state) (eneru_ups_bypass_state) > 0",
-          "legendFormat": "bypass {{state}}"
+          "expr": "eneru_ups_bypass_state == 1",
+          "legendFormat": "{{label}} bypass {{state}}"
         },
         {
+          "refId": "D",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "max by (state) (eneru_ups_overload_state) > 0",
-          "legendFormat": "overload {{state}}"
+          "expr": "eneru_ups_overload_state == 1",
+          "legendFormat": "{{label}} overload {{state}}"
         }
       ],
-      "fieldConfig": {"defaults": {"unit": "short", "min": 0}, "overrides": []}
+      "options": {"mergeValues": true, "showValue": "auto"},
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "max": 1}, "overrides": []}
     },
     {
       "type": "stat",
       "title": "Remote health failures",
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "gridPos": {"h": 8, "w": 6, "x": 18, "y": 15},
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 23},
       "targets": [
         {
+          "refId": "A",
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "sum(eneru_remote_health_consecutive_failures)",
           "legendFormat": "failures"
         }
       ],
       "fieldConfig": {"defaults": {"unit": "short", "min": 0}, "overrides": []}
+    },
+    {
+      "type": "timeseries",
+      "title": "Event signals",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "gridPos": {"h": 7, "w": 16, "x": 8, "y": 23},
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_ups_trigger_active",
+          "legendFormat": "{{label}} trigger active"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_ups_connection_failed",
+          "legendFormat": "{{label}} connection failed"
+        },
+        {
+          "refId": "C",
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "eneru_remote_health_status{status!=\"HEALTHY\"}",
+          "legendFormat": "{{server}} remote {{status}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0, "max": 1}, "overrides": []}
     }
   ]
 }

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -243,16 +243,26 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
 
     def _not_found(self, message: str) -> Dict[str, Any]:
         payload = self._error("NOT_FOUND", message)
-        payload["availableEndpoints"] = list(API_ENDPOINTS)
+        payload["availableEndpoints"] = self._available_endpoints()
         return payload
 
-    @staticmethod
-    def _api_index() -> Dict[str, Any]:
+    def _api_index(self) -> Dict[str, Any]:
         return {
             "generatedAt": time.time(),
             "version": "v1",
-            "endpoints": list(API_ENDPOINTS),
+            "endpoints": self._available_endpoints(),
         }
+
+    def _available_endpoints(self) -> List[Dict[str, Any]]:
+        # Don't advertise /metrics when Prometheus is disabled — the route
+        # genuinely returns 404 in that mode, so listing it would mislead
+        # clients that read availableEndpoints to discover what to call.
+        prometheus_enabled = bool(getattr(self.api_config.prometheus, "enabled", False))
+        return [
+            dict(endpoint)
+            for endpoint in API_ENDPOINTS
+            if endpoint["path"] != "/metrics" or prometheus_enabled
+        ]
 
 
 def _parse_int_param(

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -24,6 +24,32 @@ class APIBadRequest(ValueError):
     """Raised when a client supplies invalid API query parameters."""
 
 
+API_ENDPOINTS = (
+    {"path": "/health", "description": "Liveness probe"},
+    {"path": "/ready", "description": "Readiness probe with fresh UPS data"},
+    {"path": "/metrics", "description": "Prometheus metrics when enabled"},
+    {"path": "/api/v1", "description": "API endpoint index"},
+    {"path": "/api/v1/ups", "description": "Current UPS and redundancy status"},
+    {"path": "/api/v1/ups/{name}", "description": "Current status for one UPS"},
+    {
+        "path": "/api/v1/ups/{name}/history",
+        "description": "SQLite metric history for one UPS",
+        "query": {
+            "metric": "charge|runtime|load|voltage|depletion",
+            "from": "unix timestamp",
+            "to": "unix timestamp",
+        },
+    },
+    {
+        "path": "/api/v1/events",
+        "description": "Recent SQLite event rows",
+        "query": {"limit": "1..10000", "verbosity": "0..2"},
+    },
+    {"path": "/api/v1/config", "description": "Sanitized configuration summary"},
+    {"path": "/api/v1/remote-health", "description": "Remote SSH health rows"},
+)
+
+
 class EneruAPIServer:
     """Small stdlib HTTP server for read-only observability endpoints."""
 
@@ -155,8 +181,11 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
 
         if path == "/metrics":
             if not self.api_config.prometheus.enabled:
-                return 404, "application/json", self._error("NOT_FOUND", "Metrics disabled")
+                return 404, "application/json", self._not_found("Metrics disabled")
             return 200, "text/plain", render_prometheus_metrics(self.api_source)
+
+        if path == "/api/v1":
+            return 200, "application/json", self._api_index()
 
         if path == "/api/v1/ups":
             return 200, "application/json", collect_status(self.api_source)
@@ -168,7 +197,7 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
                 payload = collect_status(self.api_source)
                 row = find_status(payload, ups_name)
                 if row is None:
-                    return 404, "application/json", self._error("NOT_FOUND", "UPS not found")
+                    return 404, "application/json", self._not_found("UPS not found")
                 return 200, "application/json", row
             if len(parts) == 6 and parts[5] == "history":
                 metric = (qs.get("metric") or ["charge"])[0]
@@ -182,7 +211,7 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
                 start = _parse_int_param(qs, "from", end - 3600)
                 rows = query_history(self.api_config, ups_name, metric, start, end)
                 if rows is None:
-                    return 404, "application/json", self._error("NOT_FOUND", "UPS not found")
+                    return 404, "application/json", self._not_found("UPS not found")
                 return 200, "application/json", {
                     "ups": ups_name, "metric": metric, "from": start,
                     "to": end, "data": rows,
@@ -206,11 +235,24 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
             rows = live_remote_health(self.api_source, self.api_config)
             return 200, "application/json", {"generatedAt": time.time(), "servers": rows}
 
-        return 404, "application/json", self._error("NOT_FOUND", "Endpoint not found")
+        return 404, "application/json", self._not_found("Endpoint not found")
 
     @staticmethod
     def _error(code: str, message: str) -> Dict[str, Dict[str, str]]:
         return {"error": {"code": code, "message": message}}
+
+    def _not_found(self, message: str) -> Dict[str, Any]:
+        payload = self._error("NOT_FOUND", message)
+        payload["availableEndpoints"] = list(API_ENDPOINTS)
+        return payload
+
+    @staticmethod
+    def _api_index() -> Dict[str, Any]:
+        return {
+            "generatedAt": time.time(),
+            "version": "v1",
+            "endpoints": list(API_ENDPOINTS),
+        }
 
 
 def _parse_int_param(

--- a/src/eneru/remote_health.py
+++ b/src/eneru/remote_health.py
@@ -305,6 +305,12 @@ class RemoteHealthManager:
         """Record stable remote-health state transitions in SQLite events."""
         if self.event_fn is None or current == previous:
             return
+        # UNKNOWN -> HEALTHY is the initial baseline after daemon start,
+        # not an operator-actionable state change. Keep startup failures
+        # and later recoveries visible, but do not add a healthy row next
+        # to every DAEMON_START event.
+        if previous == REMOTE_HEALTH_UNKNOWN and current == REMOTE_HEALTH_HEALTHY:
+            return
         detail = (
             f"{self.group_label}/{display} ({host}) "
             f"{previous} -> {current}"

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.3.0"
+__version__ = "5.4.0-rc0"

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.4.0-rc0"
+__version__ = "5.4.0-rc1"

--- a/tests/e2e/groups/single-ups.sh
+++ b/tests/e2e/groups/single-ups.sh
@@ -675,11 +675,11 @@ echo "PASS: manual confirmed remote shutdown reached selected target"
 )
 
 # ======================================================================
-# Test 43: Embedded API health/readiness/metrics
+# Test 43: Embedded API health/readiness/metrics/index
 # ======================================================================
 (
 echo ""
-echo ">>> Running: Test 43: Embedded API health/readiness/metrics"
+echo ">>> Running: Test 43: Embedded API health/readiness/metrics/index"
 
 cp $E2E_DIR/scenarios/online-charging.dev $E2E_DIR/scenarios/apply.dev
 timeout 12s eneru run --config $E2E_DIR/config-e2e-dry-run.yaml \
@@ -712,6 +712,21 @@ if ! poll_endpoint http://127.0.0.1:9100/metrics /tmp/test43-metrics.txt; then
   cat /tmp/test43-daemon.log
   exit 1
 fi
+if ! poll_endpoint http://127.0.0.1:9100/api/v1 /tmp/test43-index.json; then
+  echo "FAIL: /api/v1 never responded within poll budget"
+  cat /tmp/test43-daemon.log
+  exit 1
+fi
+
+MISSING_UPS_STATUS=$(curl -sS \
+  -o /tmp/test43-missing-ups.json \
+  -w "%{http_code}" \
+  http://127.0.0.1:9100/api/v1/ups/missing)
+if [ "$MISSING_UPS_STATUS" != "404" ]; then
+  echo "FAIL: missing UPS endpoint returned HTTP $MISSING_UPS_STATUS, expected 404"
+  cat /tmp/test43-missing-ups.json
+  exit 1
+fi
 
 if ! grep -q "eneru_up 1" /tmp/test43-metrics.txt; then
   echo "FAIL: metrics endpoint missing eneru_up"
@@ -728,11 +743,21 @@ if ! grep -q "eneru_ups_voltage_state" /tmp/test43-metrics.txt; then
   cat /tmp/test43-metrics.txt
   exit 1
 fi
+if ! grep -q '"/api/v1/events"' /tmp/test43-index.json; then
+  echo "FAIL: API index missing /api/v1/events"
+  cat /tmp/test43-index.json
+  exit 1
+fi
+if ! grep -q '"availableEndpoints"' /tmp/test43-missing-ups.json; then
+  echo "FAIL: API 404 missing availableEndpoints"
+  cat /tmp/test43-missing-ups.json
+  exit 1
+fi
 
 kill "$DAEMON_PID" 2>/dev/null || true
 wait "$DAEMON_PID" 2>/dev/null || true
 trap - EXIT
-echo "PASS: embedded API health/readiness/metrics responded"
+echo "PASS: embedded API health/readiness/metrics/index responded"
 )
 
 # ======================================================================

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -311,6 +311,11 @@ def test_api_core_routes(minimal_config, monitor):
     assert status == 200
     assert payload["ups"][0]["name"] == "TestUPS@localhost"
 
+    handler.path = "/api/v1"
+    status, _, payload = handler._route()
+    assert status == 200
+    assert any(row["path"] == "/api/v1/events" for row in payload["endpoints"])
+
     handler.path = "/api/v1/ups/TestUPS-localhost"
     status, _, payload = handler._route()
     assert status == 200
@@ -320,12 +325,14 @@ def test_api_core_routes(minimal_config, monitor):
     status, _, payload = handler._route()
     assert status == 404
     assert payload["error"]["code"] == "NOT_FOUND"
+    assert any(row["path"] == "/api/v1/ups" for row in payload["availableEndpoints"])
 
     minimal_config.prometheus.enabled = False
     handler.path = "/metrics"
     status, _, payload = handler._route()
     assert status == 404
     assert payload["error"]["message"] == "Metrics disabled"
+    assert any(row["path"] == "/metrics" for row in payload["availableEndpoints"])
 
 
 @pytest.mark.unit
@@ -393,6 +400,22 @@ def test_api_history_rejects_unknown_metric(minimal_config):
     assert status == 400
     assert content_type == "application/json"
     assert payload["error"]["code"] == "INVALID_REQUEST"
+
+
+@pytest.mark.unit
+def test_api_history_404_includes_endpoint_index(minimal_config):
+    handler = object.__new__(EneruAPIHandler)
+    handler.path = "/api/v1/ups/missing/history"
+    handler.api_config = minimal_config
+    handler.api_source = MagicMock()
+
+    status, content_type, payload = handler._route()
+
+    assert status == 404
+    assert content_type == "application/json"
+    assert payload["error"]["code"] == "NOT_FOUND"
+    assert any(row["path"] == "/api/v1/ups/{name}/history"
+               for row in payload["availableEndpoints"])
 
 
 @pytest.mark.unit

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -332,7 +332,10 @@ def test_api_core_routes(minimal_config, monitor):
     status, _, payload = handler._route()
     assert status == 404
     assert payload["error"]["message"] == "Metrics disabled"
-    assert any(row["path"] == "/metrics" for row in payload["availableEndpoints"])
+    advertised = {row["path"] for row in payload["availableEndpoints"]}
+    assert "/metrics" not in advertised
+    assert "/api/v1" in advertised
+    assert "/api/v1/ups" in advertised
 
 
 @pytest.mark.unit
@@ -400,6 +403,26 @@ def test_api_history_rejects_unknown_metric(minimal_config):
     assert status == 400
     assert content_type == "application/json"
     assert payload["error"]["code"] == "INVALID_REQUEST"
+
+
+@pytest.mark.unit
+def test_api_index_omits_metrics_when_prometheus_disabled(minimal_config):
+    minimal_config.prometheus.enabled = False
+    handler = object.__new__(EneruAPIHandler)
+    handler.path = "/api/v1"
+    handler.api_config = minimal_config
+    handler.api_source = MagicMock()
+
+    status, content_type, payload = handler._route()
+
+    assert status == 200
+    assert content_type == "application/json"
+    advertised = {row["path"] for row in payload["endpoints"]}
+    assert "/metrics" not in advertised
+    # The rest of the index is unchanged.
+    assert "/health" in advertised
+    assert "/api/v1" in advertised
+    assert "/api/v1/events" in advertised
 
 
 @pytest.mark.unit

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,6 +13,12 @@ ROOT = Path(__file__).resolve().parents[1]
 @pytest.mark.unit
 def test_grafana_dashboard_has_observability_polish_panels():
     dashboard = json.loads((ROOT / "examples/grafana-dashboard.json").read_text())
+    titles = [panel["title"] for panel in dashboard["panels"]]
+    # Build the lookup only after asserting titles are unique so a
+    # duplicate doesn't silently overwrite a real panel and let later
+    # assertions pass against the wrong target.
+    duplicates = sorted({t for t in titles if titles.count(t) > 1})
+    assert not duplicates, f"duplicate panel titles: {duplicates}"
     panels = {panel["title"]: panel for panel in dashboard["panels"]}
 
     # Gauge row at the top: "now" view for at-a-glance health.
@@ -25,14 +31,15 @@ def test_grafana_dashboard_has_observability_polish_panels():
     assert panels["Runtime remaining"]["type"] == "timeseries"
     assert panels["UPS load"]["type"] == "timeseries"
 
-    # Power-quality state timeline kept from f36ab63.
-    assert panels["Power-quality state timeline"]["type"] == "state-timeline"
-
-    # The standalone "Event signals" and "Remote health failures" panels
-    # were removed — that information now lives in the dashboard-wide
-    # annotations so it overlays on every time-series panel in context.
+    # Standalone status panels are intentionally absent — the same
+    # information is overlaid on every time-series panel via the
+    # dashboard-wide annotations, so a separate panel would duplicate
+    # what's already in context. The state-timeline variant misrendered
+    # the merged voltage/AVR/bypass/overload series in Grafana 12, so it
+    # is not part of the shipped dashboard either.
     assert "Event signals" not in panels
     assert "Remote health failures" not in panels
+    assert "Power-quality state timeline" not in panels
 
     # Voltage panel includes nominal and warning thresholds for context.
     voltage = panels["Input and output voltage"]
@@ -63,10 +70,21 @@ def test_grafana_dashboard_overlays_events_via_annotations():
     }
     for name, fragment in expected.items():
         assert name in annotations, f"missing annotation: {name}"
-        assert annotations[name]["enable"] is True
-        assert fragment in annotations[name]["target"]["expr"], (
+        annotation = annotations[name]
+        assert annotation["enable"] is True
+        # Hidden from the top-of-dashboard annotation toggle bar — they
+        # render on the panels but don't crowd the dashboard chrome.
+        assert annotation["hide"] is True, (
+            f"{name} annotation should set hide:true to skip the toolbar toggle"
+        )
+        # titleFormat and textFormat are what makes the event name visible
+        # in the tooltip when you hover the marker. Without them Grafana
+        # falls back to the raw metric value (1) and labels.
+        assert annotation["titleFormat"], f"{name} missing titleFormat"
+        assert annotation["textFormat"], f"{name} missing textFormat"
+        assert fragment in annotation["target"]["expr"], (
             f"{name} expr does not contain {fragment!r}: "
-            f"{annotations[name]['target']['expr']}"
+            f"{annotation['target']['expr']}"
         )
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,33 @@
+"""Tests for shipped example assets."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.unit
+def test_grafana_dashboard_has_observability_polish_panels():
+    dashboard = json.loads((ROOT / "examples/grafana-dashboard.json").read_text())
+    panels = {panel["title"]: panel for panel in dashboard["panels"]}
+
+    assert panels["Power-quality state timeline"]["type"] == "state-timeline"
+    event_signals = panels["Event signals"]
+    expressions = {target["expr"] for target in event_signals["targets"]}
+    assert "eneru_ups_trigger_active" in expressions
+    assert "eneru_ups_connection_failed" in expressions
+    assert 'eneru_remote_health_status{status!="HEALTHY"}' in expressions
+
+
+@pytest.mark.unit
+def test_architecture_diagram_viewbox_matches_content_width():
+    svg = (ROOT / "docs/images/eneru-diagram.svg").read_text()
+    match = re.search(r'viewBox="0 0 (?P<width>\d+) (?P<height>\d+)"', svg)
+
+    assert match is not None
+    assert match.group("width") == "800"
+    assert match.group("height") == "550"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,12 +15,70 @@ def test_grafana_dashboard_has_observability_polish_panels():
     dashboard = json.loads((ROOT / "examples/grafana-dashboard.json").read_text())
     panels = {panel["title"]: panel for panel in dashboard["panels"]}
 
+    # Gauge row at the top: "now" view for at-a-glance health.
+    assert panels["Battery charge (now)"]["type"] == "gauge"
+    assert panels["UPS load (now)"]["type"] == "gauge"
+    assert panels["Runtime remaining (now)"]["type"] == "stat"
+
+    # Time-series view of the same trio underneath the gauges.
+    assert panels["Battery charge"]["type"] == "timeseries"
+    assert panels["Runtime remaining"]["type"] == "timeseries"
+    assert panels["UPS load"]["type"] == "timeseries"
+
+    # Power-quality state timeline kept from f36ab63.
     assert panels["Power-quality state timeline"]["type"] == "state-timeline"
-    event_signals = panels["Event signals"]
-    expressions = {target["expr"] for target in event_signals["targets"]}
-    assert "eneru_ups_trigger_active" in expressions
-    assert "eneru_ups_connection_failed" in expressions
-    assert 'eneru_remote_health_status{status!="HEALTHY"}' in expressions
+
+    # The standalone "Event signals" and "Remote health failures" panels
+    # were removed — that information now lives in the dashboard-wide
+    # annotations so it overlays on every time-series panel in context.
+    assert "Event signals" not in panels
+    assert "Remote health failures" not in panels
+
+    # Voltage panel includes nominal and warning thresholds for context.
+    voltage = panels["Input and output voltage"]
+    voltage_exprs = {target["expr"] for target in voltage["targets"]}
+    assert any("eneru_ups_nominal_voltage" in expr for expr in voltage_exprs)
+    assert any("eneru_ups_voltage_warning_low" in expr for expr in voltage_exprs)
+    assert any("eneru_ups_voltage_warning_high" in expr for expr in voltage_exprs)
+
+
+@pytest.mark.unit
+def test_grafana_dashboard_overlays_events_via_annotations():
+    dashboard = json.loads((ROOT / "examples/grafana-dashboard.json").read_text())
+    annotations = {a["name"]: a for a in dashboard["annotations"]["list"]}
+
+    # Every event the user wants to correlate against the time-series
+    # panels has a Prometheus-sourced annotation. The exprs use ``> 0``
+    # / ``== 1`` so Grafana renders a region for the event window.
+    expected = {
+        "On battery": "eneru_ups_time_on_battery_seconds",
+        "Brownout": 'eneru_ups_voltage_state{state="LOW"',
+        "Over-voltage": 'eneru_ups_voltage_state{state="HIGH"',
+        "AVR engaged": 'eneru_ups_avr_state{state=~"BOOST|TRIM"',
+        "Bypass active": 'eneru_ups_bypass_state{state="ACTIVE"',
+        "Overload": 'eneru_ups_overload_state{state="ACTIVE"',
+        "Shutdown trigger": "eneru_ups_trigger_active",
+        "Connection failed": "eneru_ups_connection_failed",
+        "Remote health failed": 'eneru_remote_health_status{status="FAILED"',
+    }
+    for name, fragment in expected.items():
+        assert name in annotations, f"missing annotation: {name}"
+        assert annotations[name]["enable"] is True
+        assert fragment in annotations[name]["target"]["expr"], (
+            f"{name} expr does not contain {fragment!r}: "
+            f"{annotations[name]['target']['expr']}"
+        )
+
+
+@pytest.mark.unit
+def test_grafana_dashboard_has_ups_template_variable():
+    dashboard = json.loads((ROOT / "examples/grafana-dashboard.json").read_text())
+    variables = {var["name"]: var for var in dashboard["templating"]["list"]}
+
+    assert "ups" in variables, "expected $ups multi-select template variable"
+    ups_var = variables["ups"]
+    assert ups_var["multi"] is True
+    assert ups_var["includeAll"] is True
 
 
 @pytest.mark.unit
@@ -29,5 +87,8 @@ def test_architecture_diagram_viewbox_matches_content_width():
     match = re.search(r'viewBox="0 0 (?P<width>\d+) (?P<height>\d+)"', svg)
 
     assert match is not None
-    assert match.group("width") == "800"
+    # Rightmost drawn elements end at x=780 (the targets-zone rect at
+    # x=540 w=240, and the bottom strip rect at x=20 w=760). 782 leaves
+    # 2px of right padding without clipping anything.
+    assert match.group("width") == "782"
     assert match.group("height") == "550"

--- a/tests/test_remote_health.py
+++ b/tests/test_remote_health.py
@@ -258,6 +258,31 @@ def test_remote_health_records_only_status_transitions(tmp_path, remote_server):
 
 
 @pytest.mark.unit
+def test_remote_health_does_not_record_initial_healthy_baseline(tmp_path, remote_server):
+    config = Config()
+    config.remote_health.enabled = True
+    events = []
+    manager = RemoteHealthManager(
+        config=config,
+        group_label="Rack",
+        servers=[remote_server],
+        sidecar_path=tmp_path / "state.remote-health.json",
+        stop_event=threading.Event(),
+        log_fn=lambda msg: None,
+        event_fn=lambda etype, detail, notified: events.append(
+            (etype, detail, notified)
+        ),
+    )
+
+    with patch("eneru.remote_health.run_remote_probe",
+               return_value=(True, "", 8)):
+        rows = manager.check_once()
+
+    assert rows[0]["status"] == REMOTE_HEALTH_HEALTHY
+    assert events == []
+
+
+@pytest.mark.unit
 def test_remote_health_probe_command_is_validated_once(tmp_path, remote_server):
     config = Config()
     config.remote_health.enabled = True


### PR DESCRIPTION
## Summary

Bumps the working version to **5.4.0-rc0** and addresses five small observability issues collected after the 5.3.0 release.

### Issues addressed (from the original prompt)

1. **Spurious `REMOTE_HEALTH_HEALTHY` next to every `DAEMON_START`.** The initial `UNKNOWN -> HEALTHY` transition is now suppressed in `RemoteHealthManager._record_status_transition`. Startup *failures* (`UNKNOWN -> FAILED`) and later transitions (`FAILED -> HEALTHY`, etc.) still record. `UNKNOWN` is only ever the boot sentinel — it cannot occur mid-run — so the asymmetric suppression is safe.

2. **`/api/v1` returned a JSON 404 with no discovery.** Now returns an endpoint index (`{generatedAt, version, endpoints: [...]}`), and every JSON 404 includes the same `availableEndpoints` list. `/metrics` is omitted from both responses when `prometheus.enabled` is `false`, so we don't advertise an endpoint that genuinely returns 404.

3. **Grafana power-quality stat panel was ambiguous** (`max by (state) (eneru_ups_voltage_state) > 0`). Replaced with a `state-timeline` using the standard `eneru_ups_voltage_state == 1` idiom — voltage / AVR / bypass / overload transitions now read as a clean coloured timeline.

4. **"Show events" in Grafana.** The events Federico cares about (power cuts, brownouts, AVR, bypass, overload, shutdown triggers, connection failures, remote-health failures) are overlaid on every time-series panel via dashboard-wide Prometheus annotations. A power cut is now visible directly on the Battery-charge curve; a brownout on the Input/output voltage curve. No Grafana plugin required — the annotation source is the same Prometheus already used for the time-series. SQLite event rows with their full detail text remain available from `/api/v1/events` for tabular feeds.

5. **SVG architecture diagram had ~180px of right-side whitespace.** viewBox tightened in two passes: `960 -> 800` (in f36ab63), then `800 -> 782` here. Rightmost drawn element is at x=780 (the targets-zone rect at x=540 w=240, and the bottom strip rect at x=20 w=760), so 782 gives 2px of right padding without clipping anything.

### Other dashboard improvements

- Top "now" row: Battery-charge gauge, UPS-load gauge, Runtime-remaining stat with sparkline. Threshold colours: charge red <20 / yellow <50 / green ≥50; load green <70 / yellow <90 / red ≥90.
- Voltage panel overlays the configured nominal voltage alongside the existing low/high warning thresholds.
- New `\$ups` multi-select template variable for filtering when many UPSes are configured.
- Standalone "Event signals" and "Remote health failures" panels removed — annotations cover the same information in context.

### Code version

Bumped to `5.4.0-rc0` (`src/eneru/version.py`). `nfpm` builds a `eneru-5.4.0~rc0-1.noarch.rpm` cleanly with this version string.

## Test plan

- [x] `uv run pytest -m unit` — 1179 passed, 7 deselected (added: dashboard shape, annotation set, $ups template var, prometheus-disabled /metrics filter, initial healthy-baseline suppression)
- [x] `python -m json.tool examples/grafana-dashboard.json` — JSON validates
- [x] `bash -n tests/e2e/groups/single-ups.sh` — syntax OK (Test 43 now exercises `/api/v1` index + 404 with `availableEndpoints`)
- [x] `VERSION=5.4.0-rc0 nfpm package --packager rpm` — RPM built locally
- [ ] Import `examples/grafana-dashboard.json` into a Grafana with the test Prometheus and confirm annotations render where expected during a simulated `ON_BATTERY` window
- [ ] Eyeball `docs/images/eneru-diagram.svg` rendered in the browser — right margin should look intentional, not hollow
- [ ] Full E2E in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes observability for v5.4.0-rc1 with API discovery, clearer Grafana event overlays, and quieter remote-health logging. Also tightens the SVG and streamlines the dashboard for faster troubleshooting.

- **New Features**
  - `GET /api/v1` returns an index with `generatedAt`, `version`, and `endpoints`; JSON 404s include `availableEndpoints`. `/metrics` is omitted from both when Prometheus is disabled.
  - Grafana dashboard: overlays key events on all time-series (with title/description tooltips and hidden toolbar toggles); adds a “now” row (battery charge, UPS load, runtime); shows nominal voltage alongside thresholds; adds a `$ups` multi-select; drops the state‑timeline and redundant event panels; widens the temperature/battery panel.

- **Bug Fixes**
  - Suppress the initial `UNKNOWN -> HEALTHY` remote-health event at startup; other transitions still emit events.
  - Tighten `docs/images/eneru-diagram.svg` viewBox to 782×550 to remove right-side whitespace.

<sup>Written for commit f406e2e2ea05b3070d7d25f307a606da9c7c92bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/api/v1` endpoint index for API discovery and versioning.
  * Enhanced 404 responses to include available endpoints.
  * Upgraded Grafana dashboard with UPS-scoped filtering via template variables.

* **Bug Fixes**
  * Suppressed spurious remote health probe events on startup.
  * Corrected SVG diagram dimensions.

* **Documentation**
  * Updated changelog for v5.4.0-rc0.
  * Enhanced observability guide with Grafana dashboard variable and annotation details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/m4r1k/Eneru/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->