### PR TITLE
fix: pre-release audit hardening (6.0.0-rc10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See the [full documentation](https://eneru.readthedocs.io/) for complete configu
 
 - Monitor one or more UPSes from a single instance, each with its own shutdown group
 - Real-time TUI dashboard (`eneru monitor`) with color-coded status
-- Shutdown triggers: battery %, runtime, depletion rate, time on battery, FSD flag
+- Shutdown triggers: battery %, runtime, depletion rate, time on battery, FSD flag, and the connection-loss failsafe (six in total)
 - Battery anomaly alerts for unexpected charge drops while on line power, with jitter filtering for APC, CyberPower, and Ubiquiti UniFi UPS units
 - Shuts down VMs, containers, remote servers, filesystems, and the local system in order
 - Notifications to 100+ services (Discord, Slack, Telegram, ntfy, email) via [Apprise](https://github.com/caronc/apprise/wiki)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,6 +77,52 @@ daemon *before* the host poweroff. Critical fixes:
   It is now a config error when local shutdown is enabled, with a defensive
   guard at both call sites.
 
+High fixes:
+
+- **Redundancy cold-start no longer drops a powered rack.** The evaluator's
+  time-based startup grace alone could fire a group shutdown when a member's NUT
+  server was merely slow to publish its first snapshot (UNKNOWN ->
+  unknown_counts_as=critical). It now holds the quorum decision until every
+  present member has reported at least once, bounded by a readiness deadline
+  derived from the per-member connection-loss grace; a member with no monitor at
+  all still counts immediately, and a genuinely dead UPS still fires once the
+  window passes.
+- **On-battery FAILSAFE no longer re-fires every poll.** In non-halting configs
+  (local shutdown disabled, dry-run, or loopback-delegated) the failsafe cleared
+  its flag and re-ran the entire remote/VM/container sequence on each failed
+  poll. A per-outage latch now runs it once per connection-loss event; it
+  re-arms on the next successful poll.
+- **A single transient NUT failure on battery no longer shuts the host down.**
+  Hard poll failures (connection refused, or a 30s upsc timeout) are now
+  debounced by `max_stale_data_tolerance` the same way stale data already was,
+  so a momentary blip can't drop a host riding out a survivable dip. Set
+  `max_stale_data_tolerance: 1` to restore instant fail-closed FSB. Off-battery
+  grace handling is unchanged.
+- **Drain phases can't abort the host poweroff.** Each local drain phase (VMs,
+  containers, sync, unmount) is wrapped so an exception is logged and the
+  sequence still reaches the poweroff -- a wedged libvirt or a bad value no
+  longer leaves the host running on a draining battery.
+- **Bounded filesystem sync.** `os.sync()` (which blocks until every mount
+  flushes) is replaced by a `sync` subprocess with a wall-clock timeout, so a
+  hung NFS/CIFS mount can't wedge the sequence before poweroff; the kernel
+  re-syncs at halt regardless.
+- **Drain-phase timeouts validated at load.** `virtual_machines.max_wait`,
+  `containers.stop_timeout`, and `filesystems.unmount.timeout` are now
+  type/range-checked (a quoted "30s" or a null value previously crashed the
+  phase or made `umount` hang forever); `run_command` also treats a `None`
+  timeout as the default bound.
+- **Remote poweroff can't be starved by a slow pre-shutdown phase.** The final
+  shutdown command now reserves its own budget before pre-shutdown commands
+  spend the phase deadline, and is skipped only if the *full* deadline is blown.
+- **SIGTERM/SIGINT during an in-flight shutdown** now waits a bounded,
+  config-derived deadline for the sequence (incl. the host poweroff) to finish
+  instead of abandoning it after 5s. **Duplicate `ups.name`** and **unknown
+  per-UPS / per-redundancy keys** (e.g. a misspelled `is_local`) are now rejected
+  at load.
+- **Depletion-rate trigger (T3) stays armed at slow poll intervals.** The
+  30-sample floor is now derived from `depletion.window / check_interval`, so a
+  larger `check_interval` no longer silently disables the fast-drain trigger.
+
 ---
 
 ## [5.5.1] - 2026-05-19

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,8 +35,9 @@ hot-reload. With authentication left off, the API stays read-only exactly as in
   commands and writable variables, wrapping `upscmd`/`upsrw` (no new dependency).
   Fail-closed — control cannot be enabled while authentication is off.
 - **Event management API.** Events carry a stable, never-reused `id` (stats schema
-  v5); `/api/v1/events` supports wide-range `from`/`to` queries and `(ts, id)`
-  cursor paging, and an authenticated `DELETE /api/v1/ups/{name}/events` removes
+  v5); `/api/v1/events` supports wide-range `from`/`to` queries and source-
+  qualified `(ts, source, id)` cursor paging, and an authenticated
+  `DELETE /api/v1/ups/{name}/events` removes
   selected rows. Existing databases migrate automatically on first start.
 - **Config hot-reload** without restarting the daemon — `systemctl reload eneru`,
   `SIGHUP` (`docker kill -s HUP`), or an authenticated `POST /api/v1/config/reload`.
@@ -187,6 +188,22 @@ already hysteresis-gated), the per-poll battery-history file write (a forensic
 record; cross-restart read-back is entangled with the on-battery deque reset),
 the `upsrw` SET timeout (operator-tunable via `nut_control.timeout`), and a
 couple of niche multi-daemon / degenerate-config edges.
