### PR TITLE
fix: repair OCI release image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,12 @@ jobs:
           IMAGE_NAME: ghcr.io/${{ github.repository }}
         run: |
           IMAGE_NAME="${IMAGE_NAME,,}"
+          # Docker installs the copied source with pip, and
+          # pyproject.toml derives the package version from this file.
+          # Keep the OCI image on the clean release version so the
+          # wheel metadata and exact image tag are both valid/simple.
+          sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" src/eneru/version.py
+          grep "__version__" src/eneru/version.py
           docker build --build-arg VERSION="$VERSION" -t "${IMAGE_NAME}:${VERSION}" .
 
       - name: Push OCI image to GHCR

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         docker.io \
         libvirt-clients \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-trixie
 
 ARG VERSION=dev
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ Homelabs, virtualization hosts (Proxmox, ESXi, libvirt), Docker/Podman container
 
 ### Installation
 
+**Docker / Podman:**
+```bash
+docker pull ghcr.io/m4r1k/eneru:latest
+
+docker run -d --name eneru \
+  --restart unless-stopped \
+  -p 9191:9191 \
+  -v /srv/eneru/config.yaml:/etc/ups-monitor/config.yaml:ro \
+  -v /srv/eneru/state:/var/lib/eneru \
+  -v /srv/eneru/run:/var/run/eneru \
+  -v /srv/eneru/ssh:/var/lib/eneru/ssh:ro \
+  ghcr.io/m4r1k/eneru:latest \
+  run --config /etc/ups-monitor/config.yaml \
+  --api --api-bind 0.0.0.0 --api-port 9191
+```
+
+Use `ghcr.io/m4r1k/eneru:testing` for pre-release builds. Run Eneru as root when it must manage local resources such as the local host, VMs, containers, or filesystems. Root is not needed for remote UPS monitoring and SSH shutdown.
+
 **PyPI:**
 ```bash
 pip install eneru[notifications]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [5.4.0-rc3] - Unreleased
+## [5.4.0-rc4] - Unreleased
 
 Release candidate for the v5.4 OCI image and Kubernetes deployment path.
 
@@ -27,6 +27,12 @@ Release candidate for the v5.4 OCI image and Kubernetes deployment path.
 - The README and docs now explain when to use the OCI image versus the systemd daemon, including Docker, Podman, SELinux volume labels, AppArmor/default confinement, and log collection through `docker logs` or `kubectl logs`.
 - `docs/containers-kubernetes.md` documents the OCI tag channels (`latest` for stable, `testing` for pre-release, exact `<version>` for either), and the Kubernetes / Docker samples now reference `:latest` so they don't need a per-release edit.
 - A dedicated logging section explains stdout capture (`docker logs`, `kubectl logs`) plus the `/var/log/eneru` forensics volume that survives container restarts (UID/GID 10001 ownership, `fsGroup: 10001` in the sample manifests).
+
+### rc4 — release workflow fixes
+- The release workflow now resets `src/eneru/version.py` to the clean release version before building the OCI image. Deb/rpm packages still keep the full code-display version with the short git hash, but Docker's in-image `pip install` now sees a valid PEP 440 package version.
+- Exact OCI tags now use the package version shape (`5.4.0`, `5.4.0-rc4`) while channel tags stay `latest` for stable releases and `testing` for pre-releases.
+- The Dockerfile runs `apt-get upgrade -y` after `apt-get update` so images pick up Debian security fixes available at build time.
+- The README now surfaces Docker first in the quick start while clarifying that root is only needed when Eneru manages local resources.
 
 ### rc3 — fixes from audit
 - New `ENERU_SKIP_PRIVILEGE_CHECK` env var downgrades the v5.4 root-required startup check to a printed warning. Intended for E2E suites and developers iterating on dry-run configs without sudo. Production containers don't set it, so the default safety guarantee for shipped images is unchanged. The E2E workflow exports it once at the matrix step level so eneru runs as the runner user — sudo-elevating eneru would leave its SQLite DB and state files root-owned and break any later test that reads them as the unprivileged runner.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@ Release candidate for the v5.4 OCI image and Kubernetes deployment path.
 - The release workflow now resets `src/eneru/version.py` to the clean release version before building the OCI image. Deb/rpm packages still keep the full code-display version with the short git hash, but Docker's in-image `pip install` now sees a valid PEP 440 package version.
 - Exact OCI tags now use the package version shape (`5.4.0`, `5.4.0-rc4`) while channel tags stay `latest` for stable releases and `testing` for pre-releases.
 - The Dockerfile runs `apt-get upgrade -y` after `apt-get update` so images pick up Debian security fixes available at build time.
+- The OCI image now uses the Python 3.12 slim Trixie base for a newer Debian userspace.
 - The README now surfaces Docker first in the quick start while clarifying that root is only needed when Eneru manages local resources.
 
 ### rc3 — fixes from audit

--- a/docs/containers-kubernetes.md
+++ b/docs/containers-kubernetes.md
@@ -18,7 +18,7 @@ Use the image for remote-only deployments: Eneru monitors NUT, exposes `/health`
 | `latest` | Latest stable release. Moves on each stable tag. Convenient for samples and quick starts. |
 | `testing` | Latest pre-release (rc/beta/alpha). Moves on each pre-release tag. |
 
-The samples below use `:latest` so they work without per-release edits. Pin to a specific `<version>` for production — `:latest` is convenient but not immutable, and rolling restarts on a moving tag can mix versions. When you pin a version, also flip `imagePullPolicy` from `Always` to `IfNotPresent` so pod restarts don't hit the registry on every reschedule. Pre-release builds never become `:latest`; they land at `:testing` and at their explicit `<version>` tag.
+The samples below use `:latest` so they work without per-release edits. Pin to a specific `<version>` tag for production — `:latest` is convenient but not immutable, and rolling restarts on a moving tag can mix versions. When you pin a version, also flip `imagePullPolicy` from `Always` to `IfNotPresent` so pod restarts don't hit the registry on every reschedule. Pre-release builds never become `:latest`; they land at `:testing` and at their explicit `<version>` tag.
 
 ## Remote-only Docker
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,7 +29,7 @@ Eneru uses unit tests, package-install tests, and end-to-end tests with real NUT
    ╱─────────────────────────────────────────────╲
 ```
 
