### PR TITLE
fix: coalesce container lifecycle notifications

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.5.1] - 2026-05-19
+
+### Fixed
+
+- Container restarts and image upgrades now send one lifecycle
+  notification instead of "Service Stopped" followed by
+  Restarted/Upgraded. Container SIGTERM is like one doorbell wired to
+  several doors: Eneru cannot tell stop from upgrade, so it leaves the
+  stop row pending for the next container to supersede.
+- Added regression coverage for explicit legacy logging paths so
+  migrated configs keep rewriting to `/var/{log,run}/eneru/...` inside
+  containers.
+
+---
+
 ## [5.5.0] - 2026-05-18
 
 ### Added

--- a/docs/migrate-to-container.md
+++ b/docs/migrate-to-container.md
@@ -384,8 +384,9 @@ Eneru silently rewrites the four native-install defaults
 `/var/run/ups-battery-history`, `/var/run/ups-shutdown-scheduled`) to
 their `/var/{log,run}/eneru/` equivalents inside container runtimes so
 the daemon can write as uid 10001. The rewrite only fires when the
-config still matches the exact legacy default; setting any other value
-in your `logging:` block opts out and your value wins.
+config still matches the exact legacy value, whether that value came
+from the dataclass default or was written explicitly in your
+`logging:` block. Setting any other value opts out and your value wins.
 
 The rewrite applies on every config load, so the daemon (`run`) and
 every read-only subcommand (`validate`, `monitor` / `tui`, `shutdown
@@ -395,6 +396,22 @@ group`, `remote list`, …) all observe the same effective paths. If
 that predates this fix — upgrade to v5.5.0-rc8 or newer, or set the
 four `logging.*` paths explicitly to their `/var/{log,run}/eneru/...`
 values in your config to bypass the auto-rewrite entirely.
+
+## Lifecycle notifications during container upgrades
+
+Docker sends Eneru the same SIGTERM for `docker stop`, `docker restart`,
+and image replacement. Think of it like one doorbell wired to three
+doors: from inside the house, Eneru hears the bell but cannot see which
+door was used. To avoid sending "Service Stopped" followed by
+"Upgraded" during a container upgrade, containerized Eneru leaves the
+stop notification pending in SQLite. If a replacement container starts,
+its lifecycle sweep cancels that pending stop and sends the single
+Restarted/Upgraded message that matters.
+
+The practical tradeoff is that a final `docker stop eneru` without a
+replacement container may not send a standalone stop notification. The
+daemon still writes the shutdown marker and exits cleanly; the pending
+row is folded by the next start.
 
 ### Where state lives across container restarts
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,11 +80,11 @@ done
 | Config loading and validation | YAML parsing, defaults, enum validation, multi-UPS inheritance, local ownership, loopback delegation config shape, redundancy rules |
 | Monitor state machine | OL/OB transitions, FSD, failsafe, shutdown trigger order, dry-run behavior |
 | Shutdown mixins | VMs, containers, compose files, filesystem sync and unmounts, remote SSH phases, remote pre-shutdown action rendering, loopback delegate bracketing (Phase A pre-actions → regulars → Phase C poweroff), exception isolation across phases, dry-run + per-server notification paths |
-| CLI inspection vs runtime | `eneru validate` shutdown-sequence tree, `eneru remote list` ORDER column, `eneru shutdown remote` drill — all partition `is_host_loopback` delegates out of `compute_effective_order` and invoke `_prepare_runtime_config` so the inspection output matches what the daemon would execute |
+| CLI inspection vs runtime | `eneru validate` shutdown-sequence tree, `eneru remote list` ORDER column, `eneru shutdown remote` drill, container legacy-path rewrite — all partition `is_host_loopback` delegates out of `compute_effective_order` and invoke `_prepare_runtime_config` / `_load_config` so the inspection output matches what the daemon would execute |
 | Multi-UPS coordinator | Group routing, `is_local`, drain policy, local shutdown locking, signal handling |
 | Redundancy runtime | Quorum evaluation, advisory triggers, connection-grace handling, idempotent group execution |
 | Health monitoring | Voltage thresholds, AVR, bypass, overload, battery anomaly filtering |