+
+Nits:
+
+- `X-Content-Type-Options: nosniff` is now sent on every API response, not just
+  the dashboard HTML.
+- Passwords containing a NUL byte are rejected at creation (guards against older
+  bcrypt builds that truncated at NUL).
+- `nut_control` allowlist entries are validated against the NUT name charset at
+  config load.
+- `StatsStore.from_connection` no longer calls `.close()` on a connection that
+  was never opened (dead code relying on a swallowed exception).
+- The slow-SSH diagnostic no longer records two `REMOTE_SSH_SLOW_RESPONSE` rows
+  in a single cycle when a probe crosses both the log and the sustained-notify
+  thresholds at once.
+- Changelog wording: event paging uses a source-qualified `(ts, source, id)`
+  cursor (was written as `(ts, id)`).
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -154,6 +154,40 @@ Medium fixes:
 - The dashboard no longer offers a `redundancy:<name>` event-source filter that
   could never return rows (redundancy events aren't persisted to a stats DB).
 
+Low fixes:
+
+- Config validation now warns when `on_battery_stabilization_delay >=
+  critical_runtime_threshold` (the stabilization window would suppress the
+  runtime trigger for the whole remaining runtime).
+- A SIGTERM/SIGINT re-entrancy guard stops a second signal re-running teardown.
+- The VM-shutdown wait loop bounds each `virsh list` poll so a wedged libvirtd
+  can't blow the `max_wait` budget.
+- A FAILED remote server is no longer re-logged as "degraded" on every poll.
+- `_SAFE_NUT_VALUE` is anchored with `\Z` (a trailing newline no longer slips
+  through the upsrw value filter).
+- `StatsStore.query_range` validates the metric against an internal allowlist
+  before it reaches the interpolated SQL column position (defense-in-depth).
+- Derived `powerQuality` thresholds (nominal / warning band) report `null`
+  before the first poll instead of dataclass defaults that look like real data.
+- The dashboard survives connection loss (fetch errors show a "Connection lost"
+  banner instead of freezing the poll loop) and no longer rebuilds the control
+  panel every poll (which wiped half-typed values and re-fetched per UPS).
+- CLI: `user create` / `passwd` validate the username/role before prompting for
+  a password; `--password-stdin` keeps a password that legitimately ends in a
+  bare carriage return.
+- The hermetic notifications test no longer requires the optional `apprise`
+  extra to be installed; several brittle tests that re-implemented loop/guard
+  logic now drive the real code paths.
+- Docs: README trigger count matches its list; the configuration.md CLI table
+  lists the `user`/`apikey`/`shutdown`/`remote` subcommands.
+
+Evaluated and intentionally left as-is (documented): the per-transition voltage
+event log (a deliberate forensic record, bounded by retention; notifications are
+already hysteresis-gated), the per-poll battery-history file write (a forensic
+record; cross-restart read-back is entangled with the on-battery deque reset),
+the `upsrw` SET timeout (operator-tunable via `nut_control.timeout`), and a
+couple of niche multi-daemon / degenerate-config edges.
+
 ---
 
 ## [5.5.1] - 2026-05-19

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -130,10 +130,6 @@ Medium fixes:
   held "in flight" while the committed sequence runs outside the lock, so an
   unrelated group's power-restored event can't re-arm it mid-sequence and admit
   a second poweroff.
-- **Loopback host-identity is checked on the destructive path**, not only in the
-  background health loop: a failed/mismatched machine-id check now logs and
-  notifies right before the delegated drain/poweroff. It deliberately proceeds
-  (the loopback targets the local host, which must go down in an outage).
 - **Deleted admin can't keep control through a DB blip.** Write/control requests
   now re-check the session's account strictly and fail closed if the auth DB is
   unavailable; reads stay lenient and the token survives for when the DB returns.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -123,6 +123,37 @@ High fixes:
   30-sample floor is now derived from `depletion.window / check_interval`, so a
   larger `check_interval` no longer silently disables the fast-drain trigger.
 
+Medium fixes:
+
+- **No double local poweroff.** The coordinator's local-shutdown guard is now
+  held "in flight" while the committed sequence runs outside the lock, so an
+  unrelated group's power-restored event can't re-arm it mid-sequence and admit
+  a second poweroff.
+- **Loopback host-identity is checked on the destructive path**, not only in the
+  background health loop: a failed/mismatched machine-id check now logs and
+  notifies right before the delegated drain/poweroff. It deliberately proceeds
+  (the loopback targets the local host, which must go down in an outage).
+- **Deleted admin can't keep control through a DB blip.** Write/control requests
+  now re-check the session's account strictly and fail closed if the auth DB is
+  unavailable; reads stay lenient and the token survives for when the DB returns.
+- **Stats aggregation no longer corrupts the bucket straddling the retention
+  cutoff.** Purge cutoffs are aligned down to the next-tier bucket boundary so
+  only whole buckets are deleted.
+- **Graceful-exit notification can't block shutdown.** The eager Apprise send
+  from the signal handler runs on a short-lived thread with a hard timeout.
+- **Config safety warnings/validation.** A multi-UPS config with no `is_local`
+  group but `local_shutdown` enabled + `trigger_on: any` now warns; `local_shutdown`
+  gets the same unknown-key sweep as other safety sections.
+- **Health robustness.** Voltage auto-detect only samples on line power (a
+  startup brownout can't latch a depressed nominal); a non-positive NUT nominal
+  falls back to the default instead of flagging everything over-voltage; a
+  worsening battery anomaly no longer resets its own 3-poll confirmation; and the
+  depletion-rate input is clamped to [0, 100] against flaky firmware readings.
+- **Drain phases run best-effort** (shared with the High fix) so a failure can't
+  skip the host poweroff.
+- The dashboard no longer offers a `redundancy:<name>` event-source filter that
+  could never return rows (redundancy events aren't persisted to a stats DB).
+
 ---
 
 ## [5.5.1] - 2026-05-19

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,6 +52,31 @@ hot-reload. With authentication left off, the API stays read-only exactly as in
 - **NUT auto-discovery**, previously listed for 6.0, was dropped: it duplicates
   `nut-scanner` and does not fit Eneru's config-first model.
 
+### Fixed (rc10 — pre-release audit hardening)
+
+A structured whole-repository audit (see `docs/testing.md` → "Pre-release code
+review") hardened the shutdown decision path. The new auth/API/control surface
+held up; the residual risk was a config typo or a slow subsystem crashing the
+daemon *before* the host poweroff. Critical fixes:
+
+- **Multi-UPS drain no longer self-joins its own thread.** With
+  `drain_on_local_shutdown: true`, `_drain_all_groups` ran on the firing group's
+  monitor thread and tried to `join()` that same thread, raising `RuntimeError`
+  and aborting the sequence before the host poweroff — a missed local shutdown.
+  It now skips the current thread, so peers drain and the host still powers off.
+- **Shutdown-trigger thresholds are validated at load.** A non-numeric YAML
+  scalar (e.g. a quoted `"20"`, which templating tools emit routinely) survived
+  parse and raised `TypeError` on the first on-battery poll, killing the monitor
+  loop exactly when a shutdown was due. `low_battery_threshold`,
+  `critical_runtime_threshold`, `depletion.window/critical_rate/grace_period`,
+  and `extended_time.threshold` are now type/range-checked for every UPS and
+  redundancy group, so a bad value is a startup error, not a mid-outage crash.
+- **Empty/null `local_shutdown.command` is rejected at load.** `command:` with
+  no value parsed to `None` (and `""` yielded `run_command([])`), silently
+  skipping the host poweroff after VMs/containers/remotes were already drained.
+  It is now a config error when local shutdown is enabled, with a defensive
+  guard at both call sites.
+
 ---
 
 ## [5.5.1] - 2026-05-19

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -553,8 +553,8 @@ See [Remote servers](remote-servers.md) for SSH keys, sudoers, predefined action
 | `test-notifications` | Send one test notification |
 | `user {create,list,show,passwd,delete}` | Manage API/dashboard users (see [Authentication](authentication.md)) |
 | `apikey {create,list,revoke}` | Manage programmatic API keys (see [Authentication](authentication.md)) |
-| `shutdown` | Run a manual shutdown drill (remote / redundancy group) |
-| `remote` | List configured remote servers |
+| `shutdown {remote,group}` | Run a manual shutdown drill for one remote server or a full group |
+| `remote {list}` | List configured remote shutdown targets |
 | `completion {bash,zsh,fish}` | Print a shell completion script |
 | `version` | Print version |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -551,6 +551,10 @@ See [Remote servers](remote-servers.md) for SSH keys, sudoers, predefined action
 | `monitor` | Open the TUI dashboard |
 | `tui` | Alias for `monitor` |
 | `test-notifications` | Send one test notification |
+| `user {create,list,show,passwd,delete}` | Manage API/dashboard users (see [Authentication](authentication.md)) |
+| `apikey {create,list,revoke}` | Manage programmatic API keys (see [Authentication](authentication.md)) |
+| `shutdown` | Run a manual shutdown drill (remote / redundancy group) |
+| `remote` | List configured remote servers |
 | `completion {bash,zsh,fish}` | Print a shell completion script |
 | `version` | Print version |
 

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -417,6 +417,17 @@ with three additions:
    from the container's `/etc/machine-id` — operators bind-mount the
    host's value at the same path instead of supplying a literal
    string. Mismatch marks the loopback FAILED with a clear hint.
+
+   **At shutdown time (6.0.0+):** the identity guard also runs at the
+   *start of the delegated shutdown sequence*, not only in the
+   background health loop. If the probe fails or mismatches there,
+   Eneru logs a prominent warning and sends a notification — but it
+   **still proceeds with the poweroff**. The loopback always targets
+   `127.0.0.1` (this very host), which is exactly what must go down
+   during an outage; refusing would leave the host running on a
+   draining battery — a missed shutdown, the worse outcome. So treat
+   that warning as "fix your `/etc/machine-id` bind-mount", not as a
+   sign the shutdown was skipped.
 3. **Eneru generates `pre_shutdown_commands` for you.** Don't
    duplicate VM / container / filesystem actions on the loopback —
    Eneru translates the local config into the equivalent SSH

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -418,16 +418,14 @@ with three additions:
    host's value at the same path instead of supplying a literal
    string. Mismatch marks the loopback FAILED with a clear hint.
 
-   **At shutdown time (6.0.0+):** the identity guard also runs at the
-   *start of the delegated shutdown sequence*, not only in the
-   background health loop. If the probe fails or mismatches there,
-   Eneru logs a prominent warning and sends a notification — but it
-   **still proceeds with the poweroff**. The loopback always targets
-   `127.0.0.1` (this very host), which is exactly what must go down
-   during an outage; refusing would leave the host running on a
-   draining battery — a missed shutdown, the worse outcome. So treat
-   that warning as "fix your `/etc/machine-id` bind-mount", not as a
-   sign the shutdown was skipped.
+   The identity guard runs in the **background remote-health loop**
+   (and gates `/ready`), where a mismatch is logged and notified. It is
+   deliberately **not** run as a blocking probe at the start of the
+   shutdown sequence: that would add an SSH round-trip on the critical
+   path before the poweroff during an outage, and Eneru would proceed
+   regardless (the loopback targets `127.0.0.1` = this host, which must
+   go down), so the probe would only add latency. Fix a reported
+   mismatch from the health-loop warning, not at shutdown time.
 3. **Eneru generates `pre_shutdown_commands` for you.** Don't
    duplicate VM / container / filesystem actions on the loopback —
    Eneru translates the local config into the equivalent SSH

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -423,7 +423,7 @@ with three additions:
    deliberately **not** run as a blocking probe at the start of the
    shutdown sequence: that would add an SSH round-trip on the critical
    path before the poweroff during an outage, and Eneru would proceed
-   regardless (the loopback targets `127.0.0.1` = this host, which must
+   regardless (the configured host-loopback target is the host that must
    go down), so the probe would only add latency. Fix a reported
    mismatch from the health-loop warning, not at shutdown time.
 3. **Eneru generates `pre_shutdown_commands` for you.** Don't

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,45 @@ thousands of tests, all gated at ≥95% per-file line+branch coverage. E2E
 tests are fewer, but they exercise the real service boundaries where
 packaging, NUT, SSH, Docker, filesystem, and CLI assumptions meet.
 
+## Pre-release code review (v6.0.0)
+
+Automated tests prove the code does what a test author *thought to ask*. They
+do not, on their own, prove that nobody overlooked a way the daemon can drop a
+healthy host or miss a real outage. So before the v6.0.0 release the whole
+repository at HEAD — not just the release diff — went through a structured,
+adversarial audit on top of the test pyramid. Think of it as a second pair of
+eyes that is paid to assume every safety claim is wrong until it reads the code
+and proves otherwise.
+
+The audit was deliberately broad-then-deep:
+
+- **Fan-out.** Eighteen independent reviewers each took one subsystem — the
+  trigger evaluation and shutdown sequence, the multi-UPS coordinator and its
+  locks, the redundancy quorum math, every shutdown/health mixin, remote-health
+  flapping, the v6.0 API/auth/`nut_control`/dashboard surface, the SQLite stats
+  layer, config parsing and hot-reload, and the test suite itself — and read
+  the relevant files **in full**, not in excerpts.
+- **Adversarial verification.** Every Critical/High/Medium candidate was handed
+  to a second, independent reviewer whose job was to *refute* it by tracing the
+  real call path and looking for an upstream guard the first reviewer missed.
+  Only findings that survived that second pass were kept; one proposed High was
+  refuted this way and dropped.
+- **Maintainer confirmation.** The crown-jewel findings (the shutdown decision
+  path and the auth/control gate) were then re-read by hand against the live
+  code before any fix was written, so no fix rests solely on an automated claim.
+
+The pass classified findings as Critical / High / Medium / Low / Nit using a
+UPS-specific rubric where "false shutdown of a healthy host", "missed shutdown
+during a real outage", and "auth bypass to a control endpoint" are the
+Critical-tier outcomes. The headline result: the new v6.0 security surface
+(argv-only NUT control, bcrypt + CSPRNG tokens, parameterized SQL, a strict
+static-asset name check, and a write gate in front of every mutating route)
+held up well; the residual risk was concentrated in the shutdown decision path,
+where a plausible config typo or a slow/wedged subsystem could crash the daemon
+*before* the host poweroff. Every confirmed finding from that audit is fixed in
+the rc10 work, each accompanied by a regression test that fails against the
+pre-fix code, so the same class of bug cannot silently return.
+
 ## CI layout
 
 | Workflow | File | What it checks |

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -158,7 +158,9 @@ FSD is the highest-priority trigger. If `ups.status` includes `FSD`, Eneru start
 
 ## Failsafe battery protection
 
-If Eneru was on battery and then loses visibility of the UPS, it starts shutdown immediately. This is not configurable.
+If Eneru was on battery and then loses visibility of the UPS, it runs the
+shutdown sequence — it assumes the UPS may be near cut-off and a missed shutdown
+is worse than an early one.
 
 Examples:
 
@@ -167,7 +169,19 @@ Examples:
 - USB connection to the UPS fails.
 - The UPS stops returning fresh data.
 
-The connection-loss grace period only applies while the UPS is on line power. It does not delay failsafe shutdown.
+**A single transient blip does not trigger it (changed in 6.0.0).** Earlier
+releases fired the failsafe on the very first failed poll. A momentary
+connection refusal (e.g. an `upsd` restart) or a slow `upsc` call that hit its
+30-second timeout could therefore drop a host that was simply riding out a
+survivable dip. The failsafe now requires **`ups.max_stale_data_tolerance`
+consecutive failed polls** — the same debounce that stale data already used — so
+both failure kinds get the same number of chances. Set
+`ups.max_stale_data_tolerance: 1` to restore the old fire-on-first-error
+behaviour.
+
+The connection-loss grace period only applies while the UPS is on line power. It
+does not change the on-battery failsafe (the failsafe still ignores the grace
+window; it only adds the consecutive-failure debounce above).
 
 ### Failsafe timeline
 
@@ -175,8 +189,9 @@ The connection-loss grace period only applies while the UPS is on line power. It
 |------|-------|--------------|
 | Line power | NUT connection drops while previous UPS status is `OL` | Connection grace may suppress the notification |
 | Line power | NUT returns during grace | No shutdown. The recovery can count toward flap detection |
-| On battery | NUT connection drops while previous UPS status is `OB` | Failsafe bypasses grace and starts shutdown immediately |
-| Afterwards | UPS visibility remains lost | Eneru assumes the UPS may be near cut-off and runs the shutdown sequence |
+| On battery | A failed poll while previous UPS status is `OB` | Counts toward the failsafe; no shutdown yet (below tolerance) |
+| On battery | `max_stale_data_tolerance` consecutive failed polls while `OB` | Failsafe starts the shutdown sequence (grace window does not apply) |
+| Afterwards | UPS visibility remains lost | Eneru assumes the UPS may be near cut-off and continues the shutdown sequence |
 
 ## Voltage sensitivity
 

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -368,13 +368,16 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
                                       "application/json; charset=utf-8"))
         self.send_header("Content-Length", str(len(raw)))
         self.send_header("Cache-Control", "no-store")
+        # N2: nosniff on EVERY response (JSON/JS/CSS/HTML), not just HTML -- the
+        # dashboard's static assets are served with specific content types and
+        # must not be MIME-sniffed.
+        self.send_header("X-Content-Type-Options", "nosniff")
         if content_type == "text/html":
             # The dashboard ships no inline scripts/styles and loads nothing
             # third-party, so a strict same-origin CSP locks it down.
             self.send_header(
                 "Content-Security-Policy",
                 "default-src 'self'; base-uri 'none'; frame-ancestors 'none'")
-            self.send_header("X-Content-Type-Options", "nosniff")
         if status == 401:
             self.send_header("WWW-Authenticate", "Bearer")
         self.end_headers()

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -438,20 +438,33 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         api_key = self.headers.get("X-API-Key")
         return api_key.strip() if api_key else None
 
-    def _authenticate_request(self) -> Optional[Dict[str, Any]]:
-        """Resolve the caller from a session token, then an API key. None if neither."""
+    def _authenticate_request(self, *, strict: bool = False) -> Optional[Dict[str, Any]]:
+        """Resolve the caller from a session token, then an API key. None if neither.
+
+        ``strict`` is set for WRITE/control paths: when a session's user lookup
+        fails (auth DB unavailable) the request is denied rather than allowed, so
+        a deleted admin can't run control commands during a DB outage. Reads
+        stay lenient (``strict=False``) so a transient blip doesn't log out a
+        valid user. An *unknown* status never invalidates the token either way,
+        so a genuine session recovers once the DB is back (M4).
+        """
         token = self._bearer_token()
         if not token:
             return None
         if self.api_sessions is not None:
             principal = self.api_sessions.validate(token)
             if principal is not None:
-                if self._session_principal_still_valid(principal):
+                status = self._session_user_status(principal)
+                if status == "ok":
                     return principal
-                # The backing user was deleted while the session lived — kill the
-                # token so the client (and any later request) is forced to 401.
-                self.api_sessions.invalidate(token)
-                return None
+                if status == "gone":
+                    # The backing user was deleted while the session lived — kill
+                    # the token so the client (and any later request) 401s.
+                    self.api_sessions.invalidate(token)
+                    return None
+                # status == "unknown" (transient auth-DB error): writes fail
+                # closed, reads keep the session. Token left intact.
+                return None if strict else principal
         if self.api_auth is not None:
             try:
                 principal = self.api_auth.authenticate_api_key(token)
@@ -461,29 +474,29 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
                 return principal
         return None
 
-    def _session_principal_still_valid(self, principal: Dict[str, Any]) -> bool:
-        """Confirm a session's user account still exists.
+    def _session_user_status(self, principal: Dict[str, Any]) -> str:
+        """Return ``'ok'`` | ``'gone'`` | ``'unknown'`` for a session principal.
+
+        - ``'ok'``      -- the user exists (or this isn't a DB-backed user session)
+        - ``'gone'``    -- the user row is definitively absent (deleted)
+        - ``'unknown'`` -- the lookup raised (auth DB unavailable)
 
         Sessions are in-memory and outlive the DB row they were minted from, so a
-        deleted user would otherwise stay signed in until TTL. Only invalidate on
-        a *definitive* answer that the user is gone; if the lookup raises (auth DB
-        unavailable), keep the established session rather than logging out a valid
-        user on a transient error. Non-user principals (API keys) are re-checked
-        against the DB on their own path and never reach here.
+        deleted user would otherwise stay signed in until TTL. Non-user
+        principals (API keys) are re-checked against the DB on their own path.
         """
         if principal.get("kind") != "user":
-            return True
+            return "ok"
         store = self.api_auth
         if store is None:
-            return True
+            return "ok"
         username = principal.get("username")
         if not username:
-            return True
+            return "ok"
         try:
-            return store.get_user(username) is not None
+            return "ok" if store.get_user(username) is not None else "gone"
         except Exception:
-            # DB error / unavailable -> fail safe: keep the existing session.
-            return True
+            return "unknown"
 
     def _authorize(self, *, write: bool) -> Optional[Dict[str, Any]]:
         """Enforce the tiered auth policy. Returns the principal (may be None).
@@ -500,7 +513,8 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
                 raise APIForbidden(
                     "write operations require api.auth.enabled")
             return None
-        principal = self._authenticate_request()
+        # Writes re-check the user account strictly (fail closed on DB error).
+        principal = self._authenticate_request(strict=write)
         if write:
             if principal is None:
                 raise APIUnauthorized("authentication required")

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -41,7 +41,9 @@ _DASHBOARD_INDEX = "index.html"
 # enum words, voltages). upscmd/upsrw run via execve arg lists (never a shell),
 # so this is defense-in-depth, not the only barrier — but it keeps control
 # characters and shell-ish metacharacters out of the value entirely.
-_SAFE_NUT_VALUE = re.compile(r"^[A-Za-z0-9 ._:+%/,\-]{1,64}$")
+# L9: anchor with \Z, not $ -- in Python `$` also matches just before a trailing
+# newline, so "value\n" would slip through this defense-in-depth charset filter.
+_SAFE_NUT_VALUE = re.compile(r"\A[A-Za-z0-9 ._:+%/,\-]{1,64}\Z")
 # Strict response content-type whitelist (avoids header injection if a route
 # ever passes user data through as a content type).
 _CONTENT_TYPE_HEADERS = {

--- a/src/eneru/auth.py
+++ b/src/eneru/auth.py
@@ -88,6 +88,12 @@ def _prepare_password(password: str) -> bytes:
 def hash_password(password: str) -> str:
     """Return a bcrypt hash (self-describing ``$2b$…`` string) for ``password``."""
     bcrypt = require_bcrypt()
+    # N3: reject an embedded NUL. Shipped bcrypt 5.x hashes the whole 72-byte
+    # input, but some older builds truncated at the first NUL -- which would let
+    # "pw\x00anything" verify against a hash of "pw". Reject at creation so the
+    # store's behavior can't silently regress on an older distro bcrypt.
+    if "\x00" in password:
+        raise AuthError("password must not contain NUL bytes")
     return bcrypt.hashpw(_prepare_password(password), bcrypt.gensalt()).decode("ascii")
 
 

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -454,6 +454,13 @@ def _synthesize_loopback_if_needed(
         owner.remote_servers.append(synthesized)
     else:
         # Implicit single-UPS mode with no groups — attach to top-level.
+        # L18 (evaluated, degenerate-only): when ups_groups is EMPTY,
+        # config.remote_servers is a read-only property returning a throwaway
+        # list, so this append is lost and the daemon later aborts with a
+        # less-than-obvious "no loopback" error. A real config always has at
+        # least one UPS group (it's required to configure local capabilities),
+        # so this only bites a degenerate/empty config that fails to start
+        # anyway -- left as-is rather than fabricating a synthetic group.
         config.remote_servers.append(synthesized)
 
     print(

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -1607,8 +1607,11 @@ def _cmd_user_create(args):
     # L19: validate username + role BEFORE prompting for the password, so an
     # invalid name/role fails fast instead of after the operator types (and
     # confirms) a password that's about to be thrown away.
+    # Capture the NORMALIZED (stripped) name back into args (cubic): a
+    # whitespace-padded --username otherwise passes validation here but the
+    # success message and any later lookup key on the raw padded string.
     try:
-        auth._validate_username(args.username)
+        args.username = auth._validate_username(args.username)
         auth._validate_role(args.role)
     except auth.AuthError as exc:
         raise SystemExit(f"ERROR: {exc}")
@@ -1629,8 +1632,10 @@ def _cmd_user_passwd(args):
     """Reset a user's password."""
     store = _resolve_auth_store(args)
     # L19: validate the username format before prompting for the new password.
+    # Canonicalize to the normalized name (cubic): set_password() keys the SQL
+    # lookup on the exact string, so a padded name would prompt-then-miss.
     try:
-        auth._validate_username(args.username)
+        args.username = auth._validate_username(args.username)
     except auth.AuthError as exc:
         raise SystemExit(f"ERROR: {exc}")
     password, generated = _resolve_password(args)

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -1573,11 +1573,13 @@ def _resolve_password(args):
         return auth.generate_password(), True
     if getattr(args, "password_stdin", False):
         data = sys.stdin.read()
-        # Strip a single trailing newline (LF or CRLF — Windows/CI pipes send
-        # \r\n), preserving any other characters the password may contain.
-        if data.endswith("\n"):
-            data = data[:-1]
-        if data.endswith("\r"):
+        # Strip a single trailing LINE TERMINATOR (CRLF from Windows/CI pipes,
+        # or LF), preserving every other character. L20: a BARE trailing "\r"
+        # (no following "\n") is NOT a line terminator -- it's a legitimate
+        # password character -- so it must be kept, not stripped.
+        if data.endswith("\r\n"):
+            data = data[:-2]
+        elif data.endswith("\n"):
             data = data[:-1]
         password = data
         if not password:
@@ -1595,6 +1597,14 @@ def _resolve_password(args):
 def _cmd_user_create(args):
     """Create a local user account."""
     store = _resolve_auth_store(args)
+    # L19: validate username + role BEFORE prompting for the password, so an
+    # invalid name/role fails fast instead of after the operator types (and
+    # confirms) a password that's about to be thrown away.
+    try:
+        auth._validate_username(args.username)
+        auth._validate_role(args.role)
+    except auth.AuthError as exc:
+        raise SystemExit(f"ERROR: {exc}")
     password, generated = _resolve_password(args)
     try:
         store.create_user(args.username, password, role=args.role)
@@ -1611,6 +1621,11 @@ def _cmd_user_create(args):
 def _cmd_user_passwd(args):
     """Reset a user's password."""
     store = _resolve_auth_store(args)
+    # L19: validate the username format before prompting for the new password.
+    try:
+        auth._validate_username(args.username)
+    except auth.AuthError as exc:
+        raise SystemExit(f"ERROR: {exc}")
     password, generated = _resolve_password(args)
     try:
         store.set_password(args.username, password)

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1419,12 +1419,31 @@ class ConfigLoader:
             _validate_remote_servers(
                 "remote_servers", raw_data.get("remote_servers", []),
             )
+            # Per-UPS-entry top-level keys. Every other section gets a strict
+            # unknown-key sweep; without this one a typo like `is_locl: true`
+            # silently parses the group as non-local (is_local defaults False),
+            # disabling local-host self-protection while the operator believes
+            # it is on. Mirror the contract: misspelled safety keys must error.
+            ups_entry_keys = {
+                "name", "display_name", "check_interval",
+                "max_stale_data_tolerance", "connection_loss_grace_period",
+                "is_local", "triggers", "remote_servers", "virtual_machines",
+                "containers", "filesystems", "nut_control",
+            }
+            redundancy_entry_keys = {
+                "name", "ups_sources", "min_healthy", "degraded_counts_as",
+                "unknown_counts_as", "is_local", "triggers", "remote_servers",
+                "virtual_machines", "containers", "filesystems",
+            }
             ups_raw = raw_data.get("ups")
             if isinstance(ups_raw, list):
                 for idx, entry in enumerate(ups_raw):
                     if not isinstance(entry, dict):
                         continue
                     label = entry.get("name", idx)
+                    messages.extend(cls._unknown_key_errors(
+                        f"ups[{label!r}]", entry, ups_entry_keys,
+                    ))
                     _validate_triggers(
                         f"ups[{label!r}].triggers",
                         entry.get("triggers", {}),
@@ -1439,6 +1458,10 @@ class ConfigLoader:
                     if not isinstance(entry, dict):
                         continue
                     label = entry.get("name", idx)
+                    messages.extend(cls._unknown_key_errors(
+                        f"redundancy_groups[{label!r}]", entry,
+                        redundancy_entry_keys,
+                    ))
                     group_triggers = entry.get("triggers", {})
                     _validate_triggers(
                         f"redundancy_groups[{label!r}].triggers",
@@ -1712,6 +1735,37 @@ class ConfigLoader:
             _check_trigger_numbers(
                 f"redundancy_groups[{(rg.name or '(unnamed)')!r}]", rg.triggers)
 
+        # Drain-phase timeouts feed `while time_waited < max_wait`,
+        # `stop_timeout + 30`, and subprocess timeouts during shutdown. A
+        # non-int (quoted "30s") crashes the phase mid-sequence; a null
+        # unmount.timeout becomes subprocess.run(timeout=None) -> a busy umount
+        # hangs forever. Validate them at load so the host still powers off.
+        def _check_drain_timeouts(label: str, grp):
+            mw = grp.virtual_machines.max_wait
+            if not cls._is_int_nonbool_in_range(mw, minimum=0):
+                messages.append(
+                    f"ERROR: {label}.virtual_machines.max_wait must be a "
+                    f"non-negative integer, got {mw!r}."
+                )
+            st = grp.containers.stop_timeout
+            if not cls._is_int_nonbool_in_range(st, minimum=0):
+                messages.append(
+                    f"ERROR: {label}.containers.stop_timeout must be a "
+                    f"non-negative integer, got {st!r}."
+                )
+            ut = grp.filesystems.unmount.timeout
+            if not cls._is_int_nonbool_in_range(ut, minimum=1):
+                messages.append(
+                    f"ERROR: {label}.filesystems.unmount.timeout must be an "
+                    f"integer >= 1, got {ut!r}."
+                )
+
+        for group in config.ups_groups:
+            _check_drain_timeouts(f"ups[{group.ups.label!r}]", group)
+        for rg in config.redundancy_groups:
+            _check_drain_timeouts(
+                f"redundancy_groups[{(rg.name or '(unnamed)')!r}]", rg)
+
         # Multi-UPS validation
         if config.multi_ups:
             # Check ownership: non-local groups must not have local resources
@@ -1753,6 +1807,27 @@ class ConfigLoader:
             messages.append(
                 f"ERROR: Multiple groups marked as is_local: {', '.join(all_local)}. "
                 "At most one group (UPS or redundancy) can power the Eneru host."
+            )
+
+        # ups.name uniqueness. The name keys the per-group stats DB path, the
+        # state-file suffix, the monitors-by-name routing dict, and redundancy
+        # member resolution -- duplicates corrupt or cross-wire all of those.
+        # Dedup on the SANITIZED name actually used for filenames, so two names
+        # differing only in @/:/ (which sanitize to the same file) still collide.
+        def _sanitize_name(n: str) -> str:
+            return (n or "").replace("@", "-").replace(":", "-").replace("/", "-")
+
+        seen_ups_names: Dict[str, int] = {}
+        for group in config.ups_groups:
+            key = _sanitize_name(group.ups.name)
+            seen_ups_names[key] = seen_ups_names.get(key, 0) + 1
+        dup_ups = sorted(k for k, c in seen_ups_names.items() if c > 1)
+        if dup_ups:
+            messages.append(
+                "ERROR: duplicate UPS name(s) across ups_groups: "
+                f"{', '.join(dup_ups)}. Each ups.name must be unique -- it keys "
+                "the stats DB, state file, API command routing, and redundancy "
+                "membership."
             )
 
         # is_host_loopback uniqueness + per-entry rules. Runtime-context checks

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1660,6 +1660,58 @@ class ConfigLoader:
                     f"non-negative integer, got {delay!r}."
                 )
 
+        # Shutdown-trigger numeric fields feed direct comparisons in the
+        # on-battery hot path (monitor._handle_on_battery, health/battery.py).
+        # A non-numeric YAML scalar -- most commonly a quoted "20", which
+        # templating tools (Ansible/Helm/envsubst) emit routinely -- survives
+        # parse as a str and raises TypeError on the FIRST on-battery poll,
+        # killing the monitor loop exactly when a shutdown decision is due.
+        # Validate every group's PARSED triggers so a bad value is a startup
+        # error, never a mid-outage crash.
+        def _check_trigger_numbers(label: str, t: TriggersConfig):
+            if not cls._is_int_nonbool_in_range(
+                    t.low_battery_threshold, minimum=0, maximum=100):
+                messages.append(
+                    f"ERROR: {label}.triggers.low_battery_threshold must be an "
+                    f"integer between 0 and 100, got {t.low_battery_threshold!r}."
+                )
+            if not cls._is_int_nonbool_in_range(
+                    t.critical_runtime_threshold, minimum=0):
+                messages.append(
+                    f"ERROR: {label}.triggers.critical_runtime_threshold must be "
+                    f"a non-negative integer, got {t.critical_runtime_threshold!r}."
+                )
+            if not cls._is_int_nonbool_in_range(t.depletion.window, minimum=1):
+                messages.append(
+                    f"ERROR: {label}.triggers.depletion.window must be an integer "
+                    f">= 1, got {t.depletion.window!r}."
+                )
+            rate = t.depletion.critical_rate
+            if (isinstance(rate, bool) or not isinstance(rate, (int, float))
+                    or rate <= 0):
+                messages.append(
+                    f"ERROR: {label}.triggers.depletion.critical_rate must be a "
+                    f"number greater than 0, got {rate!r}."
+                )
+            if not cls._is_int_nonbool_in_range(
+                    t.depletion.grace_period, minimum=0):
+                messages.append(
+                    f"ERROR: {label}.triggers.depletion.grace_period must be a "
+                    f"non-negative integer, got {t.depletion.grace_period!r}."
+                )
+            if not cls._is_int_nonbool_in_range(
+                    t.extended_time.threshold, minimum=0):
+                messages.append(
+                    f"ERROR: {label}.triggers.extended_time.threshold must be a "
+                    f"non-negative integer, got {t.extended_time.threshold!r}."
+                )
+
+        for group in config.ups_groups:
+            _check_trigger_numbers(f"ups[{group.ups.label!r}]", group.triggers)
+        for rg in config.redundancy_groups:
+            _check_trigger_numbers(
+                f"redundancy_groups[{(rg.name or '(unnamed)')!r}]", rg.triggers)
+
         # Multi-UPS validation
         if config.multi_ups:
             # Check ownership: non-local groups must not have local resources
@@ -2023,6 +2075,19 @@ class ConfigLoader:
                 f"ERROR: local_shutdown.trigger_on must be 'any' or 'none', "
                 f"got '{config.local_shutdown.trigger_on}'"
             )
+
+        # local_shutdown.command is the host poweroff itself. `command:` with a
+        # null value parses to None (the default only applies to an ABSENT key),
+        # and an empty string yields run_command([]) -- both silently skip the
+        # poweroff AFTER VMs/containers/remotes were already drained. Reject a
+        # missing/empty command at load when local shutdown is enabled.
+        if config.local_shutdown.enabled:
+            cmd = config.local_shutdown.command
+            if not isinstance(cmd, str) or not cmd.strip():
+                messages.append(
+                    "ERROR: local_shutdown.command must be a non-empty string "
+                    f"when local_shutdown.enabled is true, got {cmd!r}."
+                )
 
         # api.auth.session_ttl and nut_control.timeout are coerced with int()
         # downstream (SessionManager, subprocess timeouts) — validate here so a

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1470,6 +1470,15 @@ class ConfigLoader:
                     messages.extend(cls._unknown_key_errors(
                         f"ups[{label!r}]", entry, ups_entry_keys,
                     ))
+                    # Also sweep the nested connection_loss_grace_period sub-keys
+                    # -- it's a safety sub-section, so a typo there must error too
+                    # rather than silently fall back to defaults (cubic P2).
+                    clgp = entry.get("connection_loss_grace_period")
+                    if isinstance(clgp, dict):
+                        messages.extend(cls._unknown_key_errors(
+                            f"ups[{label!r}].connection_loss_grace_period",
+                            clgp, {"enabled", "duration", "flap_threshold"},
+                        ))
                     _validate_triggers(
                         f"ups[{label!r}].triggers",
                         entry.get("triggers", {}),
@@ -1806,6 +1815,23 @@ class ConfigLoader:
         for rg in config.redundancy_groups:
             _check_drain_timeouts(
                 f"redundancy_groups[{(rg.name or '(unnamed)')!r}]", rg)
+
+        # ups.check_interval and ups.max_stale_data_tolerance feed the poll loop
+        # and the failsafe debounce comparisons. A non-int (quoted "1") would
+        # TypeError there; validate at load. (cubic P1 follow-up to H3.)
+        for group in config.ups_groups:
+            ci = group.ups.check_interval
+            if not cls._is_int_nonbool_in_range(ci, minimum=1):
+                messages.append(
+                    f"ERROR: ups[{group.ups.label!r}].check_interval must be an "
+                    f"integer >= 1, got {ci!r}."
+                )
+            mst = group.ups.max_stale_data_tolerance
+            if not cls._is_int_nonbool_in_range(mst, minimum=1):
+                messages.append(
+                    f"ERROR: ups[{group.ups.label!r}].max_stale_data_tolerance "
+                    f"must be an integer >= 1, got {mst!r}."
+                )
 
         # Multi-UPS validation
         if config.multi_ups:

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1293,6 +1293,15 @@ class ConfigLoader:
             messages.extend(cls._unknown_key_errors(
                 "behavior", raw_data.get("behavior", {}), {"dry_run"},
             ))
+            # M13: local_shutdown is a safety section -- its parser defaults
+            # `enabled` to True, so a misspelled key would silently leave local
+            # poweroff enabled. Sweep it for unknown keys like every other
+            # safety section (configuration.md promises typos are caught).
+            messages.extend(cls._unknown_key_errors(
+                "local_shutdown", raw_data.get("local_shutdown", {}),
+                {"enabled", "command", "message", "drain_on_local_shutdown",
+                 "trigger_on", "wall"},
+            ))
             messages.extend(cls._unknown_key_errors(
                 "api", raw_data.get("api", {}),
                 {"enabled", "bind", "port", "auth"},
@@ -1807,6 +1816,23 @@ class ConfigLoader:
             messages.append(
                 f"ERROR: Multiple groups marked as is_local: {', '.join(all_local)}. "
                 "At most one group (UPS or redundancy) can power the Eneru host."
+            )
+
+        # M7: multi-UPS with NO is_local group, local shutdown enabled, and the
+        # default trigger_on='any' means ANY monitored UPS going critical (even
+        # one powering only a remote server) will run the local poweroff. That's
+        # rarely intended; warn so the operator confirms it (or marks a group
+        # is_local / sets trigger_on: none). A single-UPS config implicitly owns
+        # local resources, so this only applies to the multi-UPS topology.
+        if (config.multi_ups and not all_local
+                and config.local_shutdown.enabled
+                and config.local_shutdown.trigger_on == "any"):
+            messages.append(
+                "WARNING: multi-UPS config has no is_local group but "
+                "local_shutdown is enabled with trigger_on='any' -- ANY UPS "
+                "going critical will power off this host. Mark the owning group "
+                "is_local, or set local_shutdown.trigger_on: none, to confirm "
+                "this is intended."
             )
 
         # ups.name uniqueness. The name keys the per-group stats DB path, the

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1338,11 +1338,28 @@ class ConfigLoader:
                 if not isinstance(block, dict):
                     return
                 messages.extend(cls._unknown_key_errors(label, block, _nc_keys))
+                # N4: NUT command/variable names are dotted alphanumerics. Reject
+                # an allowlist entry with spaces / shell metacharacters / '=' at
+                # load (a typo'd entry would otherwise flow verbatim into the
+                # upscmd/upsrw argv). Not an injection (argv, not shell), but
+                # catching it here turns a silent no-op into a startup error.
+                _nut_name_chars = set(
+                    "abcdefghijklmnopqrstuvwxyz"
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._+-")
                 for list_key in ("allowed_commands", "allowed_variables"):
                     val = block.get(list_key)
-                    if val is not None and not isinstance(val, list):
+                    if val is None:
+                        continue
+                    if not isinstance(val, list):
                         messages.append(
                             f"ERROR: {label}.{list_key} must be a list")
+                        continue
+                    for entry in val:
+                        if not (isinstance(entry, str) and entry
+                                and all(c in _nut_name_chars for c in entry)):
+                            messages.append(
+                                f"ERROR: {label}.{list_key} entry {entry!r} is not "
+                                "a valid NUT name (letters, digits, . _ + - only)")
                 t = block.get("timeout")
                 if t is not None and (isinstance(t, bool) or not isinstance(t, int)
                                       or t < 1):

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1737,6 +1737,21 @@ class ConfigLoader:
                     f"ERROR: {label}.triggers.extended_time.threshold must be a "
                     f"non-negative integer, got {t.extended_time.threshold!r}."
                 )
+            # L2: relationship check -- a stabilization window >= the
+            # critical-runtime threshold suppresses the runtime trigger for the
+            # entire remaining runtime, so the host could die on battery before
+            # the window ever opens. Warn (don't reject -- it can be deliberate).
+            sd = t.on_battery_stabilization_delay
+            crt = t.critical_runtime_threshold
+            if (cls._is_int_nonbool_in_range(sd, minimum=0)
+                    and cls._is_int_nonbool_in_range(crt, minimum=1)
+                    and sd >= crt):
+                messages.append(
+                    f"WARNING: {label}.triggers.on_battery_stabilization_delay "
+                    f"({sd}s) >= critical_runtime_threshold ({crt}s): the "
+                    "stabilization window can suppress the runtime trigger for "
+                    "the whole remaining runtime. Consider lowering the delay."
+                )
 
         for group in config.ups_groups:
             _check_trigger_numbers(f"ups[{group.ups.label!r}]", group.triggers)

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -338,9 +338,17 @@ def _eager_send(
         log_fn(f"⚠️ Eager-send via Apprise raised: {e}")
         return
     if not success:
+        # At-least-once by design (cubic): a bounded send that TIMED OUT may
+        # still complete on its abandoned background thread, yet we return here
+        # and leave the row pending so the next start retries -- which can yield
+        # ONE duplicate "Service Stopped" notification. That is deliberate: for a
+        # stop notification a possible duplicate is strictly preferable to silent
+        # loss, and we must not block daemon exit to learn the orphan thread's
+        # real outcome (the whole point of the bounded send, M6).
         log_fn(
-            "⚠️ Eager-send via Apprise returned False (network down?) "
-            "— stop notification stays pending for the next start"
+            "⚠️ Eager-send via Apprise returned False/timed out (network down?) "
+            "— stop notification stays pending for the next start "
+            "(a duplicate is possible if a timed-out send later completes)"
         )
         return
     try:

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -331,7 +331,9 @@ def _eager_send(
         # method (see notifications.py); we reach in deliberately
         # rather than re-instantiating an Apprise object because the
         # worker has already validated the URLs at startup.
-        success = worker._send_via_apprise(body, notify_type)
+        # Bounded (M6): the eager send can run from the signal handler; a hung
+        # endpoint must not block daemon exit. Times out -> row stays pending.
+        success = worker._send_via_apprise_bounded(body, notify_type)
     except Exception as e:  # pragma: no cover -- defensive
         log_fn(f"⚠️ Eager-send via Apprise raised: {e}")
         return

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -52,7 +52,20 @@ class BatteryMonitorMixin:
                 f"⚠️ Battery history persist failed: {exc}"
             )
 
-        if len(self.state.battery_history) < 30:
+        # Historically this required a flat 30 samples. But the deque is first
+        # pruned to `depletion.window` seconds, so the most samples that can
+        # ever survive is ~window/check_interval. With a slow poll interval
+        # (e.g. check_interval=11, window=300 -> ~27 samples) the count never
+        # reaches 30 and the depletion trigger (T3) is silently dead forever.
+        # Cap the floor by what the window can actually hold so T3 stays armed,
+        # while still requiring a few samples for a stable rate.
+        try:
+            check_interval = max(1, int(self.config.ups.check_interval))
+        except (TypeError, ValueError):
+            check_interval = 1
+        window = self.config.triggers.depletion.window
+        min_samples = max(3, min(30, window // check_interval))
+        if len(self.state.battery_history) < min_samples:
             return 0.0
 
         oldest_time, oldest_battery = self.state.battery_history[0]

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -63,18 +63,21 @@ class BatteryMonitorMixin:
             )
 
         # Historically this required a flat 30 samples. But the deque is first
-        # pruned to `depletion.window` seconds, so the most samples that can
-        # ever survive is ~window/check_interval. With a slow poll interval
-        # (e.g. check_interval=11, window=300 -> ~27 samples) the count never
-        # reaches 30 and the depletion trigger (T3) is silently dead forever.
-        # Cap the floor by what the window can actually hold so T3 stays armed,
-        # while still requiring a few samples for a stable rate.
+        # pruned to `depletion.window` seconds, so the most samples that can ever
+        # survive is ~window/check_interval. With a slow poll interval (e.g.
+        # check_interval=11, window=300 -> ~27 samples) a flat 30 is never
+        # reached and the depletion trigger (T3) is silently dead forever.
+        # Require min(30, window/check_interval) -- capped by what the window can
+        # actually hold so T3 stays armed -- with a floor of 2 (a rate needs two
+        # points). The floor must NOT exceed the holdable count, or tiny windows
+        # would re-disable T3 (cubic P2); 2 points is the physical minimum, so a
+        # window smaller than ~2*check_interval genuinely can't compute a rate.
         try:
             check_interval = max(1, int(self.config.ups.check_interval))
         except (TypeError, ValueError):
             check_interval = 1
         window = self.config.triggers.depletion.window
-        min_samples = max(3, min(30, window // check_interval))
+        min_samples = min(30, max(2, window // check_interval))
         if len(self.state.battery_history) < min_samples:
             return 0.0
 

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -23,7 +23,10 @@ class BatteryMonitorMixin:
         if not is_numeric(current_battery):
             return 0.0
 
-        current_battery_float = float(current_battery)
+        # M12: clamp out-of-range firmware readings. A transient negative or
+        # >100 charge from flaky firmware would otherwise inflate the depletion
+        # rate that feeds the T3 shutdown trigger.
+        current_battery_float = max(0.0, min(100.0, float(current_battery)))
         cutoff_time = current_time - self.config.triggers.depletion.window
 
         self.state.battery_history = deque(
@@ -125,8 +128,13 @@ class BatteryMonitorMixin:
         drop = prev_charge - current_charge
         elapsed = current_time - prev_time if prev_time > 0 else 0
 
-        # Threshold: >20% drop within 120 seconds while on line power
-        if drop > 20 and elapsed < 120:
+        # Threshold: >20% drop within 120 seconds while on line power.
+        # M11: only START a fresh detection when none is pending. A battery that
+        # keeps dropping fast every poll previously re-entered here each time,
+        # resetting pending_anomaly_count to 1 so the 3-poll confirmation was
+        # never reached. With a pending anomaly we fall through to the
+        # confirmation branch below, which increments the counter instead.
+        if drop > 20 and elapsed < 120 and self.state.pending_anomaly_charge < 0:
             # First detection -- record as pending, wait for confirmation
             self.state.pending_anomaly_charge = current_charge
             self.state.pending_anomaly_prev_charge = prev_charge

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -35,6 +35,13 @@ class BatteryMonitorMixin:
         )
         self.state.battery_history.append((current_time, current_battery_float))
 
+        # L17 (evaluated, deferred): this file is written every poll but not
+        # read back at startup. It's a forensic record today. Reading it back to
+        # let depletion-rate survive a daemon restart mid-outage is entangled
+        # with the on-battery deque reset in monitor._handle_on_battery (a fresh
+        # OB transition clears battery_history), which is the same
+        # restart-adoption area as the H3 work -- so a safe cross-restart
+        # read-back is a larger change than a Low warrants and is deferred.
         try:
             # with_name(name + '.tmp') preserves the per-UPS suffix on the
             # path (e.g. 'ups-battery-history.ups1') so concurrent writers

--- a/src/eneru/health/voltage.py
+++ b/src/eneru/health/voltage.py
@@ -393,6 +393,13 @@ class VoltageMonitorMixin:
         # State log line is sacred -- always written immediately on
         # transition. The notification path is gated by the hysteresis
         # logic in _maybe_notify_voltage_pending unless severe.
+        # L16 (evaluated, intentionally kept): under sustained voltage flapping
+        # this writes one event row per real transition, which can accumulate.
+        # That is deliberate -- the events table is the forensic black-box and
+        # every transition is genuine. The noisy *notifications* are already
+        # silenced by the hysteresis dwell above, and total growth is bounded by
+        # the stats retention/purge. Rate-limiting the log here would discard
+        # forensic detail, so it is left as-is on purpose.
         if target != self.state.voltage_state:
             if target == "NORMAL":
                 self._log_power_event(

--- a/src/eneru/health/voltage.py
+++ b/src/eneru/health/voltage.py
@@ -62,6 +62,11 @@ _LEGACY_TRANSFER_BUFFER_V = 5.0
 # (utility fault, generator instability, site wiring) that the
 # operator wants to know about NOW, not 30s from now.
 VOLTAGE_SEVERE_DEVIATION_PCT = 0.15  # >±15% from nominal = severe
+# Below this, a NUT-reported input.voltage.nominal is garbage (0 / unset on some
+# drivers), not a real grid -- the lowest real standard grid is 100V. Treat such
+# a value as missing so it can't make warning_high=0 and flag every reading as
+# over-voltage (M10).
+MIN_PLAUSIBLE_NOMINAL_V = 50.0
 
 
 def _snap_to_standard_grid(value: float) -> float:
@@ -180,15 +185,18 @@ class VoltageMonitorMixin:
         low_transfer = self._get_ups_var("input.transfer.low")
         high_transfer = self._get_ups_var("input.transfer.high")
 
-        if is_numeric(nominal_raw):
+        if is_numeric(nominal_raw) and float(nominal_raw) >= MIN_PLAUSIBLE_NOMINAL_V:
             raw_nominal = float(nominal_raw)
             snapped = _snap_to_standard_grid(raw_nominal)
             self.state.nominal_voltage = snapped
             origin = (f"NUT={raw_nominal}, snapped" if snapped != raw_nominal
                       else f"NUT={raw_nominal}")
         else:
+            # Missing, or implausibly small (e.g. 0 from a driver that doesn't
+            # publish nominal): fall back to the default rather than deriving a
+            # warning_high of 0 that flags every reading as over-voltage (M10).
             self.state.nominal_voltage = 230.0
-            origin = "NUT=missing, default"
+            origin = "NUT=missing/implausible, default"
 
         # Stash the raw transfer values for notification context; they're
         # informational only and never used to gate any decision.
@@ -338,9 +346,13 @@ class VoltageMonitorMixin:
         (>±15%) bypass the dwell and notify immediately -- those signal
         real grid trouble where the operator wants to know now.
         """
-        # Cross-check NUT's reported nominal against observed reality.
-        # Runs only until enough samples accumulate; cheap no-op after.
-        self._check_voltage_autodetect(input_voltage)
+        # Cross-check NUT's reported nominal against observed reality, but only
+        # sample on LINE power (M9). On battery the input.voltage reading is the
+        # grid that just sagged/failed, not the steady nominal; feeding it to
+        # auto-detect during a startup brownout would latch a depressed nominal
+        # for the daemon's lifetime. Runs only until enough samples accumulate.
+        if "OB" not in ups_status and "FSD" not in ups_status:
+            self._check_voltage_autodetect(input_voltage)
 
         if "OL" not in ups_status:
             if "OB" in ups_status or "FSD" in ups_status:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -1564,7 +1564,7 @@ class UPSGroupMonitor(
                 # coalescing in this degraded case, but the alternative
                 # is no notification at all).
                 try:
-                    self._notification_worker._send_via_apprise(
+                    self._notification_worker._send_via_apprise_bounded(
                         body, notify_type,
                     )
                 except Exception:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -1184,10 +1184,20 @@ class UPSGroupMonitor(
                     reason=REASON_SEQUENCE_COMPLETE,
                 )
 
-                cmd_parts = self.config.local_shutdown.command.split()
-                if self.config.local_shutdown.message:
-                    cmd_parts.append(self.config.local_shutdown.message)
-                run_command(cmd_parts)
+                # Defense-in-depth: config validation rejects an empty/None
+                # command at load, but guard here too so a programmatically-
+                # built Config can never None.split() / run_command([]) and
+                # silently skip the poweroff after the drain phases ran.
+                cmd_parts = str(self.config.local_shutdown.command or "").split()
+                if not cmd_parts:
+                    self._log_message(
+                        "❌ local_shutdown.command is empty -- cannot power off "
+                        "the host. Set local_shutdown.command to a valid command."
+                    )
+                else:
+                    if self.config.local_shutdown.message:
+                        cmd_parts.append(self.config.local_shutdown.message)
+                    run_command(cmd_parts)
         elif self.config.local_shutdown.enabled and delegated:
             # v5.5: the loopback's shutdown_command (already executed during
             # _shutdown_remote_servers) is what actually powers off the host.

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -1179,15 +1179,40 @@ class UPSGroupMonitor(
                 pass
 
         if self.config.local_shutdown.enabled and not delegated:
-            record_sequence_complete()
-            self._log_message("🔌 Shutting down local server NOW")
-            self._log_message("✅ SHUTDOWN SEQUENCE COMPLETE")
-
             if self.config.behavior.dry_run:
+                record_sequence_complete()
+                self._log_message("🔌 Shutting down local server NOW")
+                self._log_message("✅ SHUTDOWN SEQUENCE COMPLETE")
                 self._log_message(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
                 self._log_message("🧪 [DRY-RUN] Shutdown sequence completed successfully (no actual shutdown)")
                 self._shutdown_flag_path.unlink(missing_ok=True)
             else:
+                # Validate the poweroff command BEFORE recording the run as a
+                # completed shutdown (CodeRabbit). Config validation rejects an
+                # empty/None command at load, but a programmatically-built Config
+                # could still reach here; if it does, the host stays up, so we
+                # must NOT write SHUTDOWN_SEQUENCE_COMPLETE / the recovery marker
+                # or leave the flag set (which would gate future triggers until
+                # line power returns). Report INCOMPLETE, clear the flag, bail.
+                cmd_parts = str(self.config.local_shutdown.command or "").split()
+                if not cmd_parts:
+                    self._log_message(
+                        "❌ local_shutdown.command is empty -- host poweroff "
+                        "SKIPPED; shutdown sequence INCOMPLETE. Set "
+                        "local_shutdown.command to a valid command."
+                    )
+                    self._send_notification(
+                        f"❌ **Shutdown Sequence Incomplete** (took {elapsed}s)\n"
+                        "Host poweroff command is empty; the host is still up.",
+                        self.config.NOTIFY_FAILURE,
+                        category="shutdown_summary",
+                    )
+                    self._shutdown_flag_path.unlink(missing_ok=True)
+                    return
+
+                record_sequence_complete()
+                self._log_message("🔌 Shutting down local server NOW")
+                self._log_message("✅ SHUTDOWN SEQUENCE COMPLETE")
                 # Single-shot summary notification covering the whole sequence;
                 # the per-phase chatter that used to mirror every log line is
                 # gone in v5.2 (journalctl is the forensic record).
@@ -1216,20 +1241,9 @@ class UPSGroupMonitor(
                     reason=REASON_SEQUENCE_COMPLETE,
                 )
 
-                # Defense-in-depth: config validation rejects an empty/None
-                # command at load, but guard here too so a programmatically-
-                # built Config can never None.split() / run_command([]) and
-                # silently skip the poweroff after the drain phases ran.
-                cmd_parts = str(self.config.local_shutdown.command or "").split()
-                if not cmd_parts:
-                    self._log_message(
-                        "❌ local_shutdown.command is empty -- cannot power off "
-                        "the host. Set local_shutdown.command to a valid command."
-                    )
-                else:
-                    if self.config.local_shutdown.message:
-                        cmd_parts.append(self.config.local_shutdown.message)
-                    run_command(cmd_parts)
+                if self.config.local_shutdown.message:
+                    cmd_parts.append(self.config.local_shutdown.message)
+                run_command(cmd_parts)
         elif self.config.local_shutdown.enabled and delegated:
             # v5.5: the loopback's shutdown_command (already executed during
             # _shutdown_remote_servers) is what actually powers off the host.
@@ -1873,7 +1887,14 @@ class UPSGroupMonitor(
                 # hard errors (H3) the same way stale data already is.
                 is_failsafe_trigger = False
                 onbattery_failsafe = False
-                tolerance = self.config.ups.max_stale_data_tolerance
+                # Coerce defensively: a quoted YAML max_stale_data_tolerance
+                # ("3") would otherwise make the `count >= tolerance` comparisons
+                # below raise TypeError and kill the loop on a failed poll. (Also
+                # validated at config load, but guard the hot path too.)
+                try:
+                    tolerance = max(1, int(self.config.ups.max_stale_data_tolerance))
+                except (TypeError, ValueError):
+                    tolerance = 3
 
                 if "Data stale" in error_msg:
                     self.state.stale_data_count += 1
@@ -1975,12 +1996,14 @@ class UPSGroupMonitor(
             # DATA PROCESSING
             # ==================================================================
 
-            # A successful poll clears the failure debounce counters and re-arms
-            # the FAILSAFE latch (H2/H3): NUT is visible again, so a later loss
-            # is a fresh event that must be allowed to act.
+            # A successful poll clears the failure debounce counters: NUT is
+            # visible again. The FAILSAFE latch is NOT reset here -- a brief NUT
+            # reconnection while the UPS is still ON BATTERY must not re-arm the
+            # failsafe (which would let the next hard error re-drain in dry-run/
+            # delegated/enabled=false setups). The latch is per-OUTAGE: it clears
+            # only once the UPS is back on line power (see below).
             self.state.stale_data_count = 0
             self.state.connection_error_count = 0
-            self._failsafe_initiated = False
 
             if self.state.connection_state == "GRACE_PERIOD":
                 # Recovered during grace period: quiet recovery, no notification
@@ -2034,6 +2057,12 @@ class UPSGroupMonitor(
                     self._clear_advisory_trigger()
 
             ups_status = ups_data.get('ups.status', '')
+
+            # Re-arm the FAILSAFE latch only when the outage is over (back on
+            # line power). While still on battery a reconnection doesn't end the
+            # outage, so the latch stays set (per-outage, not per-reconnect).
+            if "OB" not in ups_status and "FSD" not in ups_status:
+                self._failsafe_initiated = False
 
             if not ups_status:
                 self._log_message(

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -2058,10 +2058,12 @@ class UPSGroupMonitor(
 
             ups_status = ups_data.get('ups.status', '')
 
-            # Re-arm the FAILSAFE latch only when the outage is over (back on
-            # line power). While still on battery a reconnection doesn't end the
-            # outage, so the latch stays set (per-outage, not per-reconnect).
-            if "OB" not in ups_status and "FSD" not in ups_status:
+            # Re-arm the FAILSAFE latch only when the outage is over: we have a
+            # VALID status AND it shows line power. A missing/empty status is an
+            # unresolved state, not "on line", so it must NOT re-arm the latch
+            # mid-outage (cubic). On battery a reconnection alone doesn't end the
+            # outage either, so the latch is per-outage, not per-reconnect.
+            if ups_status and "OB" not in ups_status and "FSD" not in ups_status:
                 self._failsafe_initiated = False
 
             if not ups_status:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -7,7 +7,6 @@ https://github.com/m4r1k/Eneru
 
 import sqlite3
 import sys
-import os
 import time
 import signal
 import threading
@@ -132,6 +131,11 @@ class UPSGroupMonitor(
         # local shutdown sequence. The redundancy-group evaluator owns the
         # decision to actually drain shared resources.
         self._in_redundancy_group = bool(in_redundancy_group)
+        # H2: per-outage latch so the on-battery FAILSAFE runs the shutdown
+        # sequence at most once per connection-loss event (non-halting configs
+        # clear the flag and would otherwise re-fire every poll). Reset on the
+        # next successful poll.
+        self._failsafe_initiated = False
 
         # Per-group state file paths (suffix for multi-UPS)
         sfx = f".{state_file_suffix}" if state_file_suffix else ""
@@ -1111,19 +1115,47 @@ class UPSGroupMonitor(
         is_local = group.is_local if group else True  # legacy single-UPS = local
 
         if is_local and not delegated:
-            self._shutdown_vms()
-            self._shutdown_containers()
-            self._sync_filesystems()
-            self._unmount_filesystems()
-        remote_results = self._shutdown_remote_servers() or []
+            # Each drain phase is best-effort housekeeping. A failure in one
+            # (a wedged libvirt, a bad config value, a hung mount) must NEVER
+            # abort the path to the host poweroff below -- that is the actual
+            # protective action. Previously an unguarded exception here
+            # propagated to run() (FATAL + re-raise) or, in coordinator mode,
+            # was swallowed without ever reaching the poweroff. Wrap each phase.
+            for phase_name, phase_fn in (
+                ("VM shutdown", self._shutdown_vms),
+                ("container shutdown", self._shutdown_containers),
+                ("filesystem sync", self._sync_filesystems),
+                ("filesystem unmount", self._unmount_filesystems),
+            ):
+                try:
+                    phase_fn()
+                except Exception as exc:
+                    self._log_message(
+                        f"❌ {phase_name} phase failed: {exc}. Continuing the "
+                        "shutdown sequence -- drain is best-effort, the host "
+                        "halt is not."
+                    )
+        # Remote shutdown is also best-effort: its per-server work is already
+        # guarded internally, but wrap the call too so the H4 contract -- the
+        # host poweroff below is ALWAYS reached -- is structural, not dependent
+        # on the callee never raising during setup.
+        try:
+            remote_results = self._shutdown_remote_servers() or []
+        except Exception as exc:
+            self._log_message(
+                f"❌ remote shutdown phase failed: {exc}. Continuing to the "
+                "host poweroff."
+            )
+            remote_results = []
 
         if is_local and self.config.filesystems.sync_enabled and not delegated:
             self._log_message("💾 Final filesystem sync...")
             if self.config.behavior.dry_run:
                 self._log_message("  🧪 [DRY-RUN] Would perform final sync")
             else:
-                os.sync()
-                self._log_message("  ✅ Final sync complete")
+                # Bounded sync (FilesystemShutdownMixin) so a hung mount can't
+                # wedge the sequence before the host poweroff below.
+                self._bounded_sync("Final filesystem sync")
 
         # In coordinator mode, notify the coordinator instead of doing local shutdown
         if self._coordinator_mode:
@@ -1835,29 +1867,48 @@ class UPSGroupMonitor(
             # ==================================================================
 
             if not success:
+                # ``is_failsafe_trigger`` drives the OFF-battery grace path and
+                # fires on the first hard error (unchanged). ``onbattery_failsafe``
+                # gates the irreversible ON-battery shutdown and is debounced for
+                # hard errors (H3) the same way stale data already is.
                 is_failsafe_trigger = False
+                onbattery_failsafe = False
+                tolerance = self.config.ups.max_stale_data_tolerance
 
                 if "Data stale" in error_msg:
                     self.state.stale_data_count += 1
                     if self.state.connection_state not in ("FAILED", "GRACE_PERIOD"):
                         self._log_message(
                             f"⚠️ WARNING: Data stale from UPS {self.config.ups.name} "
-                            f"(Attempt {self.state.stale_data_count}/{self.config.ups.max_stale_data_tolerance})."
+                            f"(Attempt {self.state.stale_data_count}/{tolerance})."
                         )
 
-                    if self.state.stale_data_count >= self.config.ups.max_stale_data_tolerance:
+                    if self.state.stale_data_count >= tolerance:
                         is_failsafe_trigger = True
+                        onbattery_failsafe = True
                 else:
+                    self.state.connection_error_count += 1
                     if self.state.connection_state not in ("FAILED", "GRACE_PERIOD"):
                         self._log_message(
-                            f"❌ ERROR: Cannot connect to UPS {self.config.ups.name}. Output: {error_msg}"
+                            f"❌ ERROR: Cannot connect to UPS {self.config.ups.name} "
+                            f"(Attempt {self.state.connection_error_count}/"
+                            f"{tolerance}). Output: {error_msg}"
                         )
                     self.state.stale_data_count = 0
+                    # Off-battery: first hard error feeds the grace period as
+                    # before. On-battery (H3): require max_stale_data_tolerance
+                    # consecutive hard failures before the IRREVERSIBLE shutdown,
+                    # so a single transient NUT blip (connection refused during a
+                    # upsd restart, or a 30s upsc timeout -> run_command 124)
+                    # can't drop a healthy host riding out a survivable dip. Set
+                    # max_stale_data_tolerance=1 to restore instant FSB.
                     is_failsafe_trigger = True
+                    if self.state.connection_error_count >= tolerance:
+                        onbattery_failsafe = True
 
-                # FAILSAFE: If connection lost while on battery, shutdown immediately
-                # This is NEVER affected by the grace period
-                if is_failsafe_trigger and "OB" in self.state.previous_status:
+                # FAILSAFE: If connection lost while on battery, shut down.
+                # This is NEVER affected by the grace period.
+                if onbattery_failsafe and "OB" in self.state.previous_status:
                     with self.state._lock:
                         self.state.connection_state = "FAILED"
                         self.state.connection_lost_time = 0.0
@@ -1865,11 +1916,22 @@ class UPSGroupMonitor(
                     # once connection_state == "FAILED", health_model short-
                     # circuits to UNKNOWN regardless of the count, and the
                     # next successful poll resets it (see line ~1486).
-                    if self._in_redundancy_group:
+                    if self._failsafe_initiated:
+                        # H2: already acted on this outage's FAILSAFE. Do NOT
+                        # re-run the sequence every poll while NUT stays
+                        # unreachable. Non-halting configs (local_shutdown
+                        # disabled, dry-run, delegated) clear the shutdown flag
+                        # on completion, so without this latch the entire
+                        # remote/VM/container sequence would re-fire each poll
+                        # and flood notifications. The latch resets on the next
+                        # successful poll (recovery).
+                        pass
+                    elif self._in_redundancy_group:
                         # Advisory mode: redundancy-group evaluator owns the
                         # shutdown decision. Recording the trigger here +
                         # reporting connection_state=FAILED is enough -- the
                         # group's policy + min_healthy decide what happens.
+                        self._failsafe_initiated = True
                         self._record_advisory_trigger(
                             "FAILSAFE (FSB): connection lost while On Battery"
                         )
@@ -1878,6 +1940,7 @@ class UPSGroupMonitor(
                             "while On Battery; deferring to group evaluator."
                         )
                     else:
+                        self._failsafe_initiated = True
                         self._shutdown_flag_path.touch()
                         self._log_message(
                             "🚨 FAILSAFE TRIGGERED (FSB): Connection lost or data persistently stale "
@@ -1893,6 +1956,14 @@ class UPSGroupMonitor(
                         )
                         self._execute_shutdown_sequence()
 
+                # On battery but the hard-error debounce hasn't reached tolerance
+                # yet (H3): wait for the next poll. Do NOT start the off-battery
+                # grace machinery and do NOT shut down -- just let the counter
+                # accumulate. (Stale-data-below-tolerance lands here too, exactly
+                # as before, since neither flag is set yet.)
+                elif "OB" in self.state.previous_status:
+                    pass
+
                 # Grace period logic (only when NOT on battery)
                 elif is_failsafe_trigger:
                     self._handle_connection_failure(error_msg)
@@ -1904,7 +1975,12 @@ class UPSGroupMonitor(
             # DATA PROCESSING
             # ==================================================================
 
+            # A successful poll clears the failure debounce counters and re-arms
+            # the FAILSAFE latch (H2/H3): NUT is visible again, so a later loss
+            # is a fresh event that must be allowed to act.
             self.state.stale_data_count = 0
+            self.state.connection_error_count = 0
+            self._failsafe_initiated = False
 
             if self.state.connection_state == "GRACE_PERIOD":
                 # Recovered during grace period: quiet recovery, no notification

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -60,6 +60,8 @@ class MultiUPSCoordinator:
         # M1: set while a committed local shutdown is running outside the lock,
         # so recovery can't re-arm the guard mid-flight and admit a 2nd poweroff.
         self._local_shutdown_in_flight = False
+        # L5: re-entrancy guard for the SIGTERM/SIGINT handler.
+        self._signal_handling = False
         self._global_shutdown_flag = Path(config.logging.shutdown_flag_file)
 
         # Shared resources
@@ -865,6 +867,12 @@ class MultiUPSCoordinator:
 
     def _handle_signal(self, signum: int, frame):
         """Handle SIGTERM/SIGINT for clean shutdown."""
+        # L5: a second signal arriving during the join/teardown window must not
+        # re-run the whole teardown (double notifications, redundant joins). The
+        # first signal owns the exit; ignore the rest.
+        if self._signal_handling:
+            return
+        self._signal_handling = True
         self._log("🛑 Service stopped by signal (SIGTERM/SIGINT). Monitoring is inactive.")
 
         self._stop_event.set()

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -580,10 +580,21 @@ class MultiUPSCoordinator:
                     version=__version__,
                     reason=REASON_SEQUENCE_COMPLETE,
                 )
-                cmd_parts = self.config.local_shutdown.command.split()
-                if self.config.local_shutdown.message:
-                    cmd_parts.append(self.config.local_shutdown.message)
-                run_command(cmd_parts)
+                # Defense-in-depth: config validation already rejects an
+                # empty/None command at load, but a programmatically-built
+                # Config could still reach here. str()+strip guards against
+                # None.split() / run_command([]) silently no-op'ing the
+                # poweroff after peers were already drained.
+                cmd_parts = str(self.config.local_shutdown.command or "").split()
+                if not cmd_parts:
+                    self._log(
+                        "❌ local_shutdown.command is empty -- cannot power off "
+                        "the host. Set local_shutdown.command to a valid command."
+                    )
+                else:
+                    if self.config.local_shutdown.message:
+                        cmd_parts.append(self.config.local_shutdown.message)
+                    run_command(cmd_parts)
         else:
             self._log("✅ Local shutdown disabled. Group shutdown complete.")
             self._global_shutdown_flag.unlink(missing_ok=True)
@@ -609,12 +620,22 @@ class MultiUPSCoordinator:
         """
         self._log("⏳ Draining all UPS groups -- shutting down their resources...")
 
+        # This runs ON one of the monitor threads (the group whose trigger
+        # fired calls _handle_local_shutdown -> here, synchronously). That
+        # thread's own Thread object is in self._threads, and joining the
+        # CURRENT thread raises RuntimeError("cannot join current thread"),
+        # which would unwind out of the whole shutdown sequence BEFORE the
+        # host poweroff -- a missed local shutdown. So never join ourselves.
+        me = threading.current_thread()
+
         # Phase 1: signal every peer monitor to stop its poll loop, then
         # join with a short window so the loops exit before we run their
         # shutdown sequences.
         self._stop_event.set()
         join_deadline = time.time() + max(1, timeout // 4)
         for thread in self._threads:
+            if thread is me:
+                continue
             remaining = max(0.0, join_deadline - time.time())
             thread.join(timeout=remaining)
 
@@ -630,9 +651,11 @@ class MultiUPSCoordinator:
         # Final join window for any threads still wrapping up.
         deadline = time.time() + timeout
         for thread in self._threads:
+            if thread is me:
+                continue
             remaining = max(0.0, deadline - time.time())
             thread.join(timeout=remaining)
-        still_running = [t for t in self._threads if t.is_alive()]
+        still_running = [t for t in self._threads if t is not me and t.is_alive()]
         if still_running:
             self._log(f"⚠️ {len(still_running)} monitor(s) still running after drain timeout")
 

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -57,6 +57,9 @@ class MultiUPSCoordinator:
         self._stop_event = threading.Event()
         self._local_shutdown_lock = threading.Lock()
         self._local_shutdown_initiated = False
+        # M1: set while a committed local shutdown is running outside the lock,
+        # so recovery can't re-arm the guard mid-flight and admit a 2nd poweroff.
+        self._local_shutdown_in_flight = False
         self._global_shutdown_flag = Path(config.logging.shutdown_flag_file)
 
         # Shared resources
@@ -526,93 +529,113 @@ class MultiUPSCoordinator:
         is gone -- a state worse than the one we set out to fix.
         """
         with self._local_shutdown_lock:
+            # M1: never re-arm while a local shutdown is committed and running
+            # (its drain/flush/run_command execute outside the lock). Clearing
+            # the guard mid-flight would let a concurrent trigger admit a SECOND
+            # poweroff. The in_flight flag is cleared by _handle_local_shutdown's
+            # finally once the sequence returns, after which recovery re-arms.
+            if self._local_shutdown_in_flight:
+                return
             self._local_shutdown_initiated = False
             self._global_shutdown_flag.unlink(missing_ok=True)
 
     def _handle_local_shutdown(self, triggered_by: str):
         """Execute local shutdown with defense-in-depth protection."""
-        # Defense layer 1: in-memory lock
+        # Defense layer 1: in-memory lock. Set BOTH the "initiated" guard and the
+        # "in flight" flag atomically: in_flight tells _clear_local_shutdown_state
+        # not to re-arm the guard mid-sequence (M1), which would otherwise let an
+        # unrelated group's recovery clear the guard while the drain/flush/
+        # run_command below run outside the lock and admit a SECOND poweroff.
         proceed = False
         with self._local_shutdown_lock:
             if not self._local_shutdown_initiated:
                 self._local_shutdown_initiated = True
+                self._local_shutdown_in_flight = True
                 proceed = True
 
         if not proceed:
             return
 
-        # Defense layer 2: filesystem flag
-        self._global_shutdown_flag.touch()
+        try:
+            # Defense layer 2: filesystem flag
+            self._global_shutdown_flag.touch()
 
-        self._log(f"🚨 Local shutdown triggered by {triggered_by}")
+            self._log(f"🚨 Local shutdown triggered by {triggered_by}")
 
-        # Drain other groups if configured
-        if self.config.local_shutdown.drain_on_local_shutdown:
-            self._log("⏳ Draining all UPS groups before local shutdown...")
-            self._drain_all_groups(timeout=120)
+            # Drain other groups if configured
+            if self.config.local_shutdown.drain_on_local_shutdown:
+                self._log("⏳ Draining all UPS groups before local shutdown...")
+                self._drain_all_groups(timeout=120)
 
-        # Execute local shutdown
-        if self.config.local_shutdown.enabled:
-            self._log("🔌 Shutting down local server NOW")
-            if self.config.behavior.dry_run:
-                self._log(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
-                self._global_shutdown_flag.unlink(missing_ok=True)
+            # Execute local shutdown
+            if self.config.local_shutdown.enabled:
+                self._log("🔌 Shutting down local server NOW")
+                if self.config.behavior.dry_run:
+                    self._log(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
+                    self._global_shutdown_flag.unlink(missing_ok=True)
+                else:
+                    if self._notification_worker:
+                        self._notification_worker.send(
+                            "🛑 **Shutdown Sequence Complete**\nShutting down local server NOW.",
+                            "failure",
+                            category="shutdown_summary",
+                        )
+                        # Drain in flight before halt; lossless guarantee on
+                        # what doesn't make it.
+                        self._notification_worker.flush(timeout=5)
+                    else:
+                        time.sleep(5)
+                    # Slice 3: tag this shutdown as power-loss-triggered so
+                    # the next start can emit "📊 Recovered" and the Slice 4
+                    # bonus folds the prev shutdown into a richer message.
+                    # (Single-UPS path already does this in monitor.py;
+                    # coordinator mode was missing it — caught in pre-push
+                    # review.)
+                    write_shutdown_marker(
+                        Path(self.config.statistics.db_directory),
+                        version=__version__,
+                        reason=REASON_SEQUENCE_COMPLETE,
+                    )
+                    # Defense-in-depth: config validation already rejects an
+                    # empty/None command at load, but a programmatically-built
+                    # Config could still reach here. str()+strip guards against
+                    # None.split() / run_command([]) silently no-op'ing the
+                    # poweroff after peers were already drained.
+                    cmd_parts = str(self.config.local_shutdown.command or "").split()
+                    if not cmd_parts:
+                        self._log(
+                            "❌ local_shutdown.command is empty -- cannot power off "
+                            "the host. Set local_shutdown.command to a valid command."
+                        )
+                    else:
+                        if self.config.local_shutdown.message:
+                            cmd_parts.append(self.config.local_shutdown.message)
+                        run_command(cmd_parts)
+                        # NOTE (H9): we deliberately do NOT eagerly re-arm the
+                        # guard here. Re-entry during the SAME outage is already
+                        # blocked by the monitor's suffixed _shutdown_flag_path
+                        # (coordinator mode never clears it mid-sequence), and the
+                        # guard is re-armed on the OB/FSD->OL recovery via
+                        # power_restored_callback -> _clear_local_shutdown_state.
+                        # Clearing it right after run_command would instead
+                        # re-drain peers and re-send the "shutting down"
+                        # notification on every subsequent failed poll in a
+                        # non-halting/sandbox config (the multi-UPS analog of the
+                        # H2 failsafe re-fire).
             else:
-                if self._notification_worker:
-                    self._notification_worker.send(
-                        "🛑 **Shutdown Sequence Complete**\nShutting down local server NOW.",
-                        "failure",
-                        category="shutdown_summary",
-                    )
-                    # Drain in flight before halt; lossless guarantee on
-                    # what doesn't make it.
-                    self._notification_worker.flush(timeout=5)
-                else:
-                    time.sleep(5)
-                # Slice 3: tag this shutdown as power-loss-triggered so
-                # the next start can emit "📊 Recovered" and the Slice 4
-                # bonus folds the prev shutdown into a richer message.
-                # (Single-UPS path already does this in monitor.py;
-                # coordinator mode was missing it — caught in pre-push
-                # review.)
-                write_shutdown_marker(
-                    Path(self.config.statistics.db_directory),
-                    version=__version__,
-                    reason=REASON_SEQUENCE_COMPLETE,
-                )
-                # Defense-in-depth: config validation already rejects an
-                # empty/None command at load, but a programmatically-built
-                # Config could still reach here. str()+strip guards against
-                # None.split() / run_command([]) silently no-op'ing the
-                # poweroff after peers were already drained.
-                cmd_parts = str(self.config.local_shutdown.command or "").split()
-                if not cmd_parts:
-                    self._log(
-                        "❌ local_shutdown.command is empty -- cannot power off "
-                        "the host. Set local_shutdown.command to a valid command."
-                    )
-                else:
-                    if self.config.local_shutdown.message:
-                        cmd_parts.append(self.config.local_shutdown.message)
-                    run_command(cmd_parts)
-                    # NOTE (H9): we deliberately do NOT eagerly re-arm the guard
-                    # here. Re-entry during the SAME outage is already blocked by
-                    # the monitor's suffixed _shutdown_flag_path (coordinator
-                    # mode never clears it mid-sequence), and the guard is re-armed
-                    # on the OB/FSD->OL recovery via power_restored_callback ->
-                    # _clear_local_shutdown_state. Clearing it right after
-                    # run_command would instead re-drain peers and re-send the
-                    # "shutting down" notification on every subsequent failed poll
-                    # in a non-halting/sandbox config (the multi-UPS analog of the
-                    # H2 failsafe re-fire).
-        else:
-            self._log("✅ Local shutdown disabled. Group shutdown complete.")
-            self._global_shutdown_flag.unlink(missing_ok=True)
+                self._log("✅ Local shutdown disabled. Group shutdown complete.")
+                self._global_shutdown_flag.unlink(missing_ok=True)
 
-        # Exit if --exit-after-shutdown was specified
-        if self._exit_after_shutdown:
-            self._log("🛑 Exiting after shutdown sequence (--exit-after-shutdown)")
-            self._stop_event.set()
+            # Exit if --exit-after-shutdown was specified
+            if self._exit_after_shutdown:
+                self._log("🛑 Exiting after shutdown sequence (--exit-after-shutdown)")
+                self._stop_event.set()
+        finally:
+            # The committed sequence is no longer running outside the lock, so
+            # recovery is allowed to re-arm again. (On a real halt the process
+            # never reaches here -- the host is already going down.)
+            with self._local_shutdown_lock:
+                self._local_shutdown_in_flight = False
 
     def _drain_all_groups(self, timeout: int = 120):
         """Shut down all groups' resources, then stop monitor threads.
@@ -935,7 +958,7 @@ class MultiUPSCoordinator:
                 # row never landed in SQLite. Ship eagerly via Apprise
                 # so the lifecycle stop isn't silently lost.
                 try:
-                    self._notification_worker._send_via_apprise(
+                    self._notification_worker._send_via_apprise_bounded(
                         body, notify_type,
                     )
                 except Exception:

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -595,6 +595,16 @@ class MultiUPSCoordinator:
                     if self.config.local_shutdown.message:
                         cmd_parts.append(self.config.local_shutdown.message)
                     run_command(cmd_parts)
+                    # NOTE (H9): we deliberately do NOT eagerly re-arm the guard
+                    # here. Re-entry during the SAME outage is already blocked by
+                    # the monitor's suffixed _shutdown_flag_path (coordinator
+                    # mode never clears it mid-sequence), and the guard is re-armed
+                    # on the OB/FSD->OL recovery via power_restored_callback ->
+                    # _clear_local_shutdown_state. Clearing it right after
+                    # run_command would instead re-drain peers and re-send the
+                    # "shutting down" notification on every subsequent failed poll
+                    # in a non-halting/sandbox config (the multi-UPS analog of the
+                    # H2 failsafe re-fire).
         else:
             self._log("✅ Local shutdown disabled. Group shutdown complete.")
             self._global_shutdown_flag.unlink(missing_ok=True)
@@ -806,6 +816,30 @@ class MultiUPSCoordinator:
         for line in format_report(report):
             self._log(line)
 
+    def _shutdown_join_deadline(self) -> int:
+        """Bounded wait (seconds) for an in-flight shutdown to finish on signal.
+
+        Tied to the configured remote-shutdown + drain budgets so the host
+        poweroff (the last step of the sequence) can complete, and capped so a
+        wedged sequence can't block exit forever. (systemd's TimeoutStopSec is
+        the ultimate governor; this just stops us abandoning our own work.)
+        """
+        max_remote = 0
+        for group in self.config.ups_groups:
+            for srv in group.remote_servers:
+                try:
+                    max_remote = max(
+                        max_remote,
+                        int(srv.command_timeout) + int(srv.connect_timeout)
+                        + int(srv.shutdown_safety_margin),
+                    )
+                except (TypeError, ValueError):
+                    continue
+        budget = max_remote + 120  # + local drain/poweroff headroom
+        if self.config.local_shutdown.drain_on_local_shutdown:
+            budget += 120
+        return min(max(budget, 30), 600)
+
     def _handle_signal(self, signum: int, frame):
         """Handle SIGTERM/SIGINT for clean shutdown."""
         self._log("🛑 Service stopped by signal (SIGTERM/SIGINT). Monitoring is inactive.")
@@ -819,11 +853,32 @@ class MultiUPSCoordinator:
         if self._api_server is not None:
             self._api_server.stop()
 
-        # Wait briefly for monitor + evaluator threads to finish
-        for thread in self._threads:
-            thread.join(timeout=5)
-        for thread in self._evaluator_threads:
-            thread.join(timeout=5)
+        # If a shutdown sequence is already in flight (a real power event, not
+        # just `systemctl stop`), a monitor/evaluator thread is mid-sequence and
+        # the host poweroff is its LAST step. Racing a 5 s join then sys.exit()
+        # would kill that thread before the poweroff runs -- a missed shutdown.
+        # When in flight, wait a generous, config-derived, bounded deadline so
+        # the sequence can finish; otherwise keep the brisk 5 s exit.
+        shutdown_in_flight = (
+            self._global_shutdown_flag.exists()
+            or any(m._shutdown_flag_path.exists() for m in self._monitors)
+        )
+        if shutdown_in_flight:
+            join_budget = self._shutdown_join_deadline()
+            self._log(
+                f"⏳ Shutdown sequence in progress; waiting up to {join_budget}s "
+                "for it to complete (host poweroff) before exit."
+            )
+        else:
+            join_budget = 5
+
+        # Deadline-based join so the TOTAL wait is bounded by join_budget, not
+        # join_budget per thread. The signal handler runs on the main thread, so
+        # none of these is the current thread (no self-join hazard).
+        deadline = time.time() + join_budget
+        for thread in (*self._threads, *self._evaluator_threads):
+            remaining = max(0.0, deadline - time.time())
+            thread.join(timeout=remaining)
 
         # v5.2.1: see UPSGroupMonitor._cleanup_and_exit for the full
         # rationale. Drain pending non-lifecycle rows first, then enqueue

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -865,17 +865,28 @@ class MultiUPSCoordinator:
         wedged sequence can't block exit forever. (systemd's TimeoutStopSec is
         the ultimate governor; this just stops us abandoning our own work.)
         """
+        def _server_budget(srv) -> int:
+            # Full per-server wall time: pre-shutdown commands + the final
+            # command + connect + safety margin (cubic -- pre-command runtime
+            # was previously ignored, under-budgeting servers with pre-commands).
+            try:
+                pre = sum(
+                    int(c.timeout) if c.timeout is not None
+                    else int(srv.command_timeout)
+                    for c in srv.pre_shutdown_commands
+                )
+                return (pre + int(srv.command_timeout) + int(srv.connect_timeout)
+                        + int(srv.shutdown_safety_margin))
+            except (TypeError, ValueError):
+                return 0
+
         max_remote = 0
-        for group in self.config.ups_groups:
-            for srv in group.remote_servers:
-                try:
-                    max_remote = max(
-                        max_remote,
-                        int(srv.command_timeout) + int(srv.connect_timeout)
-                        + int(srv.shutdown_safety_margin),
-                    )
-                except (TypeError, ValueError):
-                    continue
+        # Include redundancy-group remotes too (cubic): a redundancy-group
+        # shutdown is just as much "in flight" as a per-UPS one on signal.
+        groups = list(self.config.ups_groups) + list(self.config.redundancy_groups)
+        for group in groups:
+            for srv in getattr(group, "remote_servers", []):
+                max_remote = max(max_remote, _server_budget(srv))
         budget = max_remote + 120  # + local drain/poweroff headroom
         if self.config.local_shutdown.drain_on_local_shutdown:
             budget += 120

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -60,6 +60,11 @@ class MultiUPSCoordinator:
         # M1: set while a committed local shutdown is running outside the lock,
         # so recovery can't re-arm the guard mid-flight and admit a 2nd poweroff.
         self._local_shutdown_in_flight = False
+        # If a recovery (OB->OL) arrives DURING the in-flight window we defer the
+        # re-arm to the end of _handle_local_shutdown instead of dropping it --
+        # otherwise a no-op/non-halting shutdown would stay latched forever and
+        # block the next outage (cubic P1).
+        self._rearm_after_inflight = False
         # L5: re-entrancy guard for the SIGTERM/SIGINT handler.
         self._signal_handling = False
         self._global_shutdown_flag = Path(config.logging.shutdown_flag_file)
@@ -534,9 +539,13 @@ class MultiUPSCoordinator:
             # M1: never re-arm while a local shutdown is committed and running
             # (its drain/flush/run_command execute outside the lock). Clearing
             # the guard mid-flight would let a concurrent trigger admit a SECOND
-            # poweroff. The in_flight flag is cleared by _handle_local_shutdown's
-            # finally once the sequence returns, after which recovery re-arms.
+            # poweroff. But we must NOT simply drop this recovery: if it's the
+            # only OB->OL transition (a no-op/non-halting shutdown), nothing else
+            # would re-arm and the next outage would be blocked (cubic P1). So
+            # remember it and let _handle_local_shutdown's finally re-arm once
+            # the sequence has returned.
             if self._local_shutdown_in_flight:
+                self._rearm_after_inflight = True
                 return
             self._local_shutdown_initiated = False
             self._global_shutdown_flag.unlink(missing_ok=True)
@@ -635,9 +644,16 @@ class MultiUPSCoordinator:
         finally:
             # The committed sequence is no longer running outside the lock, so
             # recovery is allowed to re-arm again. (On a real halt the process
-            # never reaches here -- the host is already going down.)
+            # never reaches here -- the host is already going down.) If a
+            # recovery arrived DURING the in-flight window, apply the deferred
+            # re-arm now so a no-op/non-halting shutdown doesn't stay latched and
+            # block the next outage (cubic P1).
             with self._local_shutdown_lock:
                 self._local_shutdown_in_flight = False
+                if self._rearm_after_inflight:
+                    self._rearm_after_inflight = False
+                    self._local_shutdown_initiated = False
+                    self._global_shutdown_flag.unlink(missing_ok=True)
 
     def _drain_all_groups(self, timeout: int = 120):
         """Shut down all groups' resources, then stop monitor threads.

--- a/src/eneru/notifications.py
+++ b/src/eneru/notifications.py
@@ -537,6 +537,30 @@ class NotificationWorker:
         except Exception:
             return False
 
+    def _send_via_apprise_bounded(self, body: str, notify_type: str,
+                                  timeout: float = 5.0) -> bool:
+        """Eager send bounded by a wall-clock timeout (M6).
+
+        The lifecycle "Service Stopped" notification is shipped eagerly from the
+        SIGTERM/SIGINT handler on the MAIN thread when no deferred delivery is
+        available. ``apprise.notify()`` has no timeout, so a hung endpoint would
+        block daemon exit -- violating the "shutdown must not wait on network"
+        contract. Run the send on a short-lived daemon thread and give up after
+        ``timeout`` seconds; on timeout the row stays pending and ships on the
+        next start (the lossless guarantee). Mirrors the flush(timeout=5) budget.
+        """
+        result = {"ok": False}
+
+        def _run():
+            result["ok"] = self._send_via_apprise(body, notify_type)
+
+        t = threading.Thread(target=_run, name="eneru-eager-notify", daemon=True)
+        t.start()
+        t.join(timeout)
+        if t.is_alive():
+            return False  # timed out -> leave pending for the next start
+        return result["ok"]
+
     def _maybe_prune(self) -> None:
         """Run TTL prune at most once per ``_PRUNE_INTERVAL_SECS``.
 

--- a/src/eneru/nut_control.py
+++ b/src/eneru/nut_control.py
@@ -120,6 +120,12 @@ def set_variable(
     """Write a UPS variable (``upsrw -s var=value -u … -p … ups``).
 
     Returns ``(ok, output, error)``.
+
+    L10 (evaluated, tunable): a write that actually changes UPS state (e.g. a
+    battery-calibration variable) can take longer to acknowledge than a read, so
+    a slow SET may be reported failed here while NUT still applies it. The bound
+    is the operator-tunable ``nut_control.timeout`` (passed as ``timeout``);
+    raise it for slow devices rather than special-casing SET.
     """
     cmd = (["upsrw", "-s", f"{variable}={value}"]
            + _creds_args(username, password) + [ups_name])

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -510,7 +510,12 @@ class RedundancyGroupEvaluator(threading.Thread):
                 # member going FAILED, so it must not stretch this group's
                 # cold-start hold and delay a real quorum-loss shutdown.
                 if grace.enabled:
-                    grace_durations.append(int(grace.duration))
+                    # Clamp to non-negative (cubic): duration is typed int but
+                    # not range-validated, so a negative/malformed value must not
+                    # SHRINK the readiness window -- that would let a real quorum
+                    # loss fire before members finish their first connect
+                    # (premature shutdown). 0 is the safe floor.
+                    grace_durations.append(max(0, int(grace.duration)))
             except Exception:
                 pass
         base_grace = max(grace_durations) if grace_durations else 0

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -621,6 +621,14 @@ class RedundancyGroupEvaluator(threading.Thread):
             # subsequent quorum loss for the rest of this daemon's
             # life, exactly the issue #4 symptom this PR fixes.
             # ``clear_shutdown_state()`` is idempotent.
+            #
+            # L4 (evaluated, intentional): this recovery clear deliberately does
+            # NOT pass refuse_active_peer=True. Recovery must always re-arm THIS
+            # daemon's own guard; the refuse-active-peer check (used at startup)
+            # would raise if another running process owned the shared flag, which
+            # would wrongly abort a legitimate recovery. The two-daemons-sharing-
+            # one-flag-file case is an operator misconfiguration already guarded
+            # at startup, so we don't re-check it on every recovery tick.
             self._executor.clear_shutdown_state()
             if self._fired:
                 self._fired = False

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -483,6 +483,30 @@ class RedundancyGroupEvaluator(threading.Thread):
         self._was_quorum_lost = False
         self._fired = False
 
+        # Cold-start protection (H1). The time-based startup grace above is not
+        # enough on its own: a member whose NUT server is merely slow to come up
+        # at boot keeps last_update_time==0 -> assess_health returns UNKNOWN ->
+        # with the default unknown_counts_as=critical it never counts healthy, so
+        # once the grace expires a fully-powered rack can be shut down. Until
+        # EVERY member has published at least one snapshot we suppress
+        # quorum-loss firing, bounded by a readiness deadline that covers
+        # realistic first-connect latency (the largest per-member
+        # connection-loss grace, on top of the startup grace). A member that has
+        # reported once and then goes stale/FAILED is NOT cold-start -- it
+        # counts per policy as before.
+        grace_durations = []
+        for m in monitors_by_ups_name.values():
+            try:
+                grace_durations.append(
+                    int(m.config.ups.connection_loss_grace_period.duration))
+            except Exception:
+                pass
+        base_grace = max(grace_durations) if grace_durations else 0
+        self._readiness_window = self._startup_grace + base_grace + 10
+        self._ever_reported = set()
+        self._start_monotonic = time.monotonic()
+        self._cold_start_logged = False
+
     def _log(self, message: str):
         prefixed = f"{self._log_prefix}{message}" if self._log_prefix else message
         if self._logger is not None:
@@ -522,6 +546,12 @@ class RedundancyGroupEvaluator(threading.Thread):
                 triggers = None
             else:
                 snap = monitor.state.snapshot()
+                # A member that has published at least one successful poll
+                # (last_update_time > 0) is no longer "cold-start" -- if it later
+                # goes stale/FAILED it counts per policy. Only never-reported
+                # members are held back below.
+                if getattr(snap, "last_update_time", 0):
+                    self._ever_reported.add(ups_name)
                 check_interval = monitor.config.ups.check_interval
                 max_stale_data_tolerance = (
                     monitor.config.ups.max_stale_data_tolerance
@@ -543,7 +573,33 @@ class RedundancyGroupEvaluator(threading.Thread):
             if self._effective_health(raw) == UPSHealth.HEALTHY:
                 healthy_count += 1
 
-        quorum_lost = healthy_count < self._group.min_healthy
+        raw_quorum_lost = healthy_count < self._group.min_healthy
+
+        # Cold-start hold (H1): if a member whose monitor EXISTS has NEVER
+        # reported and we're still inside the readiness window, do not treat
+        # quorum as lost yet -- a slow-to-boot NUT server must not drop a powered
+        # rack. Once every present member has reported (or the window expires),
+        # normal evaluation resumes so a genuinely dead UPS at boot still
+        # triggers protection per policy. A member with NO monitor in the map is
+        # a permanent (config/wiring) condition, not a boot delay, so it counts
+        # as UNKNOWN immediately and is excluded from the hold.
+        never_reported = [
+            n for n in self._group.ups_sources
+            if self._monitors.get(n) is not None and n not in self._ever_reported
+        ]
+        within_readiness = (
+            (time.monotonic() - self._start_monotonic) < self._readiness_window
+        )
+        cold_start_hold = bool(never_reported) and within_readiness
+        if cold_start_hold and raw_quorum_lost and not self._cold_start_logged:
+            self._cold_start_logged = True
+            self._log(
+                f"⏳ Redundancy group '{self._group.name}' deferring quorum "
+                f"decision: member(s) {', '.join(never_reported)} have not "
+                "published a first snapshot yet (cold-start protection)."
+            )
+
+        quorum_lost = raw_quorum_lost and not cold_start_hold
 
         if quorum_lost and not self._was_quorum_lost:
             tally = ", ".join(f"{name}={h.value}" for name, h in per_ups.items())

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -494,8 +494,15 @@ class RedundancyGroupEvaluator(threading.Thread):
         # connection-loss grace, on top of the startup grace). A member that has
         # reported once and then goes stale/FAILED is NOT cold-start -- it
         # counts per policy as before.
+        # Scope the readiness window to THIS group's members only (CodeRabbit):
+        # deriving it from every monitor would let an unrelated UPS with a large
+        # connection_loss_grace_period stretch this group's cold-start hold and
+        # delay a real quorum-loss shutdown longer than this group intended.
         grace_durations = []
-        for m in monitors_by_ups_name.values():
+        for name in group.ups_sources:
+            m = monitors_by_ups_name.get(name)
+            if m is None:
+                continue
             try:
                 grace_durations.append(
                     int(m.config.ups.connection_loss_grace_period.duration))

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -504,8 +504,13 @@ class RedundancyGroupEvaluator(threading.Thread):
             if m is None:
                 continue
             try:
-                grace_durations.append(
-                    int(m.config.ups.connection_loss_grace_period.duration))
+                grace = m.config.ups.connection_loss_grace_period
+                # Only count the grace duration when grace is actually ENABLED
+                # for that member (cubic). A disabled grace doesn't delay a
+                # member going FAILED, so it must not stretch this group's
+                # cold-start hold and delay a real quorum-loss shutdown.
+                if grace.enabled:
+                    grace_durations.append(int(grace.duration))
             except Exception:
                 pass
         base_grace = max(grace_durations) if grace_durations else 0

--- a/src/eneru/remote_health.py
+++ b/src/eneru/remote_health.py
@@ -498,7 +498,17 @@ class RemoteHealthManager:
             self._slow_ssh_check_streak[key] = 0
             self._slow_ssh_notified[key] = False
             return
-        if latency_ms >= self._slow_ssh_log_threshold_ms:
+        # N1: if THIS call is about to record the sustained-slow event below,
+        # skip the transient one so a single cycle doesn't write two
+        # REMOTE_SSH_SLOW_RESPONSE rows for the same probe.
+        will_record_sustained = (
+            latency_ms >= self._slow_ssh_notify_threshold_ms
+            and not self._slow_ssh_notified.get(key, False)
+            and (self._slow_ssh_check_streak.get(key, 0) + 1)
+            >= self._slow_ssh_notify_consecutive_checks
+        )
+        if (latency_ms >= self._slow_ssh_log_threshold_ms
+                and not will_record_sustained):
             last_log = self._last_slow_ssh_log_time.get(key, 0.0)
             if (
                 last_log == 0.0

--- a/src/eneru/remote_health.py
+++ b/src/eneru/remote_health.py
@@ -470,7 +470,11 @@ class RemoteHealthManager:
                         self.config.NOTIFY_FAILURE,
                     )
                     notification_sent = True
-        elif not success:
+        elif not success and current != REMOTE_HEALTH_FAILED:
+            # L8: only log "degraded" while the server is genuinely degrading
+            # (before it crosses failure_threshold). Once it's FAILED we've
+            # already logged + notified the failure; relabelling it "degraded"
+            # on every subsequent poll is noisy and misleading.
             self.log_fn(f"⚠️ Remote health degraded: {display}: {error}")
         self._record_slow_ssh_response(
             key, display, server.host, latency_ms, success, now,

--- a/src/eneru/shutdown/filesystems.py
+++ b/src/eneru/shutdown/filesystems.py
@@ -1,15 +1,44 @@
 """Filesystem sync + unmount phase of the shutdown sequence."""
 
-import os
 import shlex
 import time
 from typing import List
 
 from eneru.utils import run_command
 
+# Wall-clock bound for the filesystem sync. A bare os.sync() blocks until EVERY
+# mounted filesystem flushes; a hung/unreachable network mount (NFS/CIFS with a
+# dead server, on the same failing power circuit) would leave it forever in
+# uninterruptible D-state and the host would never reach poweroff. The kernel
+# re-syncs during halt anyway, so abandoning a stuck sync after this many
+# seconds is safe and strictly better than never powering off.
+_SYNC_TIMEOUT_SECONDS = 30
+
 
 class FilesystemShutdownMixin:
     """Mixin: filesystem sync and unmount during shutdown."""
+
+    def _bounded_sync(self, label: str) -> None:
+        """Run ``sync`` with a hard timeout so a hung mount can't stall poweroff.
+
+        Runs the coreutils ``sync`` binary as a subprocess (run_command bounds
+        it with a timeout) instead of the unbounded, uninterruptible
+        ``os.sync()``. On timeout/error we log and proceed -- the kernel flushes
+        again during the halt, so the poweroff must never be held hostage to a
+        dead network filesystem.
+        """
+        exit_code, _, _ = run_command(["sync"], timeout=_SYNC_TIMEOUT_SECONDS)
+        if exit_code == 124:
+            self._log_message(
+                f"  ⚠️ {label} timed out after {_SYNC_TIMEOUT_SECONDS}s "
+                "(a hung mount?); proceeding -- the kernel re-syncs during halt."
+            )
+        elif exit_code != 0:
+            self._log_message(
+                f"  ⚠️ {label} reported an error (exit {exit_code}); proceeding."
+            )
+        else:
+            self._log_message(f"  ✅ {label} complete")
 
     def _sync_filesystems(self):
         """Sync all filesystems.
@@ -26,9 +55,8 @@ class FilesystemShutdownMixin:
         if self.config.behavior.dry_run:
             self._log_message("  🧪 [DRY-RUN] Would sync filesystems")
         else:
-            os.sync()
+            self._bounded_sync("Filesystem sync")
             time.sleep(2)  # Allow storage controller caches to flush
-            self._log_message("  ✅ Filesystems synced")
 
     def _unmount_filesystems(self):
         """Unmount configured filesystems."""

--- a/src/eneru/shutdown/filesystems.py
+++ b/src/eneru/shutdown/filesystems.py
@@ -1,11 +1,19 @@
 """Filesystem sync + unmount phase of the shutdown sequence."""
 
 import shlex
+import shutil
 import subprocess
 import time
 from typing import List
 
 from eneru.utils import run_command
+
+# Resolve `sync` to an absolute path once. The previous os.sync() was PATH-free;
+# switching to a subprocess (to get a real timeout) introduced a PATH dependency
+# (cubic). A hardened systemd unit with a restricted PATH could then fail to find
+# `sync` and skip the flush entirely. Prefer the PATH lookup, falling back to the
+# canonical coreutils location so it resolves even with an empty PATH.
+_SYNC_BIN = shutil.which("sync") or "/bin/sync"
 
 # Wall-clock bound for the filesystem sync. A bare os.sync() blocks until EVERY
 # mounted filesystem flushes; a hung/unreachable network mount (NFS/CIFS with a
@@ -35,7 +43,7 @@ class FilesystemShutdownMixin:
         """
         try:
             proc = subprocess.Popen(
-                ["sync"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                [_SYNC_BIN], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except (OSError, ValueError) as exc:
             self._log_message(
                 f"  ⚠️ {label}: could not start `sync` ({exc}); proceeding.")

--- a/src/eneru/shutdown/filesystems.py
+++ b/src/eneru/shutdown/filesystems.py
@@ -1,6 +1,7 @@
 """Filesystem sync + unmount phase of the shutdown sequence."""
 
 import shlex
+import subprocess
 import time
 from typing import List
 
@@ -19,26 +20,51 @@ class FilesystemShutdownMixin:
     """Mixin: filesystem sync and unmount during shutdown."""
 
     def _bounded_sync(self, label: str) -> None:
-        """Run ``sync`` with a hard timeout so a hung mount can't stall poweroff.
+        """Run ``sync`` with a TRUE wall-clock bound so a hung mount can't stall
+        the poweroff.
 
-        Runs the coreutils ``sync`` binary as a subprocess (run_command bounds
-        it with a timeout) instead of the unbounded, uninterruptible
-        ``os.sync()``. On timeout/error we log and proceed -- the kernel flushes
-        again during the halt, so the poweroff must never be held hostage to a
-        dead network filesystem.
+        Uses ``Popen`` + a polling deadline rather than ``subprocess.run(timeout=)``
+        or the unbounded, uninterruptible ``os.sync()``. The reason
+        (CodeRabbit): ``subprocess.run``'s timeout sends SIGKILL and then BLOCKS
+        in wait() to reap -- and a ``sync`` stuck on a dead NFS/CIFS mount sits
+        in uninterruptible D-state where even SIGKILL can't land, so that wait
+        hangs and the "timeout" never returns. Here we poll ``proc.poll()`` and,
+        if the deadline passes, we best-effort kill and ABANDON the process
+        WITHOUT waiting -- the daemon thread is never blocked, the orphan dies at
+        halt, and the kernel re-syncs during the halt regardless.
         """
-        exit_code, _, _ = run_command(["sync"], timeout=_SYNC_TIMEOUT_SECONDS)
-        if exit_code == 124:
+        try:
+            proc = subprocess.Popen(
+                ["sync"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except (OSError, ValueError) as exc:
             self._log_message(
-                f"  ⚠️ {label} timed out after {_SYNC_TIMEOUT_SECONDS}s "
-                "(a hung mount?); proceeding -- the kernel re-syncs during halt."
-            )
-        elif exit_code != 0:
+                f"  ⚠️ {label}: could not start `sync` ({exc}); proceeding.")
+            return
+        deadline = time.monotonic() + _SYNC_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                break
+            time.sleep(0.2)
+        rc = proc.poll()
+        if rc is None:
+            # Still running at the deadline -- almost certainly a mount in
+            # uninterruptible D-state. Signal best-effort and abandon it; do NOT
+            # wait (that's exactly what would hang). Proceed to poweroff.
+            try:
+                proc.kill()
+            except Exception:
+                pass
             self._log_message(
-                f"  ⚠️ {label} reported an error (exit {exit_code}); proceeding."
+                f"  ⚠️ {label} did not finish within {_SYNC_TIMEOUT_SECONDS}s "
+                "(a hung mount?); proceeding without waiting -- the kernel "
+                "re-syncs during halt."
             )
-        else:
+        elif rc == 0:
             self._log_message(f"  ✅ {label} complete")
+        else:
+            self._log_message(
+                f"  ⚠️ {label} reported an error (exit {rc}); proceeding."
+            )
 
     def _sync_filesystems(self):
         """Sync all filesystems.

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -48,7 +48,16 @@ class RemoteShutdownResult:
 
     @property
     def success(self) -> bool:
-        """Return True only when the final shutdown command was accepted."""
+        """Return True only when the final shutdown command was accepted.
+
+        L6 (evaluated, intentional): for a loopback, ``crashed`` (a Phase-A
+        pre-action crash) and ``shutdown_sent`` (the Phase-C poweroff succeeded)
+        can BOTH be true -- the host drain partially failed but the poweroff
+        still went out. Both flags are accurate; ``success`` deliberately treats
+        a Phase-A crash as "not fully successful" so the summary surfaces the
+        drain failure, even though the host did power off. This is a reporting
+        nuance, not a shutdown defect, so it is left as-is.
+        """
         return (
             self.completed
             and self.shutdown_sent

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -14,6 +14,13 @@ from eneru.actions import REMOTE_ACTIONS, render_action, serialize_umount_target
 from eneru.config import RemoteServerConfig
 from eneru.utils import run_command
 
+# Per-command wall-clock buffer added on top of the configured timeout to absorb
+# SSH connection/teardown overhead. _run_remote_command spends this on every
+# command. _shutdown_remote_server reserves command_timeout + this buffer for
+# the final poweroff before spending the deadline on pre-shutdown commands, so a
+# slow pre-phase can't starve the poweroff (H8).
+_SSH_OVERHEAD_BUFFER = 30
+
 
 @dataclass
 class RemotePreShutdownResult:
@@ -504,7 +511,7 @@ class RemoteShutdownMixin:
         # shutdown-phase deadline requires a tighter cap. This prevents a
         # hung pre-shutdown command from outliving the phase and later
         # drifting into the final shutdown command.
-        command_timeout = timeout + 30
+        command_timeout = timeout + _SSH_OVERHEAD_BUFFER
         if deadline is not None:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -516,11 +523,11 @@ class RemoteShutdownMixin:
             return True, ""
         elif exit_code == 124:
             # ``command_timeout`` is the value actually handed to
-            # ``run_command`` (timeout + 30 s buffer, capped by the
+            # ``run_command`` (timeout + SSH overhead buffer, capped by the
             # phase deadline). Reporting just ``timeout`` would mislead
             # operators when deadline-capping shrinks the effective
             # window below what was configured per-command.
-            if command_timeout != timeout + 30:
+            if command_timeout != timeout + _SSH_OVERHEAD_BUFFER:
                 return (
                     False,
                     f"timed out after {command_timeout}s "
@@ -745,13 +752,28 @@ class RemoteShutdownMixin:
             category="shutdown",
         )
 
-        # Execute pre-shutdown commands first
+        # Execute pre-shutdown commands first. RESERVE enough of the phase
+        # deadline for the final shutdown command (its own timeout + the SSH
+        # overhead buffer _run_remote_command adds) so a slow pre-shutdown phase
+        # can NEVER starve or skip the actual poweroff (H8). Pre-commands run
+        # against the reduced deadline; the poweroff then runs against the full
+        # deadline, spending the reserved slice. When the reserve exceeds the
+        # whole budget, pre-commands get no time at all -- the poweroff wins.
         if has_pre_cmds:
+            pre_deadline = deadline
+            if deadline is not None:
+                final_reserve = server.command_timeout + _SSH_OVERHEAD_BUFFER
+                pre_deadline = deadline - final_reserve
             result.pre_commands = self._execute_remote_pre_shutdown(
-                server, collect_result=True, deadline=deadline,
+                server, collect_result=True, deadline=pre_deadline,
             )
 
-        if result.pre_commands.timed_out or self._remote_deadline_exceeded(deadline):
+        # Skip the poweroff ONLY when the FULL phase deadline is blown. A
+        # pre-phase that merely exhausted its reserved slice (pre_commands
+        # .timed_out) must NOT cancel the poweroff -- reserving its budget is
+        # precisely what stops the starvation H8 fixes. Pre-phase failures are
+        # still recorded in result.pre_commands for the summary.
+        if self._remote_deadline_exceeded(deadline):
             result.completed = False
             result.timed_out = True
             result.error = (

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -164,6 +164,12 @@ class RemoteShutdownMixin:
                 pre_commands=RemotePreShutdownResult(),
             )
 
+        # M2: verify each loopback's host identity ON the destructive path, not
+        # only in the background health loop, so a misconfigured machine-id
+        # bind-mount is surfaced at the moment we drain/poweroff via the delegate.
+        if loopbacks:
+            self._verify_loopback_identities(loopbacks)
+
         phase_idx = 0
         regular_results: List[RemoteShutdownResult] = []
 
@@ -338,6 +344,44 @@ class RemoteShutdownMixin:
             self._send_notification(
                 f"❌ **Remote Shutdown Failed:** {display}\nError: {error_msg}",
                 self.config.NOTIFY_FAILURE,
+                category="shutdown",
+            )
+
+    def _verify_loopback_identities(self, loopbacks) -> None:
+        """Advisory host-identity check on the DESTRUCTIVE loopback path (M2).
+
+        The background remote-health loop verifies loopback identity, but the
+        shutdown path itself did not. Re-run the probe here -- for loopbacks that
+        actually have an ``expected_host_identity`` to check against -- so a
+        misconfigured /etc/machine-id bind-mount is surfaced (log + notification)
+        at the exact moment we are about to drain/poweroff via that delegate.
+
+        We deliberately do NOT abort on failure: the loopback shutdown command
+        targets 127.0.0.1 = THIS host, which is exactly what must be powered off
+        during an outage. Refusing would leave the host running on a draining
+        battery -- a missed shutdown, the worse outcome. So we warn loudly and
+        proceed.
+        """
+        from eneru.remote_health import run_loopback_identity_probe
+        for lb in loopbacks:
+            if not lb.expected_host_identity:
+                continue  # nothing to verify against -- the probe can't confirm
+            try:
+                ok, detail, _ = run_loopback_identity_probe(lb)
+            except Exception as exc:  # pragma: no cover - defensive
+                ok, detail = False, f"identity probe raised: {exc}"
+            if ok:
+                continue
+            display = lb.name or lb.host
+            self._log_message(
+                f"⚠️ Loopback host-identity check FAILED for {display} before "
+                f"delegated shutdown: {detail} Proceeding anyway -- the loopback "
+                "poweroff targets the local host, which must go down in an outage."
+            )
+            self._send_notification(
+                f"⚠️ **Loopback identity unverified before shutdown:** {display}\n"
+                f"{detail}",
+                self.config.NOTIFY_WARNING,
                 category="shutdown",
             )
 

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -173,12 +173,15 @@ class RemoteShutdownMixin:
                 pre_commands=RemotePreShutdownResult(),
             )
 
-        # M2: verify each loopback's host identity ON the destructive path, not
-        # only in the background health loop, so a misconfigured machine-id
-        # bind-mount is surfaced at the moment we drain/poweroff via the delegate.
-        if loopbacks:
-            self._verify_loopback_identities(loopbacks)
-
+        # M2 NOTE: an earlier rc10 iteration ran a fresh, blocking
+        # run_loopback_identity_probe() here before the destructive phases. It
+        # was reverted: the probe is an SSH round-trip (bounded, but up to
+        # connect_timeout+10s) that would delay the poweroff during an outage,
+        # and we PROCEED regardless of its result, so it added latency on the
+        # critical path for purely-informational value. Loopback identity is
+        # already verified by the background RemoteHealthManager loop (which
+        # logs + notifies a mismatch) and gated by /ready, so the misconfig is
+        # surfaced there without blocking shutdown.
         phase_idx = 0
         regular_results: List[RemoteShutdownResult] = []
 
@@ -356,44 +359,6 @@ class RemoteShutdownMixin:
                 category="shutdown",
             )
 
-    def _verify_loopback_identities(self, loopbacks) -> None:
-        """Advisory host-identity check on the DESTRUCTIVE loopback path (M2).
-
-        The background remote-health loop verifies loopback identity, but the
-        shutdown path itself did not. Re-run the probe here -- for loopbacks that
-        actually have an ``expected_host_identity`` to check against -- so a
-        misconfigured /etc/machine-id bind-mount is surfaced (log + notification)
-        at the exact moment we are about to drain/poweroff via that delegate.
-
-        We deliberately do NOT abort on failure: the loopback shutdown command
-        targets 127.0.0.1 = THIS host, which is exactly what must be powered off
-        during an outage. Refusing would leave the host running on a draining
-        battery -- a missed shutdown, the worse outcome. So we warn loudly and
-        proceed.
-        """
-        from eneru.remote_health import run_loopback_identity_probe
-        for lb in loopbacks:
-            if not lb.expected_host_identity:
-                continue  # nothing to verify against -- the probe can't confirm
-            try:
-                ok, detail, _ = run_loopback_identity_probe(lb)
-            except Exception as exc:  # pragma: no cover - defensive
-                ok, detail = False, f"identity probe raised: {exc}"
-            if ok:
-                continue
-            display = lb.name or lb.host
-            self._log_message(
-                f"⚠️ Loopback host-identity check FAILED for {display} before "
-                f"delegated shutdown: {detail} Proceeding anyway -- the loopback "
-                "poweroff targets the local host, which must go down in an outage."
-            )
-            self._send_notification(
-                f"⚠️ **Loopback identity unverified before shutdown:** {display}\n"
-                f"{detail}",
-                self.config.NOTIFY_WARNING,
-                category="shutdown",
-            )
-
     def _shutdown_servers_parallel(
         self, servers: List[RemoteServerConfig]
     ) -> List[RemoteShutdownResult]:
@@ -410,11 +375,19 @@ class RemoteShutdownMixin:
                 (cmd.timeout if cmd.timeout is not None else server.command_timeout)
                 for cmd in server.pre_shutdown_commands
             )
+            # _run_remote_command spends `timeout + _SSH_OVERHEAD_BUFFER` on EACH
+            # command (every pre-shutdown command plus the final shutdown). The
+            # phase-deadline budget must reserve that buffer per command too
+            # (CodeRabbit), otherwise the parallel join deadline can expire while
+            # a worker is still legitimately inside its own SSH timeout and the
+            # server is wrongly reported timed-out.
+            num_commands = len(server.pre_shutdown_commands) + 1
             return (
                 pre_cmd_time
                 + server.command_timeout
                 + server.connect_timeout
                 + server.shutdown_safety_margin
+                + num_commands * _SSH_OVERHEAD_BUFFER
             )
 
         max_timeout = max(calc_server_timeout(s) for s in servers)

--- a/src/eneru/shutdown/vms.py
+++ b/src/eneru/shutdown/vms.py
@@ -54,7 +54,13 @@ class VMShutdownMixin:
         remaining_vms: List[str] = list(running_vms)
 
         while time_waited < max_wait:
-            exit_code, stdout, _ = run_command(["virsh", "list", "--name", "--state-running"])
+            # L7: bound each poll to wait_interval so a wedged libvirtd (a virsh
+            # call that hangs to run_command's 30s default) can't blow the
+            # max_wait budget many times over before force-destroy/poweroff.
+            exit_code, stdout, _ = run_command(
+                ["virsh", "list", "--name", "--state-running"],
+                timeout=wait_interval,
+            )
             if exit_code != 0:
                 # libvirtd may be wedged or restarting. Don't trust empty
                 # stdout as "all stopped" — keep the previous remaining_vms

--- a/src/eneru/shutdown/vms.py
+++ b/src/eneru/shutdown/vms.py
@@ -46,20 +46,24 @@ class VMShutdownMixin:
         max_wait = self.config.virtual_machines.max_wait
         self._log_message(f"  ⏳ Waiting up to {max_wait}s for VMs to shutdown gracefully...")
         wait_interval = 5
-        time_waited = 0
+        # L7 / CodeRabbit: use a WALL-CLOCK deadline rather than counting only
+        # the sleeps. The old loop advanced `time_waited` only after sleep(), so
+        # each (bounded) `virsh list` poll plus a wedged libvirtd could stretch
+        # the phase well past max_wait. A monotonic deadline charges poll time
+        # too, and each poll/sleep is capped to the remaining budget so the whole
+        # graceful wait is bounded by ~max_wait before force-destroy/poweroff.
+        deadline = time.monotonic() + max_wait
         # Seed with the originally-running list so a transient virsh
         # failure on the first poll doesn't make the loop think the VMs
         # are gone (empty stdout would otherwise yield remaining_vms=[]
         # and skip force-destroy).
         remaining_vms: List[str] = list(running_vms)
 
-        while time_waited < max_wait:
-            # L7: bound each poll to wait_interval so a wedged libvirtd (a virsh
-            # call that hangs to run_command's 30s default) can't blow the
-            # max_wait budget many times over before force-destroy/poweroff.
+        while time.monotonic() < deadline:
+            remaining_budget = max(1, int(deadline - time.monotonic()))
             exit_code, stdout, _ = run_command(
                 ["virsh", "list", "--name", "--state-running"],
-                timeout=wait_interval,
+                timeout=min(wait_interval, remaining_budget),
             )
             if exit_code != 0:
                 # libvirtd may be wedged or restarting. Don't trust empty
@@ -75,13 +79,13 @@ class VMShutdownMixin:
                 remaining_vms = [vm for vm in running_vms if vm in still_running]
 
                 if not remaining_vms:
-                    self._log_message(f"  ✅ All VMs stopped gracefully after {time_waited}s.")
+                    self._log_message("  ✅ All VMs stopped gracefully.")
                     break
 
-                self._log_message(f"  🕒 Still waiting for: {' '.join(remaining_vms)} (Waited {time_waited}s)")
+                self._log_message(f"  🕒 Still waiting for: {' '.join(remaining_vms)}")
 
-            time.sleep(wait_interval)
-            time_waited += wait_interval
+            # Sleep only up to the remaining budget so we don't overshoot.
+            time.sleep(max(0, min(wait_interval, deadline - time.monotonic())))
 
         if remaining_vms:
             self._log_message("  ⚠️ Timeout reached. Force destroying remaining VMs.")

--- a/src/eneru/state.py
+++ b/src/eneru/state.py
@@ -68,6 +68,11 @@ class MonitorState:
     connection_flap_count: int = 0
     connection_first_flap_time: float = 0.0
     stale_data_count: int = 0
+    # Consecutive HARD poll failures (connection refused / timeout / non-stale
+    # errors) since the last success. Mirrors stale_data_count so the on-battery
+    # FAILSAFE debounces a single transient NUT blip the same way stale data is
+    # debounced (H3); reset to 0 on any successful poll.
+    connection_error_count: int = 0
     voltage_warning_low: float = 0.0
     voltage_warning_high: float = 0.0
     nominal_voltage: float = 230.0

--- a/src/eneru/state.py
+++ b/src/eneru/state.py
@@ -161,6 +161,17 @@ class MonitorState:
         Always read via this helper from another thread; direct attribute
         access is not safe because the poll cycle updates several fields in
         quick succession.
+
+        L12 (SUSPECTED, evaluated): this reader holds ``_lock``, and the
+        safety-critical multi-field writes (the depletion-rate write and the
+        end-of-cycle bulk publish in monitor.py) each take ``_lock`` too, so the
+        decision-relevant fields are consistent. A few *derived display* fields
+        (voltage_state / avr_state / bypass_state / overload_state) are updated
+        in health/voltage.py without the lock, so a snapshot can occasionally
+        catch one of those a single poll stale. Impact is unproven and cosmetic
+        (they feed status/Prometheus labels, not shutdown decisions); locking
+        every writer on the hot poll loop is risk-for-little-gain, so this is
+        documented for maintainer judgment rather than changed here.
         """
         with self._lock:
             return HealthSnapshot(

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -1197,14 +1197,10 @@ class StatsStore:
     def from_connection(cls, conn: sqlite3.Connection) -> "StatsStore":
         """Wrap an existing SQLite connection without taking ownership."""
         store = cls(Path(":memory:"))
-        # __init__ already opened a throw-away in-memory SQLite handle
-        # to keep the dataclass invariants happy. Close it before
-        # rebinding to the caller-owned connection so the wrapper
-        # doesn't leak one sqlite handle per call.
-        try:
-            store._conn.close()
-        except Exception:
-            pass
+        # N5: __init__ does NOT open a connection (self._conn stays None until
+        # open()), so there is no throw-away handle to close here -- the previous
+        # store._conn.close() always raised AttributeError into a swallowed
+        # except. Just rebind to the caller-owned connection.
         store._conn = conn
         return store
 

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -51,6 +51,13 @@ SCHEMA_VERSION = 5
 BUCKET_5MIN = 5 * 60
 BUCKET_HOURLY = 60 * 60
 
+# Numeric sample columns that query_range may select. `metric` is interpolated
+# into the SQL column position there, so this internal allowlist (L11) is
+# defense-in-depth: callers already validate against status.HISTORY_METRICS, but
+# a future caller that forgets cannot inject. Derived from SAMPLE_FIELDS so it
+# stays in sync; the non-numeric/identity columns are excluded.
+_QUERYABLE_METRICS = frozenset(SAMPLE_FIELDS) - {"ts", "status", "connection_state"}
+
 
 def _to_float(value) -> Optional[float]:
     """Lenient float coercion. Returns ``None`` for empty / non-numeric."""
@@ -1100,6 +1107,11 @@ class StatsStore:
         ``depletion_rate``.
         """
         if self._conn is None:
+            return []
+
+        # L11: reject any metric not on the internal allowlist before it reaches
+        # the interpolated column position.
+        if metric not in _QUERYABLE_METRICS:
             return []
 
         tier = prefer_tier or self._pick_tier(start_ts, end_ts)

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -630,6 +630,15 @@ class StatsStore:
         cutoff_raw = now - self.retention_raw_hours * 3600
         cutoff_5min = now - self.retention_5min_days * 86400
         cutoff_hourly = now - self.retention_hourly_days * 86400
+        # M5: align the raw/5-min cutoffs DOWN to the next-tier bucket boundary
+        # so purge only ever deletes WHOLE buckets' worth of rows. Otherwise it
+        # trims the early rows of the bucket straddling the cutoff, and the next
+        # aggregate() re-derives that already-finalized bucket from the reduced
+        # set -- overwriting its avg/min/max with wrong values that then
+        # propagate into the hourly tier. Keeping at most one extra bucket of raw
+        # data (~5 min) / 5-min data (~1 h) is a negligible retention cost.
+        cutoff_raw = (cutoff_raw // BUCKET_5MIN) * BUCKET_5MIN
+        cutoff_5min = (cutoff_5min // BUCKET_HOURLY) * BUCKET_HOURLY
         try:
             with self._db_lock, self._conn:
                 deleted_raw = self._conn.execute(

--- a/src/eneru/status.py
+++ b/src/eneru/status.py
@@ -115,9 +115,18 @@ def monitor_status(monitor: Any) -> Dict[str, Any]:
             "avrState": snap.avr_state,
             "bypassState": snap.bypass_state,
             "overloadState": snap.overload_state,
-            "nominalVoltage": snap.nominal_voltage,
-            "warningLow": snap.voltage_warning_low,
-            "warningHigh": snap.voltage_warning_high,
+            # L13: these are Eneru-DERIVED thresholds, set by
+            # _initialize_voltage_thresholds on the first successful poll. Before
+            # that they hold dataclass defaults (230.0 / 0.0 / 0.0) that are
+            # indistinguishable from real readings. Report null until a poll has
+            # landed so consumers (Prometheus -> NaN, MQTT -> none) see "unknown"
+            # rather than a fake 0V warning band.
+            "nominalVoltage": (snap.nominal_voltage
+                               if snap.last_update_time else None),
+            "warningLow": (snap.voltage_warning_low
+                           if snap.last_update_time else None),
+            "warningHigh": (snap.voltage_warning_high
+                            if snap.last_update_time else None),
         },
         "depletionRate": snap.depletion_rate,
         "timeOnBattery": snap.time_on_battery,

--- a/src/eneru/utils.py
+++ b/src/eneru/utils.py
@@ -35,6 +35,12 @@ def run_command(
     capture_output: bool = True
 ) -> Tuple[int, str, str]:
     """Run a shell command and return (exit_code, stdout, stderr)."""
+    # A None timeout means "wait forever" to subprocess.run. No caller wants
+    # that during a shutdown sequence: a config value that slipped through as
+    # None (e.g. `unmount.timeout:` with no value) would otherwise let a busy
+    # umount hang the drain phase indefinitely. Fall back to the default bound.
+    if timeout is None:
+        timeout = 30
     try:
         result = subprocess.run(
             cmd,

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.0.0-rc9"
+__version__ = "6.0.0-rc10"

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -52,7 +52,16 @@ async function api(path, opts) {
   const headers = opts.headers || {};
   if (token()) headers["Authorization"] = "Bearer " + token();
   if (opts.body) headers["Content-Type"] = "application/json";
-  const res = await fetch(path, { method: opts.method || "GET", headers, body: opts.body });
+  let res;
+  try {
+    res = await fetch(path, { method: opts.method || "GET", headers, body: opts.body });
+  } catch (_e) {
+    // L14: a network error (daemon down, or connectivity lost during a power
+    // event -- exactly when the dashboard matters) rejects the fetch. Return a
+    // non-ok result with status 0 so callers show a "connection lost" indicator
+    // instead of an unhandled rejection that silently freezes the poll loop.
+    return { ok: false, status: 0, data: null };
+  }
   if (res.status === 401) { setToken(""); refreshAuthUI(); }
   let data = null;
   try { data = await res.json(); } catch (_e) { /* non-JSON (static) */ }
@@ -589,16 +598,29 @@ function observeGraphResize() {
 
 // ----- control panel (5c) -----
 
+// L15: cache key for the built control panel. The command/variable lists are
+// config-static, so rebuilding the panel every poll was pure waste -- 2 extra
+// requests per UPS each cycle AND it wiped any half-typed variable value. We
+// rebuild only when the auth token or the set of UPS names actually changes.
+let _controlBuiltKey = null;
+
 async function renderControl(payload) {
   const sec = document.getElementById("control-section");
   const panel = document.getElementById("control-panel");
   // Control is only meaningful when authenticated and nut_control is enabled.
   const nutEnabled = cfgSnapshot && cfgSnapshot.nutControl &&
     cfgSnapshot.nutControl.enabled;
-  if (!token() || !nutEnabled) { sec.hidden = true; return; }
+  if (!token() || !nutEnabled) {
+    sec.hidden = true;
+    _controlBuiltKey = null;  // rebuild when control becomes available again
+    return;
+  }
   sec.hidden = false;
-  panel.replaceChildren();
   const rows = (payload && payload.ups) || [];
+  const key = token() + "|" + rows.map((u) => u.name).join(",");
+  if (key === _controlBuiltKey) return;  // already built for this token + UPS set
+  _controlBuiltKey = key;
+  panel.replaceChildren();
   for (const u of rows) {
     const box = el("div", { class: "control-ups" }, [el("h3", { text: u.label || u.name })]);
     box.appendChild(el("h4", { text: "Commands" }));
@@ -765,6 +787,8 @@ async function refresh() {
   const ups = await api("/api/v1/ups");
   if (ups.ok) {
     renderUps(ups.data); renderControl(ups.data); renderBanner(); showError("");
+  } else if (ups.status === 0) {
+    showError("⚠️ Connection lost — retrying…");  // L14: network/daemon down
   } else if (ups.status !== 401) {
     showError("Could not load UPS status (HTTP " + ups.status + ")");
   }

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -362,9 +362,12 @@ function updateEventSourceFilter(upsRows, groups) {
   (upsRows || []).forEach((u) => knownEventSources.push({
     value: u.name, label: u.label || u.name,
   }));
-  (groups || []).forEach((g) => knownEventSources.push({
-    value: "redundancy:" + g.name, label: "redundancy:" + g.name,
-  }));
+  // M8: do NOT offer "redundancy:<name>" as an event source. Redundancy-group
+  // power events are written to the text log only -- they never land in any
+  // per-UPS stats DB, so /api/v1/events can never return rows for them and the
+  // filter would be permanently empty. (`groups` is accepted for signature
+  // stability / future use once redundancy events are persisted.)
+  void groups;
   const sel = document.getElementById("event-source-filter");
   const prev = sel.value;
   sel.replaceChildren(el("option", { value: "", text: "All sources" }));

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -617,15 +617,30 @@ async function renderControl(payload) {
   }
   sec.hidden = false;
   const rows = (payload && payload.ups) || [];
-  const key = token() + "|" + rows.map((u) => u.name).join(",");
-  if (key === _controlBuiltKey) return;  // already built for this token + UPS set
-  _controlBuiltKey = key;
-  panel.replaceChildren();
+  // Key on token + UPS set AND the allowlists, so a live config reload that
+  // changes allowed commands/variables (without changing token or UPS set)
+  // still busts the cache and rebuilds (CodeRabbit). /api/v1/config exposes the
+  // allowlists when authenticated.
+  const nc = (cfgSnapshot && cfgSnapshot.nutControl) || {};
+  const key = JSON.stringify({
+    token: token(),
+    ups: rows.map((u) => u.name),
+    commands: nc.allowedCommands || [],
+    variables: nc.allowedVariables || [],
+  });
+  if (key === _controlBuiltKey) return;  // already built for this token + UPS set + allowlists
+  // Build into a detached fragment and commit the cache key only once EVERY
+  // fetch succeeded (cubic P2). Setting the key up-front meant a transient
+  // commands/variables fetch failure built an empty panel that then never
+  // rebuilt for the rest of the session.
+  let builtOk = true;
+  const frag = document.createDocumentFragment();
   for (const u of rows) {
     const box = el("div", { class: "control-ups" }, [el("h3", { text: u.label || u.name })]);
     box.appendChild(el("h4", { text: "Commands" }));
     const cmds = el("div", { class: "cmds" });
     const res = await api("/api/v1/ups/" + encodeURIComponent(u.name) + "/commands");
+    if (!res.ok) builtOk = false;
     ((res.data && res.data.commands) || []).forEach((c) => {
       const btn = el("button", { type: "button", text: c });
       btn.addEventListener("click", () => runCommand(u.name, c));
@@ -634,9 +649,13 @@ async function renderControl(payload) {
     if (!cmds.childNodes.length) cmds.appendChild(el("span", { class: "who", text: "No allowlisted commands." }));
     box.appendChild(cmds);
     box.appendChild(el("h4", { text: "Variables" }));
-    box.appendChild(await renderVariableForms(u.name));
-    panel.appendChild(box);
+    const vres = await renderVariableForms(u.name);
+    if (!vres.ok) builtOk = false;
+    box.appendChild(vres.node);
+    frag.appendChild(box);
   }
+  panel.replaceChildren(frag);
+  _controlBuiltKey = builtOk ? key : null;  // retry next poll if anything failed
 }
 
 async function renderVariableForms(ups) {
@@ -663,7 +682,7 @@ async function renderVariableForms(ups) {
   if (!vars.childNodes.length) {
     vars.appendChild(el("span", { class: "who", text: "No allowlisted variables." }));
   }
-  return vars;
+  return { node: vars, ok: res.ok };  // ok feeds renderControl's cache-key commit
 }
 
 async function runCommand(ups, command) {

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -222,14 +222,30 @@ def test_session_preserved_when_get_user_errors(minimal_config):
 
 
 @pytest.mark.unit
+def test_write_recheck_fails_closed_on_db_error(minimal_config):
+    # M4: a WRITE/control path must fail closed when the session user lookup
+    # errors -- a just-deleted admin must not keep control through a DB blip --
+    # while reads stay lenient and the token survives for when the DB recovers.
+    store = MagicMock()
+    store.get_user.side_effect = RuntimeError("db locked")
+    sessions = SessionManager(3600)
+    token = sessions.create({"username": "alice", "role": "admin", "kind": "user"})
+    h = _handler(minimal_config, auth_store=store, sessions=sessions,
+                 headers={"Authorization": f"Bearer {token}"})
+    assert h._authenticate_request()["username"] == "alice"      # read: lenient
+    assert h._authenticate_request(strict=True) is None          # write: denied
+    assert sessions.validate(token) is not None                  # token intact
+
+
+@pytest.mark.unit
 def test_session_validity_ignores_non_user_principals(minimal_config):
     # API-key-kind principals never carry a username; they must not be re-checked
     # via get_user (and must not be invalidated by it).
     store = MagicMock()
     h = _handler(minimal_config, auth_store=store)
-    assert h._session_principal_still_valid({"kind": "api_key", "id": 1}) is True
+    assert h._session_user_status({"kind": "api_key", "id": 1}) == "ok"
     # A user-kind principal without a username is treated as valid (defensive).
-    assert h._session_principal_still_valid({"kind": "user"}) is True
+    assert h._session_user_status({"kind": "user"}) == "ok"
     store.get_user.assert_not_called()
 
 

--- a/tests/test_cli_user.py
+++ b/tests/test_cli_user.py
@@ -95,6 +95,18 @@ def test_user_create_invalid_role_errors(db):
                                  role="viewer"))
 
 
+@pytest.mark.unit
+def test_user_create_normalizes_padded_username(db, capsys):
+    # cubic: a whitespace-padded --username must be canonicalized so the
+    # success message and any later lookup key on the SAME (stripped) name.
+    cli._cmd_user_create(_ns(username="  alice  ", auth_db=db, generate=True))
+    out = capsys.readouterr().out
+    assert "Created user 'alice'" in out  # printed name is normalized
+    store = auth.AuthStore(db)
+    assert store.get_user("alice") is not None
+    assert store.get_user("  alice  ") is None  # not stored padded
+
+
 # ----- user list / show / passwd / delete -----
 
 @pytest.mark.unit
@@ -134,6 +146,15 @@ def test_user_passwd_generate(db, capsys):
 def test_user_passwd_missing_errors(db):
     with pytest.raises(SystemExit):
         cli._cmd_user_passwd(_ns(username="ghost", auth_db=db, generate=True))
+
+
+@pytest.mark.unit
+def test_user_passwd_normalizes_padded_username(db, capsys):
+    # cubic: set_password() keys the lookup on the exact string; a padded name
+    # must be normalized so an existing user is found (not prompt-then-miss).
+    auth.AuthStore(db).create_user("alice", "old")
+    cli._cmd_user_passwd(_ns(username="  alice  ", auth_db=db, generate=True))
+    assert "Updated password for 'alice'" in capsys.readouterr().out
 
 
 @pytest.mark.unit

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -88,6 +88,95 @@ class TestConfigValidation:
             messages = ConfigLoader.validate_config(minimal_config)
             assert not any("trigger_on" in m for m in messages)
 
+    # --- C2: shutdown-trigger numeric fields must be validated at load ---
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", ["20", "thirty", None, [20], True])
+    def test_validate_rejects_nonint_low_battery_threshold(self, minimal_config, bad):
+        """Regression (C2): a non-int low_battery_threshold (most commonly a
+        quoted '20' from a templating tool) must error at load. Otherwise it
+        survives parse as a str and raises TypeError (int < str) on the first
+        on-battery poll, killing the monitor loop when a shutdown is due."""
+        minimal_config.triggers.low_battery_threshold = bad
+        errors = [m for m in ConfigLoader.validate_config(minimal_config)
+                  if m.startswith("ERROR")]
+        assert any("low_battery_threshold" in m for m in errors), (
+            f"low_battery_threshold={bad!r} should ERROR; got {errors!r}")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", [-1, 101, 150])
+    def test_validate_rejects_out_of_range_low_battery_threshold(
+            self, minimal_config, bad):
+        minimal_config.triggers.low_battery_threshold = bad
+        errors = [m for m in ConfigLoader.validate_config(minimal_config)
+                  if m.startswith("ERROR")]
+        assert any("low_battery_threshold" in m for m in errors)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", ["600", None, True, [1]])
+    def test_validate_rejects_nonint_critical_runtime_threshold(
+            self, minimal_config, bad):
+        minimal_config.triggers.critical_runtime_threshold = bad
+        errors = [m for m in ConfigLoader.validate_config(minimal_config)
+                  if m.startswith("ERROR")]
+        assert any("critical_runtime_threshold" in m for m in errors)
+
+    @pytest.mark.unit
+    def test_validate_rejects_nonnumeric_depletion_and_extended(
+            self, minimal_config):
+        """depletion.* and extended_time.threshold feed comparisons too."""
+        minimal_config.triggers.depletion.critical_rate = "fast"
+        minimal_config.triggers.depletion.window = "300"
+        minimal_config.triggers.depletion.grace_period = None
+        minimal_config.triggers.extended_time.threshold = "900"
+        errors = [m for m in ConfigLoader.validate_config(minimal_config)
+                  if m.startswith("ERROR")]
+        assert any("depletion.critical_rate" in m for m in errors)
+        assert any("depletion.window" in m for m in errors)
+        assert any("depletion.grace_period" in m for m in errors)
+        assert any("extended_time.threshold" in m for m in errors)
+
+    @pytest.mark.unit
+    def test_validate_accepts_valid_trigger_numbers(self, minimal_config):
+        """Defaults (incl. float critical_rate) produce no trigger-number ERROR."""
+        messages = ConfigLoader.validate_config(minimal_config)
+        assert not any(
+            m.startswith("ERROR") and (
+                "low_battery_threshold" in m
+                or "critical_runtime_threshold" in m
+                or "depletion." in m
+                or "extended_time.threshold" in m)
+            for m in messages)
+
+    # --- C3: local_shutdown.command must be a non-empty string when enabled ---
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", [None, "", "   "])
+    def test_validate_rejects_empty_local_shutdown_command(
+            self, minimal_config, bad):
+        """Regression (C3): null/empty command must error at load, not let
+        None.split()/run_command([]) silently skip the host poweroff after the
+        drain phases already ran."""
+        minimal_config.local_shutdown.enabled = True
+        minimal_config.local_shutdown.command = bad
+        errors = [m for m in ConfigLoader.validate_config(minimal_config)
+                  if m.startswith("ERROR")]
+        assert any("local_shutdown.command" in m for m in errors), (
+            f"command={bad!r} should ERROR; got {errors!r}")
+
+    @pytest.mark.unit
+    def test_validate_accepts_valid_local_shutdown_command(self, minimal_config):
+        minimal_config.local_shutdown.enabled = True
+        minimal_config.local_shutdown.command = "shutdown -h now"
+        messages = ConfigLoader.validate_config(minimal_config)
+        assert not any("local_shutdown.command" in m for m in messages)
+
+    @pytest.mark.unit
+    def test_validate_ignores_empty_command_when_disabled(self, minimal_config):
+        """An empty command is harmless when local shutdown is disabled."""
+        minimal_config.local_shutdown.enabled = False
+        minimal_config.local_shutdown.command = ""
+        messages = ConfigLoader.validate_config(minimal_config)
+        assert not any("local_shutdown.command" in m for m in messages)
+
     @pytest.mark.unit
     def test_validate_new_observability_defaults(self, minimal_config):
         """v5.3 observability defaults are safe and valid."""

--- a/tests/test_connection_grace_period.py
+++ b/tests/test_connection_grace_period.py
@@ -4,6 +4,8 @@ import pytest
 import time
 from unittest.mock import patch, MagicMock, call
 
+from test_monitor_core import _run_one_iteration
+
 from eneru import (
     Config,
     UPSConfig,
@@ -329,51 +331,37 @@ class TestGracePeriodFailsafe:
 
     @pytest.mark.unit
     def test_failsafe_bypasses_grace_period_on_battery(self, monitor):
-        """Test that failsafe fires immediately when on battery."""
+        """L21/L22: drive the REAL _main_loop. A failed poll while on battery
+        fires the failsafe (grace never applies on battery). The hard-error
+        debounce (H3) is pre-satisfied so the single iteration fires."""
+        monitor._in_redundancy_group = False
         monitor.state.previous_status = "OB DISCHRG"
         monitor.state.connection_state = "OK"
-
-        with patch.object(monitor, "_execute_shutdown_sequence") as mock_shutdown:
-            with patch.object(monitor, "_send_notification"):
-                # Simulate the main loop logic
-                is_failsafe_trigger = True
-
-                if is_failsafe_trigger and "OB" in monitor.state.previous_status:
-                    monitor.state.connection_state = "FAILED"
-                    monitor.state.connection_lost_time = 0.0
-                    monitor._shutdown_flag_path.touch()
-                    monitor._send_notification("FAILSAFE", monitor.config.NOTIFY_FAILURE)
-                    monitor._execute_shutdown_sequence()
-                elif is_failsafe_trigger:
-                    monitor._handle_connection_failure("Connection refused")
-
-                mock_shutdown.assert_called_once()
-                assert monitor.state.connection_state == "FAILED"
+        monitor.state.connection_error_count = (
+            monitor.config.ups.max_stale_data_tolerance - 1
+        )
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_shutdown, \
+                patch.object(monitor, "_send_notification"):
+            _run_one_iteration(monitor, (False, {}, "Connection refused"))
+        mock_shutdown.assert_called_once()
+        assert monitor.state.connection_state == "FAILED"
 
     @pytest.mark.unit
     def test_failsafe_during_active_grace_period(self, monitor):
-        """Test failsafe fires if power goes out during grace period."""
-        # Start in grace period (connection lost while on line power)
+        """L22: power goes out (OB) while a connection grace period is active;
+        the REAL loop's failsafe must still fire (grace is bypassed on battery)."""
+        monitor._in_redundancy_group = False
         monitor.state.connection_state = "GRACE_PERIOD"
         monitor.state.connection_lost_time = time.time() - 10
-        # Now power goes out
         monitor.state.previous_status = "OB DISCHRG"
-
-        with patch.object(monitor, "_execute_shutdown_sequence") as mock_shutdown:
-            with patch.object(monitor, "_send_notification"):
-                is_failsafe_trigger = True
-
-                if is_failsafe_trigger and "OB" in monitor.state.previous_status:
-                    monitor.state.connection_state = "FAILED"
-                    monitor.state.connection_lost_time = 0.0
-                    monitor._shutdown_flag_path.touch()
-                    monitor._send_notification("FAILSAFE", monitor.config.NOTIFY_FAILURE)
-                    monitor._execute_shutdown_sequence()
-                elif is_failsafe_trigger:
-                    monitor._handle_connection_failure("Connection refused")
-
-                mock_shutdown.assert_called_once()
-                assert monitor.state.connection_state == "FAILED"
+        monitor.state.connection_error_count = (
+            monitor.config.ups.max_stale_data_tolerance - 1
+        )
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_shutdown, \
+                patch.object(monitor, "_send_notification"):
+            _run_one_iteration(monitor, (False, {}, "Connection refused"))
+        mock_shutdown.assert_called_once()
+        assert monitor.state.connection_state == "FAILED"
 
 
 # ==============================================================================

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -339,7 +339,7 @@ class TestScheduleDeferred:
         assert "--config" in cmd
         assert "/etc/ups-monitor/config.yaml" in cmd
         # Eager-send fallback should NOT have fired.
-        worker._send_via_apprise.assert_not_called()
+        worker._send_via_apprise_bounded.assert_not_called()
         # Log should mention scheduling.
         assert any("scheduled" in c.args[0].lower()
                    for c in log.call_args_list)
@@ -372,7 +372,7 @@ class TestScheduleDeferred:
         """No systemd-run on PATH → eager Apprise delivery."""
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
 
         with patch("eneru.deferred_delivery.subprocess.run",
                    side_effect=FileNotFoundError("systemd-run")), \
@@ -388,7 +388,7 @@ class TestScheduleDeferred:
                 worker=worker,
                 log_fn=log,
             )
-        worker._send_via_apprise.assert_called_once_with("🛑 Stopped", "warning")
+        worker._send_via_apprise_bounded.assert_called_once_with("🛑 Stopped", "warning")
         assert any("falling back" in c.args[0].lower()
                    for c in log.call_args_list)
 
@@ -396,7 +396,7 @@ class TestScheduleDeferred:
     def test_falls_back_when_systemd_run_returns_nonzero(self, tmp_path):
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
 
         result = MagicMock(returncode=1, stderr=b"some systemd error")
         with patch("eneru.deferred_delivery.subprocess.run",
@@ -411,13 +411,13 @@ class TestScheduleDeferred:
                 body="x", notify_type="warning",
                 worker=worker, log_fn=log,
             )
-        worker._send_via_apprise.assert_called_once()
+        worker._send_via_apprise_bounded.assert_called_once()
 
     @pytest.mark.unit
     def test_falls_back_when_systemd_run_times_out(self, tmp_path):
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
 
         with patch("eneru.deferred_delivery.subprocess.run",
                    side_effect=subprocess.TimeoutExpired(cmd="systemd-run",
@@ -432,7 +432,7 @@ class TestScheduleDeferred:
                 body="x", notify_type="warning",
                 worker=worker, log_fn=log,
             )
-        worker._send_via_apprise.assert_called_once()
+        worker._send_via_apprise_bounded.assert_called_once()
 
     @pytest.mark.unit
     def test_falls_back_to_eager_when_no_config_path(self, tmp_path):
@@ -440,7 +440,7 @@ class TestScheduleDeferred:
         delivery via the worker's Apprise instance."""
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
 
         with patch("eneru.deferred_delivery.subprocess.run") as run, \
              patch("eneru.stats.StatsStore.open"), \
@@ -454,7 +454,7 @@ class TestScheduleDeferred:
                 worker=worker, log_fn=log,
             )
         run.assert_not_called()
-        worker._send_via_apprise.assert_called_once()
+        worker._send_via_apprise_bounded.assert_called_once()
 
 
 # ==============================================================================
@@ -473,7 +473,7 @@ class TestScheduleShortCircuits:
         no Job query. This is the foreground `eneru run` path."""
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
         # Drop INVOCATION_ID from env to simulate non-systemd context.
         env = {k: v for k, v in __import__("os").environ.items()
                if k != "INVOCATION_ID"}
@@ -492,7 +492,7 @@ class TestScheduleShortCircuits:
                 worker=worker, log_fn=log,
             )
         run.assert_not_called()
-        worker._send_via_apprise.assert_called_once_with("🛑 stop", "warning")
+        worker._send_via_apprise_bounded.assert_called_once_with("🛑 stop", "warning")
         assert any("Not running under systemd" in c.args[0]
                    for c in log.call_args_list)
 
@@ -518,7 +518,7 @@ class TestScheduleShortCircuits:
                 worker=worker, log_fn=log,
             )
         run.assert_not_called()
-        worker._send_via_apprise.assert_not_called()
+        worker._send_via_apprise_bounded.assert_not_called()
         assert any("container runtime" in c.args[0].lower()
                    and "pending" in c.args[0].lower()
                    for c in log.call_args_list)
@@ -529,7 +529,7 @@ class TestScheduleShortCircuits:
         This is the instant-Stopped UX win for `systemctl stop eneru`."""
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
         with patch.dict("os.environ",
                         {"INVOCATION_ID": "test-invocation"}), \
              patch("eneru.deferred_delivery._detect_systemd_stop_intent",
@@ -549,7 +549,7 @@ class TestScheduleShortCircuits:
         # is also mocked, so subprocess.run shouldn't have been
         # called (the systemd-run path is what would call it).
         run.assert_not_called()
-        worker._send_via_apprise.assert_called_once_with("🛑 stop", "warning")
+        worker._send_via_apprise_bounded.assert_called_once_with("🛑 stop", "warning")
         assert any("systemctl stop detected" in c.args[0]
                    for c in log.call_args_list)
 
@@ -564,7 +564,7 @@ class TestEagerSend:
     def test_marks_sent_on_apprise_success(self, tmp_path):
         """Worker.send_via_apprise returns True → row gets marked sent."""
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
         db_path = tmp_path / "ups.db"
         # Pre-create a row via real StatsStore so mark_notification_sent
         # has something to update.
@@ -599,7 +599,7 @@ class TestEagerSend:
     @pytest.mark.unit
     def test_leaves_pending_on_apprise_failure(self, tmp_path):
         worker = MagicMock()
-        worker._send_via_apprise.return_value = False
+        worker._send_via_apprise_bounded.return_value = False
         db_path = tmp_path / "ups.db"
         store = StatsStore(db_path)
         store.open()
@@ -1063,7 +1063,7 @@ class TestEagerSendMarkSentFailure:
         risk."""
         log = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.return_value = True
+        worker._send_via_apprise_bounded.return_value = True
 
         _eager_send(
             notification_id=42,
@@ -1074,5 +1074,5 @@ class TestEagerSendMarkSentFailure:
             log_fn=log,
         )
 
-        worker._send_via_apprise.assert_called_once_with("🛑 Stopped", "warning")
+        worker._send_via_apprise_bounded.assert_called_once_with("🛑 Stopped", "warning")
         assert any("mark_sent failed" in c.args[0] for c in log.call_args_list)

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -1592,34 +1592,40 @@ class TestMultiPhaseShutdown:
         for 2 × max_timeout. Regression guard for the deadline-based join in
         ``_shutdown_servers_parallel``.
         """
-        # Tiny budgets so the test is fast: pre_cmd=0, command_timeout=0,
-        # connect_timeout=0, safety_margin=1 -> max_timeout = 1 second.
+        # Two no-op workers in one phase. With the SSH-overhead buffer now in
+        # the budget the absolute deadline is ~30s+, so instead of timing a hung
+        # worker we prove the *structure*: the join timeout handed to each
+        # successive thread DECREASES (deadline - elapsed), which only happens
+        # under a single shared deadline. Per-thread stacking would hand each
+        # thread the same full budget.
         servers = [
-            RemoteServerConfig(name="StuckA", enabled=True, host="10.0.0.1", user="root",
-                               shutdown_order=1, command_timeout=0, connect_timeout=0,
-                               shutdown_safety_margin=1),
-            RemoteServerConfig(name="StuckB", enabled=True, host="10.0.0.2", user="root",
-                               shutdown_order=1, command_timeout=0, connect_timeout=0,
-                               shutdown_safety_margin=1),
+            RemoteServerConfig(name="A", enabled=True, host="10.0.0.1", user="root",
+                               shutdown_order=1, command_timeout=5, connect_timeout=2,
+                               shutdown_safety_margin=10),
+            RemoteServerConfig(name="B", enabled=True, host="10.0.0.2", user="root",
+                               shutdown_order=1, command_timeout=5, connect_timeout=2,
+                               shutdown_safety_margin=10),
         ]
         monitor = make_monitor(tmp_path, remote_servers=servers)
+        monitor._shutdown_remote_server = lambda s: None  # no-op workers
 
-        def hang_forever(server):
-            time.sleep(10)  # well beyond the 1s budget
+        timeouts = []
+        original_join = threading.Thread.join
 
-        monitor._shutdown_remote_server = hang_forever
+        def capture_join(self, timeout=None):
+            timeouts.append(timeout)
+            time.sleep(0.05)  # advance the deadline clock between joins
+            return original_join(self, timeout=0)
 
-        start = time.monotonic()
-        monitor._shutdown_remote_servers()
-        elapsed = time.monotonic() - start
+        with patch.object(threading.Thread, "join", capture_join):
+            monitor._shutdown_remote_servers()
 
-        # Stacked behavior would be ~2 s; deadline-based should be ~1 s.
-        # Allow a generous 1.8 s ceiling for CI scheduler jitter; still well
-        # below the 2 s stacked floor and the 10 s actual hang time.
-        assert elapsed < 1.8, (
-            f"Phase took {elapsed:.2f}s — expected ~1s (deadline-based join), "
-            "looks like per-thread timeouts are stacking."
+        assert len(timeouts) >= 2
+        assert timeouts[1] < timeouts[0], (
+            "join timeouts should DECREASE across threads (one shared "
+            "deadline); constant timeouts indicate per-thread stacking"
         )
+        assert all(t >= 0 for t in timeouts)
 
 
 class TestRemoteShutdownSafetyMargin:
@@ -1651,11 +1657,11 @@ class TestRemoteShutdownSafetyMargin:
         with patch.object(threading.Thread, "join", capture_join):
             monitor._shutdown_remote_servers()
 
-        # max_timeout = max(0+5+2+10, 0+5+2+120) = 127.
-        # Deadline-based join subtracts the tiny elapsed time between
-        # computing `deadline` and the first join, so the captured value
-        # will be just under 127.
-        assert captured["first_timeout"] == pytest.approx(127, abs=0.5)
+        # Each server has 0 pre-commands -> num_commands=1 -> +1*30 SSH buffer.
+        # max_timeout = max(0+5+2+10+30, 0+5+2+120+30) = max(47, 157) = 157.
+        # Deadline-based join subtracts the tiny elapsed time between computing
+        # `deadline` and the first join, so the captured value is just under 157.
+        assert captured["first_timeout"] == pytest.approx(157, abs=0.5)
 
 
 # ==============================================================================

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -2827,7 +2827,7 @@ class TestCleanupAndExit:
 
         # Scheduler not invoked (no notif_id), eager Apprise fallback fires
         scheduler.assert_not_called()
-        worker._send_via_apprise.assert_called_once()
+        worker._send_via_apprise_bounded.assert_called_once()
 
     @pytest.mark.unit
     def test_graceful_stop_does_not_overwrite_sequence_complete_marker(self, tmp_path):
@@ -3534,7 +3534,7 @@ class TestCleanupAndExitDefensive:
         monitor._stats_store = store
         monitor._stop_stats = MagicMock()
         worker = MagicMock()
-        worker._send_via_apprise.side_effect = RuntimeError("apprise gone")
+        worker._send_via_apprise_bounded.side_effect = RuntimeError("apprise gone")
         monitor._notification_worker = worker
         monitor._send_notification = MagicMock(return_value=None)
         monitor._shutdown_flag_path.unlink(missing_ok=True)
@@ -3546,7 +3546,7 @@ class TestCleanupAndExitDefensive:
             with pytest.raises(SystemExit):
                 monitor._cleanup_and_exit(15, None)
 
-        worker._send_via_apprise.assert_called_once()
+        worker._send_via_apprise_bounded.assert_called_once()
 
 
 class TestHandleOnBatteryDefensive:

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -584,12 +584,66 @@ class TestFailsafe:
         monitor._in_redundancy_group = False
         monitor.state.previous_status = "OB DISCHRG"
         monitor.state.connection_state = "OK"
-        # Trigger failsafe immediately (non-stale-data path).
+        # H3: hard failures are debounced like stale data. Push the hard-error
+        # counter to tolerance-1 so this iteration reaches tolerance and fires
+        # (mirrors how the stale-data tests pre-set stale_data_count).
+        monitor.state.connection_error_count = (
+            monitor.config.ups.max_stale_data_tolerance - 1
+        )
         with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
             _run_one_iteration(monitor, (False, {}, "Network error"))
 
         mock_exec.assert_called_once()
         assert monitor.state.connection_state == "FAILED"
+
+    @pytest.mark.unit
+    def test_single_hard_error_while_ob_is_debounced(self, tmp_path):
+        """H3: a single transient hard NUT failure while on battery does NOT
+        fire the FAILSAFE (it is debounced by max_stale_data_tolerance), so a
+        momentary connection refusal / upsc timeout can't drop a healthy host."""
+        monitor = make_monitor(tmp_path)
+        monitor._in_redundancy_group = False
+        monitor.state.previous_status = "OB DISCHRG"
+        monitor.state.connection_state = "OK"
+        monitor.config.ups.max_stale_data_tolerance = 3
+        monitor.state.connection_error_count = 0
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            _run_one_iteration(monitor, (False, {}, "Network error"))
+        mock_exec.assert_not_called()
+        assert monitor.state.connection_error_count == 1
+
+    @pytest.mark.unit
+    def test_tolerance_one_restores_instant_fsb(self, tmp_path):
+        """H3: max_stale_data_tolerance=1 restores the instant fail-closed FSB."""
+        monitor = make_monitor(tmp_path)
+        monitor._in_redundancy_group = False
+        monitor.state.previous_status = "OB DISCHRG"
+        monitor.state.connection_state = "OK"
+        monitor.config.ups.max_stale_data_tolerance = 1
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            _run_one_iteration(monitor, (False, {}, "Network error"))
+        mock_exec.assert_called_once()
+
+    @pytest.mark.unit
+    def test_failsafe_does_not_refire_while_latched(self, tmp_path):
+        """H2: once the on-battery FAILSAFE has acted, it must not re-run the
+        shutdown sequence on every subsequent failed poll (non-halting config)."""
+        monitor = make_monitor(tmp_path)
+        monitor._in_redundancy_group = False
+        monitor.state.previous_status = "OB DISCHRG"
+        monitor.state.connection_state = "OK"
+        monitor.config.ups.max_stale_data_tolerance = 1
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            # First failed poll fires the sequence.
+            _run_one_iteration(monitor, (False, {}, "Network error"))
+            assert mock_exec.call_count == 1
+            assert monitor._failsafe_initiated is True
+            # Subsequent failed polls (NUT still down, previous_status still OB)
+            # must NOT re-fire while the latch is set.
+            for _ in range(3):
+                monitor._stop_event.clear()
+                _run_one_iteration(monitor, (False, {}, "Network error"))
+            assert mock_exec.call_count == 1
 
     @pytest.mark.unit
     def test_connection_lost_while_ol_enters_grace_period(self, tmp_path):
@@ -685,15 +739,14 @@ class TestShutdownSequence:
         assert flag_existed
 
     @pytest.mark.unit
-    def test_shutdown_aborts_on_step_failure(self, tmp_path):
-        """Documents current behavior: an unhandled exception inside a
-        shutdown step propagates up and ABORTS the remaining steps. The
-        steps themselves handle expected failures internally; only an
-        unexpected raise reaches the orchestrator. If we ever decide to
-        wrap each step in try/except so subsequent steps run as
-        best-effort, this test must change to assert the new contract.
+    def test_shutdown_continues_past_drain_step_failure(self, tmp_path):
+        """H4: an unhandled exception inside a drain step is caught and logged;
+        the remaining drain steps AND the remote/poweroff path still run, so a
+        wedged libvirt or a bad config value can never skip the host poweroff.
+        (Previously such an exception aborted the whole sequence.)
         """
         monitor = make_monitor(tmp_path)
+        monitor.config.behavior.dry_run = True  # don't actually power off in the test
         call_order = []
 
         def failing_vms():
@@ -704,13 +757,14 @@ class TestShutdownSequence:
         monitor._shutdown_containers = lambda: call_order.append("containers")
         monitor._sync_filesystems = lambda: call_order.append("sync")
         monitor._unmount_filesystems = lambda: call_order.append("unmount")
-        monitor._shutdown_remote_servers = lambda: call_order.append("remote")
+        monitor._shutdown_remote_servers = (
+            lambda: call_order.append("remote") or [])
 
-        with pytest.raises(RuntimeError, match="VM shutdown failed"):
-            monitor._execute_shutdown_sequence()
+        # No raise: the sequence completes despite the VM step failing.
+        monitor._execute_shutdown_sequence()
 
-        # Only the failing step ran; subsequent steps did NOT execute.
-        assert call_order == ["vms"]
+        # Every drain step ran AND the remote/poweroff path was reached.
+        assert call_order == ["vms", "containers", "sync", "unmount", "remote"]
 
 
 # ==============================================================================
@@ -1776,8 +1830,13 @@ class TestAdvisoryTriggers:
         monitor = make_monitor(tmp_path)
         monitor._in_redundancy_group = False
         monitor.state.previous_status = "OB DISCHRG"
-        # Connection error (not "Data stale") fires failsafe immediately.
+        # Connection error (not "Data stale") fires the failsafe once the hard-
+        # error counter reaches tolerance (H3); pre-set to tolerance-1 so this
+        # iteration fires (mirrors the stale-data tests).
         monitor.state.stale_data_count = 0
+        monitor.state.connection_error_count = (
+            monitor.config.ups.max_stale_data_tolerance - 1
+        )
         monitor.state.connection_state = "OK"
 
         with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -659,36 +659,33 @@ class TestFailsafe:
 
     @pytest.mark.unit
     def test_stale_data_increments_counter(self, tmp_path):
-        """Stale data increments counter before triggering failsafe."""
+        """L23: drive the REAL loop -- one stale poll (below tolerance, not on
+        battery) increments the counter and does NOT fire a shutdown."""
         monitor = make_monitor(tmp_path)
+        monitor.state.previous_status = "OL CHRG"  # not on battery
+        monitor.state.connection_state = "OK"
         monitor.state.stale_data_count = 0
-
-        # Simulate stale data handling from main loop
-        error_msg = "Data stale"
-        if "Data stale" in error_msg:
-            monitor.state.stale_data_count += 1
-            if monitor.state.stale_data_count >= monitor.config.ups.max_stale_data_tolerance:
-                is_failsafe_trigger = True
-            else:
-                is_failsafe_trigger = False
-
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            _run_one_iteration(monitor, (False, {}, "Data stale"))
         assert monitor.state.stale_data_count == 1
-        assert is_failsafe_trigger is False  # Not yet at tolerance (3)
+        mock_exec.assert_not_called()
 
     @pytest.mark.unit
     def test_stale_data_reaches_tolerance(self, tmp_path):
-        """Stale data at tolerance threshold triggers failsafe."""
+        """L23: drive the REAL loop -- stale data reaching tolerance while on
+        battery fires the failsafe shutdown."""
         monitor = make_monitor(tmp_path)
-        monitor.state.stale_data_count = 2  # One more will reach 3
-
-        error_msg = "Data stale"
-        monitor.state.stale_data_count += 1
-        is_failsafe_trigger = (
-            monitor.state.stale_data_count >= monitor.config.ups.max_stale_data_tolerance
+        monitor._in_redundancy_group = False
+        monitor.state.previous_status = "OB DISCHRG"
+        monitor.state.connection_state = "OK"
+        monitor.state.stale_data_count = (
+            monitor.config.ups.max_stale_data_tolerance - 1
         )
-
-        assert monitor.state.stale_data_count == 3
-        assert is_failsafe_trigger is True
+        with patch.object(monitor, "_execute_shutdown_sequence") as mock_exec:
+            _run_one_iteration(monitor, (False, {}, "Data stale"))
+        assert (monitor.state.stale_data_count
+                >= monitor.config.ups.max_stale_data_tolerance)
+        mock_exec.assert_called_once()
 
 
 # ==============================================================================

--- a/tests/test_monitor_shutdown_delegated.py
+++ b/tests/test_monitor_shutdown_delegated.py
@@ -184,7 +184,7 @@ class TestDelegatedShutdownSequence:
         monitor = _make_delegated_monitor(tmp_path)
         self._spy_phases(monitor)
         with _patch_runtime("container (Docker)"), \
-             patch("eneru.monitor.os.sync") as sync_mock:
+             patch.object(monitor, "_bounded_sync") as sync_mock:
             monitor._execute_shutdown_sequence()
             sync_mock.assert_not_called()
 
@@ -724,11 +724,11 @@ class TestNativeFinalSyncBranch:
         monitor._log_message = lambda msg, **kw: log.append(msg)
 
         with _patch_runtime("systemd service"), \
-             patch("eneru.monitor.os.sync") as sync_mock:
+             patch.object(monitor, "_bounded_sync") as sync_mock:
             monitor._execute_shutdown_sequence()
 
         assert any("Final filesystem sync" in m for m in log), log
-        # Dry-run: no actual os.sync call.
+        # Dry-run: no actual sync call.
         sync_mock.assert_not_called()
         assert any("[DRY-RUN] Would perform final sync" in m for m in log), log
 
@@ -751,8 +751,9 @@ class TestNativeFinalSyncBranch:
         monitor._log_message = lambda msg, **kw: log.append(msg)
 
         with _patch_runtime("systemd service"), \
-             patch("eneru.monitor.os.sync") as sync_mock:
+             patch.object(monitor, "_bounded_sync") as sync_mock:
             monitor._execute_shutdown_sequence()
 
+        # H6: the final sync now runs via the bounded `sync` subprocess helper.
         sync_mock.assert_called_once()
-        assert any("Final sync complete" in m for m in log), log
+        assert any("Final filesystem sync" in m for m in log), log

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -350,12 +350,17 @@ class TestMultiUPSCoordinator:
         assert len(calls) == 0
 
     @pytest.mark.unit
-    def test_defense_in_depth_lock(self):
+    def test_defense_in_depth_lock(self, tmp_path):
         """L24: the REAL _handle_local_shutdown guard prevents a double local
         shutdown -- a second call (e.g. a second UPS group tripping) returns
         before running the body. Drives the real method, not a copy of it."""
         config = self._make_config(
             [UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+                shutdown_flag_file=str(tmp_path / "global-shutdown-flag"),
+            ),
             local_shutdown=LocalShutdownConfig(enabled=False),
         )
         coord = MultiUPSCoordinator(config)
@@ -2565,3 +2570,105 @@ class TestHandleSignalDeferredScheduling:
         sched.assert_not_called()
         # Eager fallback was attempted (and its exception swallowed).
         worker._send_via_apprise_bounded.assert_called_once()
+
+
+# ==============================================================================
+# COVERAGE: H10 join-deadline, in-flight signal branch, control-event routing
+# ==============================================================================
+
+class TestCoordinatorShutdownJoinAndAudit:
+    """Cover the rc10 additions: _shutdown_join_deadline, the in-flight signal
+    branch, and record_control_event routing."""
+
+    def _cfg(self, tmp_path, *, servers=None, drain=False):
+        from types import SimpleNamespace  # noqa: F401 (kept local)
+        return Config(
+            ups_groups=[UPSGroupConfig(
+                ups=UPSConfig(name="UPS1"), is_local=True,
+                remote_servers=servers or [],
+            )],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+                shutdown_flag_file=str(tmp_path / "flag"),
+            ),
+            local_shutdown=LocalShutdownConfig(
+                enabled=True, drain_on_local_shutdown=drain),
+        )
+
+    @pytest.mark.unit
+    def test_shutdown_join_deadline_from_remote_budget(self, tmp_path):
+        """H10: budget = max remote (cmd+connect+margin) + 120 drain headroom."""
+        srv = RemoteServerConfig(
+            name="nas", host="10.0.0.1", user="root",
+            command_timeout=20, connect_timeout=10, shutdown_safety_margin=60)
+        coord = MultiUPSCoordinator(self._cfg(tmp_path, servers=[srv]))
+        assert coord._shutdown_join_deadline() == 20 + 10 + 60 + 120
+
+    @pytest.mark.unit
+    def test_shutdown_join_deadline_capped_and_floored(self, tmp_path):
+        """H10: the deadline is clamped to [30, 600]."""
+        big = RemoteServerConfig(
+            name="nas", host="10.0.0.1", user="root",
+            command_timeout=9999, connect_timeout=0, shutdown_safety_margin=0)
+        coord = MultiUPSCoordinator(self._cfg(tmp_path, servers=[big], drain=True))
+        assert coord._shutdown_join_deadline() == 600  # capped
+        # No remote servers -> just the 120 headroom (above the 30 floor).
+        coord2 = MultiUPSCoordinator(self._cfg(tmp_path))
+        assert coord2._shutdown_join_deadline() == 120
+
+    @pytest.mark.unit
+    def test_handle_signal_in_flight_waits_longer(self, tmp_path):
+        """H10: with a shutdown already in flight, the signal handler logs the
+        longer bounded wait instead of the brisk 5s exit."""
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        logs = []
+        coord._log = lambda m: logs.append(m)
+        coord._notification_worker = None
+        coord._threads = []
+        coord._evaluator_threads = []
+        coord._global_shutdown_flag.touch()  # shutdown in flight
+        with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
+             patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
+             patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.sys.exit"):
+            coord._handle_signal(15, None)
+        assert any("Shutdown sequence in progress" in m for m in logs), logs
+
+    @pytest.mark.unit
+    def test_handle_signal_reentrancy_guard(self, tmp_path):
+        """L5: a second signal during teardown is ignored."""
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        coord._log = lambda m: None
+        coord._notification_worker = None
+        coord._threads = []
+        coord._evaluator_threads = []
+        coord._signal_handling = True  # pretend a handler is already running
+        # Must return immediately without raising SystemExit.
+        coord._handle_signal(15, None)
+
+    @pytest.mark.unit
+    def test_record_control_event_routes_to_matching_store(self, tmp_path):
+        """Audit groundwork: a control event lands in the matching UPS's store."""
+        from types import SimpleNamespace
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        mon = MagicMock()
+        mon.config.ups_groups = [SimpleNamespace(ups=SimpleNamespace(name="UPS1"))]
+        store = MagicMock()
+        mon._stats_store = store
+        coord._monitors = [mon]
+        coord.record_control_event("UPS1", "CONTROL_COMMAND", "ran beeper.toggle")
+        store.log_event.assert_called_once_with("CONTROL_COMMAND", "ran beeper.toggle")
+
+    @pytest.mark.unit
+    def test_record_control_event_falls_back_to_first_store(self, tmp_path):
+        """Unknown/reload UPS name -> first monitor's store."""
+        from types import SimpleNamespace
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        mon = MagicMock()
+        mon.config.ups_groups = [SimpleNamespace(ups=SimpleNamespace(name="UPS1"))]
+        store = MagicMock()
+        mon._stats_store = store
+        coord._monitors = [mon]
+        coord.record_control_event("", "CONFIG_RELOAD", "reloaded")
+        store.log_event.assert_called_once_with("CONFIG_RELOAD", "reloaded")

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -2618,6 +2618,57 @@ class TestCoordinatorShutdownJoinAndAudit:
         assert coord2._shutdown_join_deadline() == 120
 
     @pytest.mark.unit
+    def test_shutdown_join_deadline_ignores_non_int_timeout(self, tmp_path):
+        """A server with a non-int timeout is skipped in the budget calc, not
+        crashed (defensive int() guard)."""
+        bad = RemoteServerConfig(
+            name="bad", host="10.0.0.1", user="root",
+            command_timeout="oops", connect_timeout=0, shutdown_safety_margin=0)
+        coord = MultiUPSCoordinator(self._cfg(tmp_path, servers=[bad]))
+        # bad server contributes nothing -> just the 120 drain headroom.
+        assert coord._shutdown_join_deadline() == 120
+
+    @pytest.mark.unit
+    def test_inflight_recovery_defers_rearm(self, tmp_path):
+        """cubic P1: a recovery that races the in-flight window does not drop the
+        re-arm -- _clear_local_shutdown_state defers it, and the finally of
+        _handle_local_shutdown applies it so the guard isn't left stuck after a
+        non-halting shutdown."""
+        config = Config(
+            ups_groups=[UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+                shutdown_flag_file=str(tmp_path / "flag"),
+            ),
+            local_shutdown=LocalShutdownConfig(
+                enabled=False, drain_on_local_shutdown=True),
+        )
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda m: None
+        coord._notification_worker = None
+        coord._monitors = []
+        coord._threads = []
+
+        seen = {}
+
+        def fake_drain(timeout=120):
+            # A concurrent OB->OL recovery fires while the shutdown is in flight.
+            coord._clear_local_shutdown_state()
+            seen["initiated_midflight"] = coord._local_shutdown_initiated
+            seen["rearm_pending"] = coord._rearm_after_inflight
+
+        coord._drain_all_groups = fake_drain
+        coord._handle_local_shutdown("UPS1")
+
+        # Mid-flight: the guard was NOT cleared (no second-poweroff window)...
+        assert seen["initiated_midflight"] is True
+        assert seen["rearm_pending"] is True
+        # ...but the deferred re-arm fired in the finally, so we're not stuck.
+        assert coord._local_shutdown_initiated is False
+        assert coord._rearm_after_inflight is False
+
+    @pytest.mark.unit
     def test_handle_signal_in_flight_waits_longer(self, tmp_path):
         """H10: with a shutdown already in flight, the signal handler logs the
         longer bounded wait instead of the brisk 5s exit."""

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -412,6 +412,37 @@ class TestMultiUPSCoordinator:
         )
 
     @pytest.mark.unit
+    def test_clear_local_shutdown_state_refuses_mid_flight(self, tmp_path):
+        """M1: while a local shutdown is committed and running outside the lock,
+        an unrelated group's recovery must NOT re-arm the guard -- otherwise a
+        concurrent trigger could admit a SECOND poweroff. Once the sequence
+        returns (in_flight cleared), recovery re-arms normally."""
+        flag_path = tmp_path / "global-shutdown-flag"
+        config = self._make_config(
+            [UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+                shutdown_flag_file=str(flag_path),
+            ),
+            local_shutdown=LocalShutdownConfig(enabled=False),
+        )
+        coord = MultiUPSCoordinator(config)
+        coord._local_shutdown_initiated = True
+        coord._local_shutdown_in_flight = True
+        flag_path.touch()
+
+        coord._clear_local_shutdown_state()
+        assert coord._local_shutdown_initiated is True, "must not re-arm mid-flight"
+        assert flag_path.exists(), "flag must survive a mid-flight clear attempt"
+
+        # Sequence finished -> recovery may re-arm.
+        coord._local_shutdown_in_flight = False
+        coord._clear_local_shutdown_state()
+        assert coord._local_shutdown_initiated is False
+        assert not flag_path.exists()
+
+    @pytest.mark.unit
     def test_clear_local_shutdown_state_idempotent(self, tmp_path):
         """Safe to call when nothing was in flight (steady-state OL or
         repeated OL transitions)."""
@@ -2513,8 +2544,8 @@ class TestHandleSignalDeferredScheduling:
 
     @pytest.mark.unit
     def test_eager_apprise_fallback_swallows_exception(self, tmp_path):
-        """When `_send_via_apprise` raises in the no-store fallback path,
-        the handler swallows the exception (lines 726-727)."""
+        """When `_send_via_apprise_bounded` raises in the no-store fallback
+        path, the handler swallows the exception."""
         config = _coord_config(tmp_path)
         coord = MultiUPSCoordinator(config)
         coord._log = MagicMock()
@@ -2526,7 +2557,7 @@ class TestHandleSignalDeferredScheduling:
         worker.send.return_value = None  # No stores registered → returns None
         worker._stores_lock = threading.Lock()
         worker._stores = []
-        worker._send_via_apprise.side_effect = RuntimeError("apprise gone")
+        worker._send_via_apprise_bounded.side_effect = RuntimeError("apprise gone")
         coord._notification_worker = worker
 
         with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
@@ -2538,4 +2569,4 @@ class TestHandleSignalDeferredScheduling:
 
         sched.assert_not_called()
         # Eager fallback was attempted (and its exception swallowed).
-        worker._send_via_apprise.assert_called_once()
+        worker._send_via_apprise_bounded.assert_called_once()

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -699,6 +699,46 @@ class TestDrainOnLocalShutdown:
         mock_monitor._execute_shutdown_sequence.assert_called_once()
 
     @pytest.mark.unit
+    def test_drain_skips_current_thread_no_self_join_crash(self, tmp_path):
+        """Regression (C1): _drain_all_groups runs ON a monitor thread whose
+        own Thread object is in self._threads. Joining the current thread
+        raises RuntimeError('cannot join current thread'), which previously
+        unwound the whole sequence BEFORE the host poweroff -- a missed
+        shutdown. The drain must skip itself and still drain peers."""
+        config = Config(
+            ups_groups=[
+                UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True),
+            ],
+            behavior=BehaviorConfig(dry_run=True),
+            logging=LoggingConfig(
+                shutdown_flag_file=str(tmp_path / "flag"),
+                state_file=str(tmp_path / "state"),
+                battery_history_file=str(tmp_path / "history"),
+            ),
+            local_shutdown=LocalShutdownConfig(
+                enabled=False,
+                drain_on_local_shutdown=True,
+            ),
+        )
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+
+        mock_monitor = MagicMock()
+        mock_monitor._shutdown_flag_path = tmp_path / "flag-ups2"
+        mock_monitor._shutdown_flag_path.unlink(missing_ok=True)
+        mock_monitor._log_prefix = "[UPS2] "
+        coord._monitors = [mock_monitor]
+        # The bug trigger: the CURRENT thread is in _threads (real runtime
+        # shape -- the firing group's poll thread drives the drain).
+        coord._threads = [threading.current_thread()]
+
+        # Pre-fix this raised RuntimeError; post-fix it returns cleanly.
+        coord._drain_all_groups(timeout=1)
+
+        # And the peer drain must still have happened.
+        mock_monitor._execute_shutdown_sequence.assert_called_once()
+
+    @pytest.mark.unit
     def test_drain_not_called_when_disabled(self, tmp_path):
         """drain_on_local_shutdown=false must NOT drain other groups."""
         config = Config(

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1480,8 +1480,13 @@ class TestCoordinatorHandleSignal:
         with patch("eneru.multi_ups.sys.exit"):
             coord._handle_signal(_signal.SIGINT, None)
 
+        # Deadline-based join (H10): each thread is joined once with a positive,
+        # bounded timeout (<= the 5 s no-in-flight budget), not necessarily the
+        # exact integer 5 -- it's `deadline - now`.
         for thread in threads:
-            thread.join.assert_called_once_with(timeout=5)
+            thread.join.assert_called_once()
+            timeout = thread.join.call_args.kwargs["timeout"]
+            assert 0 < timeout <= 5
 
     @pytest.mark.unit
     def test_handle_signal_enqueues_stop_after_flush_and_stop(self, tmp_path):
@@ -2070,8 +2075,10 @@ ups:
         rh2.stop.assert_called_once()
         coord._mqtt_publisher.stop.assert_called_once()
         coord._api_server.stop.assert_called_once()
-        t1.join.assert_called_once_with(timeout=5)
-        t2.join.assert_called_once_with(timeout=5)
+        # Deadline-based join (H10): bounded positive timeout, not exactly 5.
+        for thread in (t1, t2):
+            thread.join.assert_called_once()
+            assert 0 < thread.join.call_args.kwargs["timeout"] <= 5
 
     @pytest.mark.unit
     def test_handle_signal_skips_lifecycle_notif_during_upgrade(self, tmp_path):

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -2618,6 +2618,29 @@ class TestCoordinatorShutdownJoinAndAudit:
         assert coord2._shutdown_join_deadline() == 120
 
     @pytest.mark.unit
+    def test_shutdown_join_deadline_includes_redundancy_and_pre_commands(self, tmp_path):
+        """cubic: the budget must count redundancy-group remotes AND pre-shutdown
+        command runtime, not just per-UPS final commands."""
+        from eneru import RedundancyGroupConfig, RemoteCommandConfig
+        rg_srv = RemoteServerConfig(
+            name="rnas", host="10.0.0.9", user="root",
+            command_timeout=10, connect_timeout=5, shutdown_safety_margin=20,
+            pre_shutdown_commands=[RemoteCommandConfig(command="echo x", timeout=40)],
+        )
+        config = Config(
+            ups_groups=[UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
+            redundancy_groups=[RedundancyGroupConfig(
+                name="rg", ups_sources=["UPS1"], remote_servers=[rg_srv])],
+            logging=LoggingConfig(
+                state_file=str(tmp_path / "s"),
+                battery_history_file=str(tmp_path / "h"),
+                shutdown_flag_file=str(tmp_path / "f")),
+        )
+        coord = MultiUPSCoordinator(config)
+        # rg_srv: pre(40) + cmd(10) + connect(5) + margin(20) = 75; + 120 headroom.
+        assert coord._shutdown_join_deadline() == 75 + 120
+
+    @pytest.mark.unit
     def test_shutdown_join_deadline_ignores_non_int_timeout(self, tmp_path):
         """A server with a non-int timeout is skipped in the budget calc, not
         crashed (defensive int() guard)."""

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -351,30 +351,25 @@ class TestMultiUPSCoordinator:
 
     @pytest.mark.unit
     def test_defense_in_depth_lock(self):
-        """Threading lock prevents double local shutdown."""
+        """L24: the REAL _handle_local_shutdown guard prevents a double local
+        shutdown -- a second call (e.g. a second UPS group tripping) returns
+        before running the body. Drives the real method, not a copy of it."""
         config = self._make_config(
             [UPSGroupConfig(ups=UPSConfig(name="UPS1"), is_local=True)],
             local_shutdown=LocalShutdownConfig(enabled=False),
         )
         coord = MultiUPSCoordinator(config)
-        coord._log = lambda msg: None
+        logs = []
+        coord._log = lambda msg: logs.append(msg)
         coord._notification_worker = None
 
-        shutdown_count = []
-
-        def counting_shutdown(label):
-            proceed = False
-            with coord._local_shutdown_lock:
-                if not coord._local_shutdown_initiated:
-                    coord._local_shutdown_initiated = True
-                    proceed = True
-            if proceed:
-                shutdown_count.append(label)
-
-        coord._handle_local_shutdown = counting_shutdown
         coord._handle_local_shutdown("UPS1")
         coord._handle_local_shutdown("UPS2")
-        assert len(shutdown_count) == 1
+
+        # The body's "triggered by" line fires once; the second call hit the
+        # guard (proceed=False) and returned before logging anything.
+        triggered = [m for m in logs if "Local shutdown triggered by" in m]
+        assert triggered == ["🚨 Local shutdown triggered by UPS1"]
 
     @pytest.mark.unit
     def test_clear_local_shutdown_state_resets_lock_and_flag(self, tmp_path):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -8,6 +8,7 @@ flush(), and the memory-buffer drain on first ``register_store``.
 """
 
 import pytest
+import threading
 import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -111,6 +112,35 @@ class TestWorkerLifecycle:
         config.notifications.urls = []
         worker = NotificationWorker(config)
         assert worker.start() is False
+
+    @pytest.mark.unit
+    def test_send_via_apprise_bounded_returns_result(self):
+        """M6: bounded eager send returns the underlying send result."""
+        worker = NotificationWorker(Config())
+        with patch.object(worker, "_send_via_apprise", return_value=True) as inner:
+            assert worker._send_via_apprise_bounded("b", "info") is True
+        inner.assert_called_once_with("b", "info")
+        with patch.object(worker, "_send_via_apprise", return_value=False):
+            assert worker._send_via_apprise_bounded("b", "info") is False
+
+    @pytest.mark.unit
+    def test_send_via_apprise_bounded_times_out(self):
+        """M6: a hung eager send is abandoned after the timeout (returns False)
+        so the SIGTERM handler isn't blocked; the row stays pending."""
+        worker = NotificationWorker(Config())
+        started = threading.Event()
+        release = threading.Event()
+
+        def _slow(body, notify_type):
+            started.set()
+            release.wait(5)
+            return True
+
+        with patch.object(worker, "_send_via_apprise", side_effect=_slow):
+            result = worker._send_via_apprise_bounded("b", "info", timeout=0.05)
+        assert result is False
+        assert started.is_set()
+        release.set()  # let the daemon thread unwind
 
     @pytest.mark.unit
     @patch("eneru.notifications.APPRISE_AVAILABLE", True)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -868,14 +868,18 @@ class TestNotificationWorkerStartEarlyReturns:
         minimal_config.notifications.urls = ["bogus://not-a-real-scheme/x"]
         worker = NotificationWorker(minimal_config)
 
-        with patch("eneru.notifications.APPRISE_AVAILABLE", True):
+        # L1: patch the whole `apprise` module object (like the sibling tests),
+        # not its `.Apprise` attribute -- when the optional apprise extra isn't
+        # installed `eneru.notifications.apprise` is None, and patching an
+        # attribute of None raises AttributeError. This keeps the test hermetic.
+        with patch("eneru.notifications.APPRISE_AVAILABLE", True), \
+                patch("eneru.notifications.apprise") as mock_apprise:
             fake_apprise_instance = MagicMock()
             # add() returns False for every URL, len() returns 0
             fake_apprise_instance.add = MagicMock(return_value=False)
             fake_apprise_instance.__len__ = MagicMock(return_value=0)
-            with patch("eneru.notifications.apprise.Apprise",
-                       return_value=fake_apprise_instance):
-                assert worker.start() is False
+            mock_apprise.Apprise.return_value = fake_apprise_instance
+            assert worker.start() is False
 
         out = capsys.readouterr().out
         assert "Failed to add notification URL" in out or "No valid notification URLs" in out

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -752,6 +752,26 @@ class TestEvaluatorThreadLifecycle:
         # base_grace excluded (disabled) -> window = startup_grace(10) + 0 + 10.
         assert ev._readiness_window == 20
 
+    @pytest.mark.unit
+    def test_readiness_window_clamps_negative_grace_duration(self):
+        """cubic: a negative/malformed grace duration must NOT shrink the
+        cold-start readiness window (which would let a real quorum loss fire
+        before members finish their first connect). 0 is the safe floor."""
+        group = _redundancy_group(min_healthy=1)
+        monitors = {
+            "UPS-A": _FakeMonitor("UPS-A", _snap()),
+            "UPS-B": _FakeMonitor("UPS-B", _snap()),
+        }
+        for m in monitors.values():
+            m.config.ups.connection_loss_grace_period.enabled = True
+            m.config.ups.connection_loss_grace_period.duration = -300
+        ev = RedundancyGroupEvaluator(
+            group, monitors, MagicMock(),
+            stop_event=threading.Event(), logger=None, startup_grace_seconds=10,
+        )
+        # Clamped to 0 -> window = startup_grace(10) + 0 + 10, never shrunk.
+        assert ev._readiness_window == 20
+
 
 # ===========================================================================
 # Executor: synthetic config wiring + idempotency + dry-run cleanup

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -734,6 +734,24 @@ class TestEvaluatorThreadLifecycle:
         ev.evaluate_once()
         executor.shutdown.assert_called_once()
 
+    @pytest.mark.unit
+    def test_readiness_window_excludes_disabled_grace(self):
+        """cubic: a member whose connection grace is DISABLED must not extend the
+        cold-start readiness window (a disabled grace doesn't delay FAILED)."""
+        group = _redundancy_group(min_healthy=1)
+        monitors = {
+            "UPS-A": _FakeMonitor("UPS-A", _snap()),
+            "UPS-B": _FakeMonitor("UPS-B", _snap()),
+        }
+        for m in monitors.values():
+            m.config.ups.connection_loss_grace_period.enabled = False
+        ev = RedundancyGroupEvaluator(
+            group, monitors, MagicMock(),
+            stop_event=threading.Event(), logger=None, startup_grace_seconds=10,
+        )
+        # base_grace excluded (disabled) -> window = startup_grace(10) + 0 + 10.
+        assert ev._readiness_window == 20
+
 
 # ===========================================================================
 # Executor: synthetic config wiring + idempotency + dry-run cleanup

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -677,6 +677,63 @@ class TestEvaluatorThreadLifecycle:
         ev.join(timeout=2)
         executor.shutdown.assert_not_called()
 
+    @pytest.mark.unit
+    def test_cold_start_holds_fire_until_members_report(self):
+        """H1: present members that have NEVER reported (last_update_time==0)
+        must not drop a powered rack while inside the readiness window, even
+        with unknown_counts_as=critical and quorum numerically lost."""
+        group = _redundancy_group(
+            min_healthy=2, unknown_counts_as="critical",
+            ups_sources=["A", "B", "C"],
+        )
+        monitors = {
+            "A": _FakeMonitor("A", _snap()),                     # reported, healthy
+            "B": _FakeMonitor("B", _snap(last_update_time=0)),   # never reported
+            "C": _FakeMonitor("C", _snap(last_update_time=0)),   # never reported
+        }
+        executor = MagicMock()
+        executor.shutdown.return_value = True
+        ev = RedundancyGroupEvaluator(
+            group, monitors, executor,
+            stop_event=threading.Event(), logger=None,
+            startup_grace_seconds=0,
+        )
+        # healthy_count=1 < min_healthy=2, but B/C never reported and we're in
+        # the readiness window -> hold, no fire.
+        ev.evaluate_once()
+        executor.shutdown.assert_not_called()
+        # Once B and C publish their first (healthy) snapshot, quorum holds.
+        for n in ("B", "C"):
+            with monitors[n].state._lock:
+                monitors[n].state.latest_update_time = time.time()
+                monitors[n].state.latest_status = "OL"
+        ev.evaluate_once()
+        executor.shutdown.assert_not_called()
+
+    @pytest.mark.unit
+    def test_cold_start_hold_expires_then_fires(self):
+        """H1: once the readiness window elapses, a still-never-reported member
+        counts as UNKNOWN->critical and a real quorum loss fires -- a genuinely
+        dead UPS at boot is still protected."""
+        group = _redundancy_group(
+            min_healthy=2, unknown_counts_as="critical",
+            ups_sources=["A", "B"],
+        )
+        monitors = {
+            "A": _FakeMonitor("A", _snap()),                    # reported healthy
+            "B": _FakeMonitor("B", _snap(last_update_time=0)),  # never reports
+        }
+        executor = MagicMock()
+        executor.shutdown.return_value = True
+        ev = RedundancyGroupEvaluator(
+            group, monitors, executor,
+            stop_event=threading.Event(), logger=None,
+            startup_grace_seconds=0,
+        )
+        ev._readiness_window = 0  # force the readiness window to have elapsed
+        ev.evaluate_once()
+        executor.shutdown.assert_called_once()
+
 
 # ===========================================================================
 # Executor: synthetic config wiring + idempotency + dry-run cleanup

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -994,6 +994,62 @@ class TestLoopbackShutdownOrdering:
         assert hosts == ["10.0.0.10", "127.0.0.1"]
 
     @pytest.mark.unit
+    def test_loopback_identity_mismatch_warns_but_proceeds(self, remote_monitor):
+        """M2: when a loopback's host-identity probe FAILS on the destructive
+        path, Eneru warns + notifies but still issues the poweroff (refusing
+        would leave the local host running on a draining battery)."""
+        loopback = RemoteServerConfig(
+            name="host-loopback", enabled=True, host="127.0.0.1", user="root",
+            is_host_loopback=True, shutdown_command="shutdown -h now",
+            expected_host_identity="expected-machine-id",
+            pre_shutdown_commands=[],
+        )
+        remote_monitor.config.ups_groups[0].remote_servers = [loopback]
+        remote_monitor._send_notification = MagicMock()
+
+        calls, run_patch = self._record_calls(remote_monitor)
+        with run_patch, patch(
+            "eneru.remote_health.run_loopback_identity_probe",
+            return_value=(False, "host identity mismatch: bind-mount missing", 5),
+        ):
+            remote_monitor._shutdown_remote_servers()
+
+        # Poweroff still ran despite the failed identity check.
+        assert "127.0.0.1" in [host for host, _ in calls]
+        # And an identity warning notification was emitted.
+        bodies = [
+            (c.args[0] if c.args else "")
+            for c in remote_monitor._send_notification.call_args_list
+        ]
+        assert any("identity" in b.lower() for b in bodies), bodies
+
+    @pytest.mark.unit
+    def test_loopback_identity_ok_no_warning(self, remote_monitor):
+        """M2: a passing identity probe emits no identity warning."""
+        loopback = RemoteServerConfig(
+            name="host-loopback", enabled=True, host="127.0.0.1", user="root",
+            is_host_loopback=True, shutdown_command="shutdown -h now",
+            expected_host_identity="expected-machine-id",
+            pre_shutdown_commands=[],
+        )
+        remote_monitor.config.ups_groups[0].remote_servers = [loopback]
+        remote_monitor._send_notification = MagicMock()
+
+        calls, run_patch = self._record_calls(remote_monitor)
+        with run_patch, patch(
+            "eneru.remote_health.run_loopback_identity_probe",
+            return_value=(True, "", 5),
+        ):
+            remote_monitor._shutdown_remote_servers()
+
+        assert "127.0.0.1" in [host for host, _ in calls]
+        bodies = [
+            (c.args[0] if c.args else "")
+            for c in remote_monitor._send_notification.call_args_list
+        ]
+        assert not any("identity" in b.lower() for b in bodies), bodies
+
+    @pytest.mark.unit
     def test_loopback_result_aggregates_pre_and_post(self, remote_monitor):
         """The single loopback RemoteShutdownResult must reflect BOTH
         the pre-actions outcome and the final shutdown command outcome."""

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -635,29 +635,54 @@ class TestRemotePreShutdownExecution:
         assert "1 failed" in log_text
 
     @pytest.mark.unit
-    def test_pre_shutdown_deadline_skips_late_final_shutdown(self, remote_monitor):
+    def test_slow_pre_phase_still_attempts_final_shutdown(self, remote_monitor):
+        """H8: a slow pre-shutdown phase that exhausts its reserved slice must
+        NOT starve or skip the final poweroff. As long as the FULL phase
+        deadline isn't blown, the shutdown command is still attempted."""
+        from eneru.shutdown.remote import RemotePreShutdownResult
         server = RemoteServerConfig(
-            name="slow",
-            enabled=True,
-            host="10.0.0.3",
-            user="root",
+            name="slow", enabled=True, host="10.0.0.3", user="root",
             command_timeout=30,
             pre_shutdown_commands=[
                 RemoteCommandConfig(command="sleep 999", timeout=1),
+            ],
+        )
+        # Pre-phase reports timed_out (used up its reserved budget); the full
+        # deadline is far away (monotonic pinned to 0, deadline 100).
+        pre_result = RemotePreShutdownResult(attempted=1, failed=1, timed_out=True)
+        with patch.object(remote_monitor, "_execute_remote_pre_shutdown",
+                          return_value=pre_result), \
+             patch.object(remote_monitor, "_run_remote_command",
+                          return_value=(True, "")) as mock_run, \
+             patch("eneru.shutdown.remote.time.monotonic", return_value=0.0):
+            result = remote_monitor._shutdown_remote_server(server, deadline=100.0)
+
+        assert mock_run.call_count == 1          # poweroff attempted
+        assert result.shutdown_sent is True
+
+    @pytest.mark.unit
+    def test_full_deadline_blown_skips_final_shutdown(self, remote_monitor):
+        """If the FULL phase deadline is already exceeded, the poweroff is
+        skipped -- the phase is genuinely out of time."""
+        from eneru.shutdown.remote import RemotePreShutdownResult
+        server = RemoteServerConfig(
+            name="slow", enabled=True, host="10.0.0.3", user="root",
+            command_timeout=30,
+            pre_shutdown_commands=[
                 RemoteCommandConfig(command="sleep 999", timeout=1),
             ],
         )
+        pre_result = RemotePreShutdownResult(attempted=1, failed=0, timed_out=False)
+        with patch.object(remote_monitor, "_execute_remote_pre_shutdown",
+                          return_value=pre_result), \
+             patch.object(remote_monitor, "_run_remote_command",
+                          return_value=(True, "")) as mock_run, \
+             patch("eneru.shutdown.remote.time.monotonic", return_value=200.0):
+            result = remote_monitor._shutdown_remote_server(server, deadline=100.0)
 
-        with patch("eneru.shutdown.remote.time.monotonic", side_effect=[0.0, 11.0]):
-            with patch.object(remote_monitor, "_run_remote_command",
-                              return_value=(False, "timed out")) as mock_run:
-                result = remote_monitor._shutdown_remote_server(server, deadline=10.0)
-
-        assert result.timed_out is True
+        assert mock_run.call_count == 0          # poweroff skipped (out of time)
         assert result.shutdown_sent is False
-        assert result.pre_commands.timed_out is True
-        assert mock_run.call_count == 1
-        assert mock_run.call_args.args[3] == "sleep 999"
+        assert result.timed_out is True
 
     @pytest.mark.unit
     def test_loopback_pre_shutdown_supplies_skip_ids_and_umount_targets(

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -685,6 +685,41 @@ class TestRemotePreShutdownExecution:
         assert result.timed_out is True
 
     @pytest.mark.unit
+    def test_pre_shutdown_skips_when_deadline_already_exceeded(self, remote_monitor):
+        """Pre-shutdown commands are skipped (timed_out) when the phase deadline
+        is already blown on entry -- nothing runs."""
+        server = RemoteServerConfig(
+            name="s", enabled=True, host="10.0.0.3", user="root",
+            pre_shutdown_commands=[RemoteCommandConfig(command="echo hi", timeout=5)],
+        )
+        with patch.object(remote_monitor, "_remote_deadline_exceeded",
+                          return_value=True), \
+             patch.object(remote_monitor, "_run_remote_command") as mock_run:
+            result = remote_monitor._execute_remote_pre_shutdown(
+                server, collect_result=True, deadline=10.0)
+        assert result.timed_out is True
+        mock_run.assert_not_called()
+
+    @pytest.mark.unit
+    def test_pre_shutdown_stops_when_deadline_exceeded_midway(self, remote_monitor):
+        """Once the deadline passes after a pre-command, the rest are skipped."""
+        server = RemoteServerConfig(
+            name="s", enabled=True, host="10.0.0.3", user="root",
+            pre_shutdown_commands=[
+                RemoteCommandConfig(command="echo a", timeout=5),
+                RemoteCommandConfig(command="echo b", timeout=5),
+            ],
+        )
+        with patch.object(remote_monitor, "_remote_deadline_exceeded",
+                          side_effect=[False, True]), \
+             patch.object(remote_monitor, "_run_remote_command",
+                          return_value=(True, "")) as mock_run:
+            result = remote_monitor._execute_remote_pre_shutdown(
+                server, collect_result=True, deadline=10.0)
+        assert result.timed_out is True
+        assert mock_run.call_count == 1          # only the first command ran
+
+    @pytest.mark.unit
     def test_loopback_pre_shutdown_supplies_skip_ids_and_umount_targets(
         self, remote_monitor
     ):
@@ -992,62 +1027,6 @@ class TestLoopbackShutdownOrdering:
 
         hosts = [host for host, _ in calls]
         assert hosts == ["10.0.0.10", "127.0.0.1"]
-
-    @pytest.mark.unit
-    def test_loopback_identity_mismatch_warns_but_proceeds(self, remote_monitor):
-        """M2: when a loopback's host-identity probe FAILS on the destructive
-        path, Eneru warns + notifies but still issues the poweroff (refusing
-        would leave the local host running on a draining battery)."""
-        loopback = RemoteServerConfig(
-            name="host-loopback", enabled=True, host="127.0.0.1", user="root",
-            is_host_loopback=True, shutdown_command="shutdown -h now",
-            expected_host_identity="expected-machine-id",
-            pre_shutdown_commands=[],
-        )
-        remote_monitor.config.ups_groups[0].remote_servers = [loopback]
-        remote_monitor._send_notification = MagicMock()
-
-        calls, run_patch = self._record_calls(remote_monitor)
-        with run_patch, patch(
-            "eneru.remote_health.run_loopback_identity_probe",
-            return_value=(False, "host identity mismatch: bind-mount missing", 5),
-        ):
-            remote_monitor._shutdown_remote_servers()
-
-        # Poweroff still ran despite the failed identity check.
-        assert "127.0.0.1" in [host for host, _ in calls]
-        # And an identity warning notification was emitted.
-        bodies = [
-            (c.args[0] if c.args else "")
-            for c in remote_monitor._send_notification.call_args_list
-        ]
-        assert any("identity" in b.lower() for b in bodies), bodies
-
-    @pytest.mark.unit
-    def test_loopback_identity_ok_no_warning(self, remote_monitor):
-        """M2: a passing identity probe emits no identity warning."""
-        loopback = RemoteServerConfig(
-            name="host-loopback", enabled=True, host="127.0.0.1", user="root",
-            is_host_loopback=True, shutdown_command="shutdown -h now",
-            expected_host_identity="expected-machine-id",
-            pre_shutdown_commands=[],
-        )
-        remote_monitor.config.ups_groups[0].remote_servers = [loopback]
-        remote_monitor._send_notification = MagicMock()
-
-        calls, run_patch = self._record_calls(remote_monitor)
-        with run_patch, patch(
-            "eneru.remote_health.run_loopback_identity_probe",
-            return_value=(True, "", 5),
-        ):
-            remote_monitor._shutdown_remote_servers()
-
-        assert "127.0.0.1" in [host for host, _ in calls]
-        bodies = [
-            (c.args[0] if c.args else "")
-            for c in remote_monitor._send_notification.call_args_list
-        ]
-        assert not any("identity" in b.lower() for b in bodies), bodies
 
     @pytest.mark.unit
     def test_loopback_result_aggregates_pre_and_post(self, remote_monitor):

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -49,6 +49,17 @@ class TestRunCommand:
         assert "timed out" in stderr.lower()
 
     @pytest.mark.unit
+    def test_none_timeout_falls_back_to_default(self):
+        """H7: a None timeout must NOT mean 'wait forever' -- it falls back to
+        the default bound so a config slip (unmount.timeout:) can't hang."""
+        from unittest.mock import patch
+        with patch("eneru.utils.subprocess.run") as mock_run:
+            mock_run.return_value = type(
+                "R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            run_command(["echo", "hi"], timeout=None)
+        assert mock_run.call_args.kwargs["timeout"] == 30
+
+    @pytest.mark.unit
     def test_command_not_found(self):
         """Test command that doesn't exist."""
         exit_code, stdout, stderr = run_command(

--- a/tests/test_shutdown_actions.py
+++ b/tests/test_shutdown_actions.py
@@ -448,6 +448,7 @@ class TestNoDriftBetweenInProcessAndTemplates:
         "docker": "stop_containers",  # also covered by stop_compose
         "podman": "stop_containers",
         "umount": "unmount_filesystems",
+        "sync": None,  # local bounded `sync` (H6); no remote analogue
         "mountpoint": None,  # introspection only, no remote analogue
         "loginctl": "stop_containers_rootless",
         "sudo": None,  # transport, not a unique action

--- a/tests/test_shutdown_filesystems.py
+++ b/tests/test_shutdown_filesystems.py
@@ -46,32 +46,57 @@ def _make_fs_monitor(tmp_path, *, sync_enabled=True, unmount_enabled=True, mount
 
 @pytest.mark.unit
 def test_sync_filesystems_disabled_no_op(tmp_path):
-    """sync_enabled=False returns without invoking os.sync."""
+    """sync_enabled=False returns without invoking sync."""
     monitor = _make_fs_monitor(tmp_path, sync_enabled=False)
-    with patch("eneru.shutdown.filesystems.os.sync") as mock_sync, \
+    with patch("eneru.shutdown.filesystems.run_command") as mock_run, \
          patch("eneru.shutdown.filesystems.time.sleep"):
         monitor._sync_filesystems()
-    mock_sync.assert_not_called()
+    mock_run.assert_not_called()
 
 
 @pytest.mark.unit
 def test_sync_filesystems_dry_run_skips_os_sync(tmp_path):
-    """Dry-run logs the action but never calls os.sync()."""
+    """Dry-run logs the action but never runs the sync subprocess."""
     monitor = _make_fs_monitor(tmp_path, dry_run=True)
-    with patch("eneru.shutdown.filesystems.os.sync") as mock_sync:
+    with patch("eneru.shutdown.filesystems.run_command") as mock_run:
         monitor._sync_filesystems()
-    mock_sync.assert_not_called()
+    mock_run.assert_not_called()
 
 
 @pytest.mark.unit
-def test_sync_filesystems_real_calls_os_sync_then_sleeps(tmp_path):
-    """Real path: os.sync() + 2-second sleep for storage controller flush."""
+def test_sync_filesystems_real_runs_bounded_sync_then_sleeps(tmp_path):
+    """H6: real path runs a bounded `sync` subprocess + 2s controller-flush sleep."""
     monitor = _make_fs_monitor(tmp_path)
-    with patch("eneru.shutdown.filesystems.os.sync") as mock_sync, \
+    with patch("eneru.shutdown.filesystems.run_command",
+               return_value=(0, "", "")) as mock_run, \
          patch("eneru.shutdown.filesystems.time.sleep") as mock_sleep:
         monitor._sync_filesystems()
-    mock_sync.assert_called_once()
+    mock_run.assert_called_once()
+    # Bounded against a wall-clock timeout, not an unbounded os.sync().
+    assert mock_run.call_args.args[0] == ["sync"]
+    assert mock_run.call_args.kwargs.get("timeout")
     mock_sleep.assert_called_once_with(2)
+
+
+@pytest.mark.unit
+def test_sync_filesystems_timeout_proceeds(tmp_path):
+    """H6: a hung sync (exit 124) is logged and the sequence proceeds (no raise)."""
+    monitor = _make_fs_monitor(tmp_path)
+    with patch("eneru.shutdown.filesystems.run_command",
+               return_value=(124, "", "")) as mock_run, \
+         patch("eneru.shutdown.filesystems.time.sleep"):
+        monitor._sync_filesystems()
+    mock_run.assert_called_once()
+
+
+@pytest.mark.unit
+def test_sync_filesystems_error_proceeds(tmp_path):
+    """H6: a sync error (non-zero, non-124) is logged and the sequence proceeds."""
+    monitor = _make_fs_monitor(tmp_path)
+    with patch("eneru.shutdown.filesystems.run_command",
+               return_value=(1, "", "boom")), \
+         patch("eneru.shutdown.filesystems.time.sleep"):
+        monitor._sync_filesystems()
 
 
 @pytest.mark.unit

--- a/tests/test_shutdown_filesystems.py
+++ b/tests/test_shutdown_filesystems.py
@@ -48,55 +48,62 @@ def _make_fs_monitor(tmp_path, *, sync_enabled=True, unmount_enabled=True, mount
 def test_sync_filesystems_disabled_no_op(tmp_path):
     """sync_enabled=False returns without invoking sync."""
     monitor = _make_fs_monitor(tmp_path, sync_enabled=False)
-    with patch("eneru.shutdown.filesystems.run_command") as mock_run, \
+    with patch("eneru.shutdown.filesystems.subprocess.Popen") as mock_popen, \
          patch("eneru.shutdown.filesystems.time.sleep"):
         monitor._sync_filesystems()
-    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
 
 
 @pytest.mark.unit
 def test_sync_filesystems_dry_run_skips_os_sync(tmp_path):
-    """Dry-run logs the action but never runs the sync subprocess."""
+    """Dry-run logs the action but never spawns the sync subprocess."""
     monitor = _make_fs_monitor(tmp_path, dry_run=True)
-    with patch("eneru.shutdown.filesystems.run_command") as mock_run:
+    with patch("eneru.shutdown.filesystems.subprocess.Popen") as mock_popen:
         monitor._sync_filesystems()
-    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
 
 
 @pytest.mark.unit
 def test_sync_filesystems_real_runs_bounded_sync_then_sleeps(tmp_path):
-    """H6: real path runs a bounded `sync` subprocess + 2s controller-flush sleep."""
+    """H6: real path spawns a bounded `sync` Popen + 2s controller-flush sleep."""
     monitor = _make_fs_monitor(tmp_path)
-    with patch("eneru.shutdown.filesystems.run_command",
-               return_value=(0, "", "")) as mock_run, \
+    proc = MagicMock()
+    proc.poll.return_value = 0  # finishes immediately, success
+    with patch("eneru.shutdown.filesystems.subprocess.Popen",
+               return_value=proc) as mock_popen, \
          patch("eneru.shutdown.filesystems.time.sleep") as mock_sleep:
         monitor._sync_filesystems()
-    mock_run.assert_called_once()
-    # Bounded against a wall-clock timeout, not an unbounded os.sync().
-    assert mock_run.call_args.args[0] == ["sync"]
-    assert mock_run.call_args.kwargs.get("timeout")
+    mock_popen.assert_called_once()
+    assert mock_popen.call_args.args[0] == ["sync"]  # Popen(["sync"], ...)
     mock_sleep.assert_called_once_with(2)
 
 
 @pytest.mark.unit
-def test_sync_filesystems_timeout_proceeds(tmp_path):
-    """H6: a hung sync (exit 124) is logged and the sequence proceeds (no raise)."""
+def test_sync_filesystems_timeout_abandons_and_proceeds(tmp_path):
+    """H6 (CodeRabbit): a sync stuck past the deadline is killed best-effort and
+    ABANDONED (no blocking wait), and the sequence proceeds without raising."""
     monitor = _make_fs_monitor(tmp_path)
-    with patch("eneru.shutdown.filesystems.run_command",
-               return_value=(124, "", "")) as mock_run, \
+    proc = MagicMock()
+    proc.poll.return_value = None  # never finishes
+    with patch("eneru.shutdown.filesystems.subprocess.Popen",
+               return_value=proc), \
+         patch("eneru.shutdown.filesystems._SYNC_TIMEOUT_SECONDS", 0), \
          patch("eneru.shutdown.filesystems.time.sleep"):
-        monitor._sync_filesystems()
-    mock_run.assert_called_once()
+        monitor._sync_filesystems()  # must not hang or raise
+    proc.kill.assert_called_once()
 
 
 @pytest.mark.unit
 def test_sync_filesystems_error_proceeds(tmp_path):
-    """H6: a sync error (non-zero, non-124) is logged and the sequence proceeds."""
+    """H6: a sync error (non-zero exit) is logged and the sequence proceeds."""
     monitor = _make_fs_monitor(tmp_path)
-    with patch("eneru.shutdown.filesystems.run_command",
-               return_value=(1, "", "boom")), \
+    proc = MagicMock()
+    proc.poll.return_value = 1
+    with patch("eneru.shutdown.filesystems.subprocess.Popen",
+               return_value=proc) as mock_popen, \
          patch("eneru.shutdown.filesystems.time.sleep"):
         monitor._sync_filesystems()
+    mock_popen.assert_called_once()  # the bounded-sync path WAS exercised
 
 
 @pytest.mark.unit

--- a/tests/test_shutdown_filesystems.py
+++ b/tests/test_shutdown_filesystems.py
@@ -74,7 +74,8 @@ def test_sync_filesystems_real_runs_bounded_sync_then_sleeps(tmp_path):
          patch("eneru.shutdown.filesystems.time.sleep") as mock_sleep:
         monitor._sync_filesystems()
     mock_popen.assert_called_once()
-    assert mock_popen.call_args.args[0] == ["sync"]  # Popen(["sync"], ...)
+    argv = mock_popen.call_args.args[0]
+    assert len(argv) == 1 and argv[0].endswith("sync")  # Popen([<abs>/sync])
     mock_sleep.assert_called_once_with(2)
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1758,21 +1758,30 @@ class TestEdgeCases:
         assert n == 1
 
     @pytest.mark.unit
-    def test_purge_keeps_row_at_exact_cutoff(self, tmp_path):
-        """Purge SQL is ``ts < cutoff``; a row at cutoff exactly stays."""
+    def test_purge_aligns_raw_cutoff_to_bucket_boundary(self, tmp_path):
+        """M5: the raw cutoff is aligned DOWN to a 5-min bucket boundary so purge
+        deletes only WHOLE buckets. It must NOT trim the early samples of the
+        bucket straddling the rolling cutoff -- doing so would let the next
+        aggregate() re-derive that finalized bucket from a reduced sample set
+        and corrupt its avg/min/max (which then propagates to the hourly tier)."""
+        from eneru.stats import BUCKET_5MIN
         s = StatsStore(tmp_path / "boundary.db", retention_raw_hours=1)
         s.open()
         try:
             now = int(time.time())
-            cutoff = now - 3600  # the rolling cutoff_raw
-            # One row strictly older, one at the cutoff.
-            s.buffer_sample(SAMPLE_UPS_DATA, ts=cutoff - 1)
-            s.buffer_sample(SAMPLE_UPS_DATA, ts=cutoff)
+            aligned = (now - 3600) // BUCKET_5MIN * BUCKET_5MIN
+            older_ts = aligned - 1     # in the previous, fully-expired bucket
+            straddle_ts = aligned + 1  # in the bucket straddling the rolling cutoff
+            s.buffer_sample(SAMPLE_UPS_DATA, ts=older_ts)
+            s.buffer_sample(SAMPLE_UPS_DATA, ts=straddle_ts)
             s.flush()
-            s.purge()
-            cur = s._conn.execute("SELECT ts FROM samples ORDER BY ts ASC")
-            tss = [r[0] for r in cur.fetchall()]
-            assert tss == [cutoff]
+            # Pin time so the aligned cutoff is deterministic.
+            with patch("eneru.stats.time.time", return_value=now):
+                s.purge()
+            tss = [r[0] for r in s._conn.execute(
+                "SELECT ts FROM samples ORDER BY ts ASC").fetchall()]
+            assert older_ts not in tss       # whole expired bucket deleted
+            assert straddle_ts in tss        # straddling bucket's sample kept
         finally:
             s.close()
 


### PR DESCRIPTION
## Summary

Addresses the findings of a whole-repository pre-release audit of the v6.0 line and bumps to **6.0.0-rc10**. The audit (18-agent fan-out + adversarial verification + maintainer confirmation; documented in `docs/testing.md` → "Pre-release code review") found the new auth/API/control surface solid, with the residual risk concentrated in the **shutdown decision path** — where a plausible config typo or a slow/wedged subsystem could crash or stall the daemon *before* the host poweroff.

This PR lands the **Critical** and **High** fixes. **Medium / Low / Nit** fixes will be pushed to this same PR next (so CI gates the safety-critical changes first).

Every fix ships with a regression test that fails against the pre-fix code. A pre-push `code-reviewer` pass (opus, fresh context) reviewed the full diff and found no P0/P1 blockers; its two P2 suggestions are incorporated.

## Critical (missed-shutdown of the protected host)
- **C1** `multi_ups._drain_all_groups` self-joined the firing group's own monitor thread → `RuntimeError` aborted the sequence before poweroff when `drain_on_local_shutdown: true`. Skip the current thread.
- **C2** Shutdown-trigger numeric fields were never validated; a quoted `"20"` (common from templating tools) survived parse and `TypeError`-crashed the monitor loop on the first on-battery poll. Validate all trigger numbers per group at load.
- **C3** Null/empty `local_shutdown.command` → `None.split()` / `run_command([])` silently skipped the poweroff. Reject at load + guard call sites.

## High
- **H1** Redundancy cold-start hold (don't drop a powered rack when a member is merely slow to publish its first snapshot).
- **H2** On-battery FAILSAFE per-outage latch (stop re-firing the whole sequence every poll in non-halting configs).
- **H3** Debounce hard NUT failures on battery by `max_stale_data_tolerance` (a single transient blip can't drop a healthy host; `=1` restores instant FSB; off-battery grace unchanged).
- **H4** Wrap each drain phase (and the remote phase) so an exception can never skip the host poweroff.
- **H5/H7** Validate drain-phase timeouts (`max_wait`, `stop_timeout`, `unmount.timeout`); `run_command` treats `None` timeout as the default bound.
- **H6** Bounded `sync` subprocess instead of unbounded `os.sync()` (a hung mount can't wedge the poweroff).
- **H8** Reserve the final remote poweroff's budget before pre-shutdown commands spend the phase deadline.
- **H10** SIGTERM/SIGINT waits a bounded, config-derived deadline for an in-flight shutdown to complete.
- **H11/H12** Reject duplicate `ups.name` (sanitized) and unknown per-UPS / per-redundancy entry keys (e.g. misspelled `is_local`).
- **H13** Derive the depletion-rate min-sample floor from `window / check_interval` so a large `check_interval` can't silently disable T3.

## Testing
`pytest -m unit` green locally (one unrelated pre-existing failure: optional `apprise` not installed in the dev sandbox — fixed in the upcoming Low batch). E2E / Docker / full CI run here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the shutdown path and bumps to 6.0.0-rc10; restores ≥95% per-file coverage and fixes a CI non-root path. Adds a per-outage failsafe latch, stricter numeric validation, refined SSH/VM budgets, bounded filesystem sync, a more resilient dashboard, clearer loopback-target docs, and follow-up hardening from re-review.

- **Bug Fixes**
  - Multi-UPS/local shutdown: fixed self-join crash; added an in-flight guard and a SIGTERM/SIGINT re-entrancy guard; guard re-arms after the in-flight window; bounded wait derived from config.
  - Config validation: validate numeric triggers/timeouts; coerce/validate `ups.max_stale_data_tolerance` and `ups.check_interval`; non-empty `local_shutdown.command`; unique `ups.name`; sweep unknown keys under `ups`, `redundancy_groups`, `local_shutdown`, and nested `connection_loss_grace_period`; validate `nut_control.allowlist` values.
  - On-battery safety: debounce hard poll failures by `max_stale_data_tolerance` (int-coerced); add a per-outage FAILSAFE latch that resets only when back on valid line power.
  - Shutdown sequence: validate the poweroff command before marking complete; wrap each drain phase so exceptions never skip host poweroff; replace unbounded `os.sync()` with a bounded `sync` subprocess that abandons a stuck flush.
  - Remote/VMS: reserve per-command SSH overhead and attempt the final poweroff unless the full window is blown; use a wall-clock deadline for `virsh list` polls and the graceful wait; loopback host identity stays checked in the background health loop (no blocking probe at shutdown).
  - Voltage/battery: clamp charge to [0,100]; keep the depletion-rate trigger active at slow polls with a capped min-sample floor; treat implausible nominal voltage as missing; report null voltage thresholds until the first poll.
  - Redundancy: cold-start hold until all present members publish once, scoped to the group and bounded by the readiness window.
  - API/auth: strict write-path session recheck (fail closed on store errors); add `X-Content-Type-Options: nosniff`; anchor the NUT value filter; reject NUL bytes in passwords.
  - Notifications: bound eager Apprise sends from the signal handler so a hung endpoint can’t block exit.
  - Stats/dashboard: align purge cutoffs to bucket boundaries; add a `query_range` metric allowlist; show “connection lost” on fetch errors and only commit the control-panel cache key after a clean build.
  - Tests/CI: fix non-root shutdown-flag path and maintain ≥95% per-file coverage.
  - Follow-ups: cold-start readiness ignores disabled grace and clamps negative grace durations to 0; coordinator join deadline budgets UPS+group remotes and pre-commands; bounded `sync` uses an absolute path; FAILSAFE re-arms only on a valid OL status; CLI normalizes padded usernames in `user create`/`user passwd`; a timed-out eager send may yield one duplicate “Service Stopped” on next start (intentional at-least-once).

- **Migration**
  - Ensure trigger thresholds, drain timeouts, `ups.check_interval`, and `ups.max_stale_data_tolerance` are integers.
  - If `local_shutdown.enabled`, set a non-empty `local_shutdown.command`.
  - Make each `ups.name` unique and fix typos/unknown keys under `ups`, `redundancy_groups`, `local_shutdown`, and per-UPS `connection_loss_grace_period`.
  - For instant on-battery FAILSAFE, set `max_stale_data_tolerance: 1`.
  - If using `nut_control.allowlist`, keep values to the safe NUT charset.

<sup>Written for commit 788d1a3967bc544562ddb2d4c0bcc73ab10544d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: user/apikey/shutdown/remote management commands.
  * Connection-loss failsafe latch and multi-UPS cold-start protection.

* **Bug Fixes**
  * Auth: writes fail-closed on auth DB errors.
  * Improved battery/voltage handling and validation.
  * Bounded timeouts for filesystem sync, VM polling, SSH and run-command paths.
  * Signal re-entrancy guards, reduced noisy remote logging, safer notification delivery.
  * Expanded config validation and shutdown sequencing hardening.

* **Documentation**
  * Pre-release audit process, changelog, triggers, and remote-server clarifications.

* **Tests**
  * New and updated tests covering auth, config validation, shutdown, and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->