-The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc3 pass,
+The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc4 pass,
 the local pytest suite contains 1483 tests. E2E tests are fewer, but they
 exercise the real service boundaries where packaging, NUT, SSH, Docker,
 filesystem, and CLI assumptions meet.

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.4.0-rc3"
+__version__ = "5.4.0-rc4"


### PR DESCRIPTION
Reset the source version to the clean release version before the Docker build so pip sees valid PEP 440 metadata, while deb/rpm builds keep their full short-hash display version.

Also bump the release candidate to rc4, document Docker-first installation, and refresh Debian packages during image builds.

Co-authored-by: Codex <noreply@openai.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OCI image build by resetting to a clean PEP 440 version so in-image `pip` installs use valid metadata. Bumps to 5.4.0-rc4 and updates docs to make Docker the primary install path.

- **Bug Fixes**
  - Release workflow resets `src/eneru/version.py` to `$VERSION` before `docker build` so `pyproject.toml` yields a valid PEP 440 version; deb/rpm builds keep the short-hash display version.
  - Exact OCI tags align with the package version (`5.4.0`, `5.4.0-rc4`); channel tags remain `latest` and `testing`.

- **Dependencies**
  - Switch OCI base image to `python:3.12-slim-trixie` for a newer Debian userspace.
  - `Dockerfile` runs `apt-get upgrade -y` after `apt-get update` to pick up security fixes during image builds.

<sup>Written for commit c5a495762d46b823e52f25a890d202767d63020a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