-| Notifications | Formatting, retry queue, lifecycle classification, coalescing, suppression rules |
+| Notifications | Formatting, retry queue, lifecycle classification, coalescing, suppression rules, container restart/upgrade stop-row deferral |
 | Statistics and TUI | SQLite schema, aggregation, event tier filtering, TUI grouping, graphs, one-shot monitor output |
 | Observability | API routing, readiness, Prometheus escaping, power-quality metrics, remote-health sidecars, MQTT publishing |
 | Packaging | nFPM file list, package install paths, wrapper execution, OCI image smoke tests |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,7 +80,7 @@ done
 | Config loading and validation | YAML parsing, defaults, enum validation, multi-UPS inheritance, local ownership, loopback delegation config shape, redundancy rules |
 | Monitor state machine | OL/OB transitions, FSD, failsafe, shutdown trigger order, dry-run behavior |
 | Shutdown mixins | VMs, containers, compose files, filesystem sync and unmounts, remote SSH phases, remote pre-shutdown action rendering, loopback delegate bracketing (Phase A pre-actions → regulars → Phase C poweroff), exception isolation across phases, dry-run + per-server notification paths |
-| CLI inspection vs runtime | `eneru validate` shutdown-sequence tree, `eneru remote list` ORDER column, `eneru shutdown remote` drill, container legacy-path rewrite — all partition `is_host_loopback` delegates out of `compute_effective_order` and invoke `_prepare_runtime_config` / `_load_config` so the inspection output matches what the daemon would execute |
+| CLI inspection vs runtime | `python -m eneru validate` shutdown-sequence tree, `python -m eneru remote list` ORDER column, `python -m eneru shutdown remote` drill, container legacy-path rewrite — all partition `is_host_loopback` delegates out of `compute_effective_order` and invoke `_prepare_runtime_config` / `_load_config` so the inspection output matches what the daemon would execute |
 | Multi-UPS coordinator | Group routing, `is_local`, drain policy, local shutdown locking, signal handling |
 | Redundancy runtime | Quorum evaluation, advisory triggers, connection-grace handling, idempotent group execution |
 | Health monitoring | Voltage thresholds, AVR, bypass, overload, battery anomaly filtering |

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -30,11 +30,14 @@ When the timer fires:
   sends the row, and marks it ``sent``. The user gets a single
   ``🛑 Service Stopped`` notification.
 
-Fallback path: when ``systemd-run`` isn't available (non-systemd
-containers, frozen-pristine sandboxes), the helper falls back to
-shipping the stop synchronously via the worker's Apprise instance.
-This loses the restart-coalescing benefit on those hosts but at least
-the user always sees a notification.
+Fallback path: when ``systemd-run`` isn't available in a foreground
+non-container run, the helper falls back to shipping the stop
+synchronously via the worker's Apprise instance. Containers are the
+exception: Docker/Podman/Kubernetes send the same SIGTERM for a plain
+stop and for an upgrade/restart, and there is no service-manager timer
+outside the container to arbitrate intent. In that environment Eneru
+leaves the stop row pending so the replacement container can supersede
+it with one Restarted/Upgraded lifecycle notification.
 """
 
 from __future__ import annotations
@@ -88,10 +91,10 @@ def _eneru_invocation_args() -> Optional[list]:
 # entry points (`schedule_deferred_stop_or_eager_send` and
 # `deliver_pending_stop`) can stay as-is — the systemd-specific paths
 # are gated by `_running_under_systemd()` below, so non-systemd
-# environments naturally take the eager path with no code changes.
-# Anything more sophisticated for K8s (e.g., a sidecar that delivers
-# the row when the pod terminates) is a future-release concern, not
-# a v5.2.1 one.
+# environments need their own branch. A detached in-container helper
+# cannot reliably survive PID 1 exit / container removal, so Docker
+# restart coalescing is handled by leaving the stop row pending for the
+# next container's startup sweep.
 # ============================================================================
 
 def _running_under_systemd() -> bool:
@@ -103,6 +106,41 @@ def _running_under_systemd() -> bool:
     from a shell), and under most CI test environments.
     """
     return bool(os.environ.get("INVOCATION_ID"))
