### PR TITLE
chore: prepare 5.4.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker run -d --name eneru \
   --api --api-bind 0.0.0.0 --api-port 9191
 ```
 
-Use `ghcr.io/m4r1k/eneru:testing` for pre-release builds. Run Eneru as root when it must manage local resources such as the local host, VMs, containers, or filesystems. Root is not needed for remote UPS monitoring and SSH shutdown.
+Use `ghcr.io/m4r1k/eneru:testing` for pre-release builds. The OCI image is for remote UPS monitoring and SSH shutdown. Use a native host install when Eneru must manage the local host, VMs, containers, or filesystems.
 
 **PyPI:**
 ```bash
@@ -188,7 +188,7 @@ See the [full documentation](https://eneru.readthedocs.io/) for complete configu
 
 Eneru still works best as a native systemd daemon when it owns the local host shutdown sequence: stopping local VMs, stopping local Docker/Podman containers, syncing filesystems, and powering off the machine.
 
-v5.4 adds an official OCI image for remote-only and Kubernetes deployments. That scope now makes sense because Eneru can monitor NUT and orchestrate remote systems without root. If you configure `is_local: true` or local-host resources, the container must run as root with the required host access; otherwise startup fails clearly. Container shutdown also skips Eneru's own container so it does not stop itself mid-sequence.
+v5.4 adds an official OCI image for remote-only Docker, Podman, and Kubernetes deployments. Use it when Eneru monitors NUT, exposes API/health endpoints, publishes telemetry, and shuts down remote systems over SSH. Do not use the image for local-host ownership; install Eneru on the host instead.
 
 See the [container documentation](https://eneru.readthedocs.io/latest/containers-kubernetes/) for Docker, Podman, SELinux/AppArmor, and Kubernetes examples.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,54 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [5.4.0-rc4] - Unreleased
+## [5.4.0] - 2026-05-15
 
-Release candidate for the v5.4 OCI image and Kubernetes deployment path.
+Stable v5.4 release. This release adds the official container deployment path while keeping local host shutdown on native installs.
 
 ### Added
-- Official OCI image packaging for GHCR, with Docker and Podman smoke checks in CI and release-workflow publishing alongside deb/rpm packages.
-- `eneru run --api`, `--api-bind`, and `--api-port` so container healthchecks and Kubernetes probes can enable the read-only API without editing the YAML config.
-- `remote_servers[].ssh_key_path`, an explicit SSH identity-file path for container and Kubernetes volume mounts. Existing OpenSSH config and `ssh_options` behavior is unchanged.
-- Remote-only Kubernetes `Deployment` and `Pod` examples with non-root security contexts, `resources` requests/limits, and a `/var/log/eneru` log volume for forensic timeline data.
+- Official GHCR image for remote-only Docker, Podman, and Kubernetes deployments. The release workflow publishes exact `<version>` tags, `latest` for stable releases, and `testing` for pre-releases.
+- `eneru run --api`, `--api-bind`, and `--api-port`, so container healthchecks and Kubernetes probes can enable the read-only API without editing YAML.
+- `remote_servers[].ssh_key_path` for SSH private keys mounted from Docker bind mounts or Kubernetes Secrets.
+- Kubernetes `Deployment` and `Pod` examples with non-root security contexts, resource requests/limits, HTTP probes, SSH Secret mounts, and a `/var/log/eneru` volume for retained log files.
 
 ### Changed
-- Containerized Eneru is documented as a remote-only deployment path. Local-host ownership stays on native host installs where shutdown, VM, container, and filesystem operations run in the host environment.
-- Dependency checks are scoped to configured behavior: remote-only deployments no longer require local shutdown tooling, and the legacy `logger(1)` syslog side-channel is best effort.
-- The `examples/config-container-remote.yaml` starter config now ships with `logging.file: /var/log/eneru/ups-monitor.log` and a commented-out `remote_servers` block demonstrating `ssh_key_path` against a Kubernetes Secret / Docker bind-mount.
-
-### Documentation
-- The README and docs now explain when to use the OCI image versus the systemd daemon, including Docker, Podman, SELinux volume labels, AppArmor/default confinement, and log collection through `docker logs` or `kubectl logs`.
-- `docs/containers-kubernetes.md` documents the OCI tag channels (`latest` for stable, `testing` for pre-release, exact `<version>` for either), and the Kubernetes / Docker samples now reference `:latest` so they don't need a per-release edit.
-- A dedicated logging section explains stdout capture (`docker logs`, `kubectl logs`) plus the `/var/log/eneru` forensics volume that survives container restarts (UID/GID 10001 ownership, `fsGroup: 10001` in the sample manifests).
-
-### rc4 — release workflow fixes
-- The release workflow now resets `src/eneru/version.py` to the clean release version before building the OCI image. Deb/rpm packages still keep the full code-display version with the short git hash, but Docker's in-image `pip install` now sees a valid PEP 440 package version.
-- Exact OCI tags now use the package version shape (`5.4.0`, `5.4.0-rc4`) while channel tags stay `latest` for stable releases and `testing` for pre-releases.
-- The Dockerfile runs `apt-get upgrade -y` after `apt-get update` so images pick up Debian security fixes available at build time.
-- The OCI image now uses the Python 3.12 slim Trixie base for a newer Debian userspace.
-- The README now surfaces Docker first in the quick start while clarifying that the OCI image is for remote-only deployments.
-
-### rc3 — fixes from audit
-- New `ENERU_SKIP_PRIVILEGE_CHECK` env var downgrades the v5.4 root-required startup check to a printed warning for E2E suites and local dry-run development. Production containers don't set it.
-- K8s and Docker samples now reference `ghcr.io/m4r1k/eneru:latest` instead of the not-yet-existing `:5.4.0` tag, with `imagePullPolicy: Always` and a documented expectation that production users pin to `<version>` for immutability.
-- Kubernetes manifests gain `resources.requests` (50m CPU, 64Mi memory) and `resources.limits` (200m CPU, 128Mi memory) so copy-paste deployments don't run unbounded.
-- Container logging story documented end-to-end: stdout via `docker/podman/kubectl logs`, plus an opt-in `/var/log/eneru/ups-monitor.log` on a mounted volume.
-- `eneru validate` now reports the runtime context as one of `container (Docker)`, `container (Podman)`, `container`, `systemd service`, or `bare process`, so operators can confirm at a glance whether the deployment is running where they think it is.
-- Test coverage added for `eneru run` API CLI overrides, privilege checks, runtime-context detection, and OCI deployment behavior.
-
-## [5.4.0-rc1] - 2026-05-14
-
-Release candidate for the v5.4 observability polish pass.
-
-### Changed
-- `/api/v1` now returns an endpoint index, and JSON 404 responses include the same available-endpoints list. When Prometheus is disabled, `/metrics` is omitted from both responses so clients don't see an endpoint advertised that genuinely returns 404.
-- The reference Grafana dashboard overlays power, voltage, bypass, overload, AVR, shutdown-trigger, connection-failed, and remote-health-failed events on every time-series panel via dashboard-wide Prometheus annotations, so operators can correlate a battery-charge inflection or voltage dip with the event that caused it without leaving Grafana. Each annotation carries a tooltip title and description text so the event name is visible on hover, and the toolbar toggles are hidden so the dashboard chrome stays clean.
-- The dashboard adds a Battery-charge / UPS-load / Runtime-remaining "now" row (gauge + sparkline stat) and a `$ups` multi-select template variable for filtering when many UPSes are configured.
-- The voltage panel overlays the configured nominal voltage alongside the existing low/high warning thresholds.
+- The OCI image is remote-only by design. Use native deb/rpm or PyPI installs when Eneru must stop local VMs, local containers, filesystems, or the host itself.
+- Dependency checks now follow configured behavior: remote-only deployments no longer require local shutdown tooling, and the legacy `logger(1)` syslog side-channel is best effort.
+- The container image uses the Python 3.12 slim Trixie base and runs `apt-get upgrade -y` during builds so release images pick up current Debian fixes.
+- `/api/v1` now returns an endpoint index, and JSON 404 responses include the same endpoint list. When Prometheus is disabled, `/metrics` is omitted from both.
+- The reference Grafana dashboard adds power-event annotations, a battery/load/runtime "now" row, a `$ups` selector, and a nominal-voltage overlay.
+- `eneru validate` reports whether it is running in Docker, Podman, another container, systemd, or a bare process.
 
 ### Fixed
 - Remote-health startup probes no longer record a noisy `REMOTE_HEALTH_HEALTHY` event for the initial `UNKNOWN -> HEALTHY` baseline next to every `DAEMON_START`. Startup failures and later failure/recovery transitions are still recorded.
 - The SVG architecture diagram viewBox matches the drawn content width (782×550 instead of 960×550), removing the blank right-side margin in rendered docs.
+
+### Migration notes
+- Existing native installs can upgrade without YAML changes.
+- Use `ghcr.io/m4r1k/eneru:latest` for the latest stable image, `ghcr.io/m4r1k/eneru:testing` for pre-releases, or pin `ghcr.io/m4r1k/eneru:<version>` for immutable production deployments.
+- For local host shutdown, local VM/container teardown, or filesystem unmounts, keep Eneru on the host. The OCI image is for remote UPS monitoring, API/health endpoints, telemetry, and SSH shutdown of remote systems.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,8 +18,7 @@ Release candidate for the v5.4 OCI image and Kubernetes deployment path.
 - Remote-only Kubernetes `Deployment` and `Pod` examples with non-root security contexts, `resources` requests/limits, and a `/var/log/eneru` log volume for forensic timeline data.
 
 ### Changed
-- Containerized Eneru can run non-root for remote-only deployments. Startup now refuses local-host orchestration unless Eneru runs as root, so a Kubernetes or rootless Podman deployment fails clearly instead of half-running local shutdown steps it cannot execute.
-- Container shutdown now skips Eneru's own container automatically and skips compose stacks that include the running Eneru container.
+- Containerized Eneru is documented as a remote-only deployment path. Local-host ownership stays on native host installs where shutdown, VM, container, and filesystem operations run in the host environment.
 - Dependency checks are scoped to configured behavior: remote-only deployments no longer require local shutdown tooling, and the legacy `logger(1)` syslog side-channel is best effort.
 - The `examples/config-container-remote.yaml` starter config now ships with `logging.file: /var/log/eneru/ups-monitor.log` and a commented-out `remote_servers` block demonstrating `ssh_key_path` against a Kubernetes Secret / Docker bind-mount.
 
@@ -33,16 +32,15 @@ Release candidate for the v5.4 OCI image and Kubernetes deployment path.
 - Exact OCI tags now use the package version shape (`5.4.0`, `5.4.0-rc4`) while channel tags stay `latest` for stable releases and `testing` for pre-releases.
 - The Dockerfile runs `apt-get upgrade -y` after `apt-get update` so images pick up Debian security fixes available at build time.
 - The OCI image now uses the Python 3.12 slim Trixie base for a newer Debian userspace.
-- The README now surfaces Docker first in the quick start while clarifying that root is only needed when Eneru manages local resources.
+- The README now surfaces Docker first in the quick start while clarifying that the OCI image is for remote-only deployments.
 
 ### rc3 — fixes from audit
-- New `ENERU_SKIP_PRIVILEGE_CHECK` env var downgrades the v5.4 root-required startup check to a printed warning. Intended for E2E suites and developers iterating on dry-run configs without sudo. Production containers don't set it, so the default safety guarantee for shipped images is unchanged. The E2E workflow exports it once at the matrix step level so eneru runs as the runner user — sudo-elevating eneru would leave its SQLite DB and state files root-owned and break any later test that reads them as the unprivileged runner.
+- New `ENERU_SKIP_PRIVILEGE_CHECK` env var downgrades the v5.4 root-required startup check to a printed warning for E2E suites and local dry-run development. Production containers don't set it.
 - K8s and Docker samples now reference `ghcr.io/m4r1k/eneru:latest` instead of the not-yet-existing `:5.4.0` tag, with `imagePullPolicy: Always` and a documented expectation that production users pin to `<version>` for immutability.
 - Kubernetes manifests gain `resources.requests` (50m CPU, 64Mi memory) and `resources.limits` (200m CPU, 128Mi memory) so copy-paste deployments don't run unbounded.
 - Container logging story documented end-to-end: stdout via `docker/podman/kubectl logs`, plus an opt-in `/var/log/eneru/ups-monitor.log` on a mounted volume.
-- Self-container detection learns `/proc/self/mountinfo` as a third source. Modern Docker on cgroup v2 hosts enables cgroup namespaces by default, which collapses `/proc/self/cgroup` and `/proc/1/cgroup` to `0::/` with no extractable container ID. Docker bind-mounts `/etc/hostname`, `/etc/resolv.conf`, and `/etc/hosts` from `/var/lib/docker/containers/<id>/...`, and Podman uses `/var/lib/containers/storage/overlay-containers/<id>/...`; both survive cgroupns and let Eneru reliably skip its own container during shutdown.
 - `eneru validate` now reports the runtime context as one of `container (Docker)`, `container (Podman)`, `container`, `systemd service`, or `bare process`, so operators can confirm at a glance whether the deployment is running where they think it is.
-- Test coverage added: 18 unit tests for self-container detection (helper boundaries, cgroup v1/v2 parsing, mountinfo Docker/Podman/cgroupns, hostname fallback, missing-proc tolerance), 4 unit tests for `eneru run` API CLI overrides (each flag alone, CLI overrides YAML), 9 unit tests for privilege checks (root/non-root/non-Unix, parametrized per-feature, dormant-local-shutdown semantics), 6 unit tests for runtime-context detection.
+- Test coverage added for `eneru run` API CLI overrides, privilege checks, runtime-context detection, and OCI deployment behavior.
 
 ## [5.4.0-rc1] - 2026-05-14
 

--- a/docs/containers-kubernetes.md
+++ b/docs/containers-kubernetes.md
@@ -80,28 +80,11 @@ podman run -d --name eneru \
   --api --api-bind 0.0.0.0
 ```
 
-Rootless Podman works for remote-only deployments as long as the mounted state and SSH-key paths are readable by the container user. If you mount the host Docker or Podman socket for local container orchestration, that is no longer remote-only and must be treated as privileged local-host access.
+Rootless Podman works for remote-only deployments as long as the mounted state and SSH-key paths are readable by the container user.
 
 ## AppArmor
 
-The default Docker AppArmor profile is enough for remote-only Eneru because it needs ordinary network access and writable state directories. Do not disable AppArmor for remote-only deployments. Local-host orchestration is different: stopping host containers, VMs, filesystems, or the host itself requires additional host access and usually belongs on the native systemd install path.
-
-## Local-host orchestration in a container
-
-If you configure `is_local: true`, local shutdown, local VMs, local containers, or filesystem unmounts, Eneru must run as root. A non-root container exits at startup with the local feature that requires root.
-
-For local container shutdown, mount the relevant runtime socket and keep Eneru outside the shutdown target set where possible:
-
-```bash
-docker run -d --name eneru \
-  --user 0:0 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /srv/eneru/config.yaml:/etc/ups-monitor/config.yaml:ro \
-  -v /srv/eneru/state:/var/lib/eneru \
-  ghcr.io/m4r1k/eneru:latest
-```
-
-Eneru auto-detects and skips its own container during the remaining-container stop phase. If a configured compose file includes the Eneru container, Eneru skips `compose down` for that file to avoid killing itself.
+The default Docker AppArmor profile is enough for remote-only Eneru because it needs ordinary network access and writable state directories. Do not disable AppArmor for remote-only deployments. If Eneru must stop local VMs, local containers, filesystems, or the host itself, use a native host install instead of the OCI image.
 
 ## Kubernetes
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,7 +29,7 @@ Eneru uses unit tests, package-install tests, and end-to-end tests with real NUT
    ╱─────────────────────────────────────────────╲
 ```
 
-The pyramid is intentionally bottom-heavy. As of the v5.4.0-rc4 pass,
+The pyramid is intentionally bottom-heavy. As of the v5.4.0 pass,
 the local pytest suite contains 1483 tests. E2E tests are fewer, but they
 exercise the real service boundaries where packaging, NUT, SSH, Docker,
 filesystem, and CLI assumptions meet.

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.4.0-rc4"
+__version__ = "5.4.0"


### PR DESCRIPTION
## Summary
- document OCI as remote-only and keep local host shutdown on native installs
- bump Eneru to 5.4.0
- trim the v5.4 changelog into a stable release entry

## Verification
- source /tmp/eneru-venv/bin/activate && python -m eneru version
- source /tmp/eneru-venv/bin/activate && pytest -m unit tests/test_cli.py -q
- source /tmp/eneru-venv/bin/activate && pytest -m unit --cov=src/eneru --cov-report=term-missing
- git diff --check

Release notes draft: /tmp/release5-4.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 5.4.0 stable release: bumps the version, trims the changelog into a stable entry, and updates docs to state the OCI image is remote-only while native installs keep local host shutdown.

- **Migration**
  - No YAML changes required for native upgrades.
  - Use `ghcr.io/m4r1k/eneru:latest` for stable, `ghcr.io/m4r1k/eneru:testing` for pre-releases, or pin `ghcr.io/m4r1k/eneru:<version>` for production.
  - For local host shutdown, local VMs/containers, or filesystems, install Eneru on the host; use the container for remote UPS monitoring, API/health, telemetry, and SSH shutdown of remote systems.

<sup>Written for commit 92d699344b8dc16fa8c6ada69441a399af43bf2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

