### PR TITLE
fix: install auth extra in release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[notifications]"
+          pip install -e ".[notifications,auth]"
           pip install pytest pytest-cov pytest-mock
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- Install the auth extra in release.yml before running the full test suite
- Keeps release workflow dependency setup aligned with validate.yml for bcrypt-backed auth/user tests

## Verification
- /tmp/eneru-venv/bin/pytest tests/test_auth.py tests/test_api_auth.py tests/test_cli_user.py -q
- git diff --check

No local Docker run; release/package Docker validation should stay in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `.[notifications,auth]` in the release CI workflow before running tests. This aligns release with `validate.yml` and ensures bcrypt-backed auth and user CLI tests pass prior to packaging.

<sup>Written for commit 609662a649606af5f20aeaccec601fabc9c1d43b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