+
+
+def _running_in_container() -> bool:
+    """Best-effort container runtime check used before eager stop sends.
+
+    Kept local to this module instead of importing ``eneru.cli`` because
+    ``monitor.py`` imports this helper during module import, and ``cli.py``
+    imports ``monitor.py``. A shared runtime-detection module would be
+    cleaner eventually; this small detector covers the stop-notification
+    decision without introducing that cycle.
+    """
+    if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():
+        return True
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return True
+    if os.environ.get("container", "").strip():
+        return True
+
+    try:
+        cgroup_text = Path("/proc/1/cgroup").read_text(encoding="utf-8")
+    except OSError:
+        cgroup_text = ""
+    if any(marker in cgroup_text for marker in (
+        "docker", "kubepods", "containerd", "lxc",
+    )):
+        return True
+
+    try:
+        mountinfo = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
+    except OSError:
+        mountinfo = ""
+    return (
+        "/docker/containers/" in mountinfo
+        or "/containers/storage/overlay-containers/" in mountinfo
+    )
 
 
 def _detect_systemd_stop_intent() -> bool:
@@ -177,11 +215,18 @@ def schedule_deferred_stop_or_eager_send(
     # v5.2.1: short-circuit to eager send in two cases — both produce
     # an INSTANT 🛑 Stopped notification with no 15-second wait.
     #
-    # 1. Not running under systemd (containers, K8s pods, manual
-    #    `eneru run` from a shell, CI tests). The defer-then-ship
-    #    mechanism only makes sense when there's a service manager
-    #    that will or won't restart us. See the ROADMAP NOTE above.
+    # 1. Not running under systemd. Foreground non-container runs get an
+    #    eager stop because no replacement manager exists. Containers
+    #    keep the row pending because Docker/Podman/K8s use the same
+    #    SIGTERM shape for stop and upgrade/restart; the next daemon's
+    #    lifecycle sweep cancels it before delivery.
     if not _running_under_systemd():
+        if _running_in_container():
+            log_fn(
+                "📤 Container runtime without systemd — leaving stop "
+                "notification pending so the next daemon can supersede it"
+            )
+            return
         log_fn(
             "📤 Not running under systemd — shipping stop notification "
             "eagerly via Apprise"

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "5.5.0"
+__version__ = "5.5.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3778,6 +3778,38 @@ class TestLegacyContainerPathRewrite:
         assert config.logging.shutdown_flag_file == "/var/run/eneru/ups-shutdown-scheduled"
 
     @pytest.mark.unit
+    def test_explicit_legacy_paths_are_rewritten(self, tmp_path, capsys):
+        """Migration-guide contract: a native config that explicitly
+        spells the old defaults still gets the container-safe paths.
+
+        Like replacing a narrow pipe with a wider one: whether the old
+        pipe was installed by default or named in the plan, it still
+        has to be swapped before water can flow under the new pressure.
+        Here the "pressure" is uid 10001 in the OCI image, which cannot
+        write directly under /var/log or /var/run.
+        """
+        from eneru.cli import _rewrite_legacy_paths_for_container
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "ups:\n  name: 'TestUPS@localhost'\n"
+            "logging:\n"
+            "  file: /var/log/ups-monitor.log\n"
+            "  state_file: /var/run/ups-monitor.state\n"
+            "  battery_history_file: /var/run/ups-battery-history\n"
+        )
+        config = ConfigLoader.load(str(config_file))
+        with patch("eneru.cli._detect_runtime_context",
+                   return_value="container (Docker)"):
+            _rewrite_legacy_paths_for_container(config)
+
+        assert config.logging.file == "/var/log/eneru/ups-monitor.log"
+        assert config.logging.state_file == "/var/run/eneru/ups-monitor.state"
+        assert config.logging.battery_history_file == "/var/run/eneru/ups-battery-history"
+        assert config.logging.shutdown_flag_file == "/var/run/eneru/ups-shutdown-scheduled"
+        assert capsys.readouterr().err == ""
+
+    @pytest.mark.unit
     def test_silent_when_nothing_to_rewrite(self, tmp_path, capsys):
         """All four paths set explicitly to non-legacy values → no banner."""
         from eneru.cli import _rewrite_legacy_paths_for_container

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -12,6 +12,7 @@ from eneru.deferred_delivery import (
     _detect_systemd_stop_intent,
     _eager_send,
     _eneru_invocation_args,
+    _running_in_container,
     _running_under_systemd,
     deliver_pending_stop,
     schedule_deferred_stop_or_eager_send,
@@ -66,6 +67,35 @@ class TestRunningUnderSystemd:
     def test_false_when_invocation_id_empty(self):
         with patch.dict("os.environ", {"INVOCATION_ID": ""}, clear=False):
             assert _running_under_systemd() is False
+
+
+# ==============================================================================
+# _running_in_container
+# ==============================================================================
+
+class TestRunningInContainer:
+
+    @pytest.mark.unit
+    def test_true_when_dockerenv_exists(self):
+        def fake_exists(self):
+            return str(self) == "/.dockerenv"
+
+        with patch("pathlib.Path.exists", new=fake_exists), \
+             patch.dict("os.environ", {}, clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
+    def test_true_when_container_env_set(self):
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch.dict("os.environ", {"container": "docker"}, clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
+    def test_false_when_no_container_signal(self):
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch("pathlib.Path.read_text", side_effect=OSError), \
+             patch.dict("os.environ", {}, clear=True):
+            assert _running_in_container() is False
 
 
 # ==============================================================================
@@ -384,13 +414,14 @@ class TestScheduleDeferred:
 
 class TestScheduleShortCircuits:
     """The instant-eager paths added in v5.2.1 to drop the 15-second
-    notification latency on `systemctl stop` and in non-systemd
-    contexts (containers, K8s, manual `eneru run`)."""
+    notification latency on `systemctl stop` and in foreground
+    non-systemd contexts. Containers keep the row pending so the next
+    container can supersede it on restart/upgrade."""
 
     @pytest.mark.unit
-    def test_short_circuit_when_not_under_systemd(self, tmp_path):
+    def test_short_circuit_when_foreground_not_under_systemd(self, tmp_path):
         """No INVOCATION_ID env var → eager send, no systemd-run call,
-        no Job query. This is the K8s / Docker / foreground path."""
+        no Job query. This is the foreground `eneru run` path."""
         log = MagicMock()
         worker = MagicMock()
         worker._send_via_apprise.return_value = True
@@ -398,6 +429,8 @@ class TestScheduleShortCircuits:
         env = {k: v for k, v in __import__("os").environ.items()
                if k != "INVOCATION_ID"}
         with patch.dict("os.environ", env, clear=True), \
+             patch("eneru.deferred_delivery._running_in_container",
+                   return_value=False), \
              patch("eneru.deferred_delivery.subprocess.run") as run, \
              patch("eneru.stats.StatsStore.open"), \
              patch("eneru.stats.StatsStore.mark_notification_sent"), \
@@ -412,6 +445,33 @@ class TestScheduleShortCircuits:
         run.assert_not_called()
         worker._send_via_apprise.assert_called_once_with("🛑 stop", "warning")
         assert any("Not running under systemd" in c.args[0]
+                   for c in log.call_args_list)
+
+    @pytest.mark.unit
+    def test_container_without_systemd_leaves_stop_pending(self, tmp_path):
+        """Docker/Podman upgrades send SIGTERM like a plain stop. Since
+        there is no systemd-run timer outside the container, eager-send
+        would produce stop + upgraded. Leave the row pending so the next
+        daemon's lifecycle sweep can cancel it."""
+        log = MagicMock()
+        worker = MagicMock()
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "INVOCATION_ID"}
+        with patch.dict("os.environ", env, clear=True), \
+             patch("eneru.deferred_delivery._running_in_container",
+                   return_value=True), \
+             patch("eneru.deferred_delivery.subprocess.run") as run:
+            schedule_deferred_stop_or_eager_send(
+                notification_id=1,
+                db_path=tmp_path / "ups.db",
+                config_path="/etc/cfg.yaml",
+                body="🛑 stop", notify_type="warning",
+                worker=worker, log_fn=log,
+            )
+        run.assert_not_called()
+        worker._send_via_apprise.assert_not_called()
+        assert any("container runtime" in c.args[0].lower()
+                   and "pending" in c.args[0].lower()
                    for c in log.call_args_list)
 
     @pytest.mark.unit

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -85,9 +85,58 @@ class TestRunningInContainer:
             assert _running_in_container() is True
 
     @pytest.mark.unit
+    def test_true_when_containerenv_exists(self):
+        def fake_exists(self):
+            return str(self) == "/run/.containerenv"
+
+        with patch("pathlib.Path.exists", new=fake_exists), \
+             patch.dict("os.environ", {}, clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
+    def test_true_when_kubernetes_env_set(self):
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch.dict("os.environ",
+                        {"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+                        clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
     def test_true_when_container_env_set(self):
         with patch("pathlib.Path.exists", return_value=False), \
              patch.dict("os.environ", {"container": "docker"}, clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
+    def test_true_when_cgroup_contains_container_marker(self):
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch("pathlib.Path.read_text",
+                   return_value="12:cpuset:/docker/abc123\n"), \
+             patch.dict("os.environ", {}, clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
+    def test_true_when_mountinfo_contains_docker_path(self):
+        def fake_read_text(self, encoding="utf-8"):
+            if str(self) == "/proc/1/cgroup":
+                return ""
+            return "123 /var/lib/docker/containers/abc123/merged\n"
+
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch("pathlib.Path.read_text", new=fake_read_text), \
+             patch.dict("os.environ", {}, clear=True):
+            assert _running_in_container() is True
+
+    @pytest.mark.unit
+    def test_true_when_mountinfo_contains_podman_path(self):
+        def fake_read_text(self, encoding="utf-8"):
+            if str(self) == "/proc/1/cgroup":
+                return ""
+            return "123 /containers/storage/overlay-containers/abc/userdata\n"
+
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch("pathlib.Path.read_text", new=fake_read_text), \
+             patch.dict("os.environ", {}, clear=True):
             assert _running_in_container() is True
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary
- leave container stop lifecycle rows pending so restart/upgrade startup can supersede them
- keep systemd and foreground non-container stop behavior unchanged
- add regression coverage for explicit legacy log/run path rewrites
- bump version to 5.5.1

## Verification
- /tmp/eneru-venv/bin/python -m pytest
- /tmp/eneru-venv/bin/python -m pytest -m unit tests/test_cli.py::TestCLIVersion tests/test_deferred_delivery.py tests/test_cli.py::TestLegacyContainerPathRewrite -q
- git diff --check

## Local review
- Reviewed for correctness, architecture, security, performance, and test coverage; no blocking findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces container lifecycle notifications by leaving stop rows pending so restarts/upgrades emit a single event. Keeps systemd and foreground non-container behavior unchanged.

- **Bug Fixes**
  - Containers: defer stop notifications; the next container startup cancels the pending stop and sends one Restarted/Upgraded message.
  - Foreground non-systemd runs still send stop eagerly; systemd stop path remains as before.
  - Added container runtime detection helper and tests covering Docker/Podman/K8s signals; tests for stop-row deferral; regression coverage for explicit legacy `/var/{log,run}` path rewrites in configs.
  - Docs: added lifecycle-upgrade guidance and switched testing examples to `python -m` CLI; bump version to 5.5.1.

<sup>Written for commit d25290a252a8623fba43b545e809a48b07aecfad. Summary will update on new commits. <a href="https://cubic.dev/pr/m4r1k/Eneru/pull/59?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lifecycle notifications during container restarts and upgrades
  * Fixed legacy logging path rewriting in containerized deployments

* **Documentation**
  * Updated container upgrade and lifecycle notification guidance
  * Clarified legacy path auto-rewrite behavior for containers

* **Tests**
  * Added regression tests for container-specific path rewriting and lifecycle scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/m4r1k/Eneru/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->