### PR TITLE
fix: address rc11 pre-release audit findings

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -73,11 +73,13 @@ There is deliberately **no `--password VALUE` flag** — a password on the comma
 line leaks into shell history and the process list (`ps`). Use the interactive
 prompt, `--generate`, or `--password-stdin`.
 
-**Deleting a user ends their active sessions.** Dashboard sessions are held in
-memory with a TTL, but the API re-checks on every request that the session's user
-still exists; deleting the account invalidates its session token immediately, so
-an open dashboard is signed out on its next poll. (A transient auth-DB error
-during that check keeps the existing session rather than logging out a valid user.)
+**Deleting a user or resetting their password ends their active sessions.**
+Dashboard sessions are held in memory with a TTL, but the API re-checks on every
+request that the session's user still exists and still has the same
+`password_changed_at` value; deleting the account or running `eneru user passwd`
+invalidates its session token immediately, so an open dashboard is signed out on
+its next poll. (A transient auth-DB error during that check keeps the existing
+session rather than logging out a valid user.)
 
 ## Managing API keys
 
@@ -109,7 +111,7 @@ api:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `api.auth.enabled` | `false` | Turn API authentication on. Off keeps v5.3 read-only behavior |
+| `api.auth.enabled` | unset (`false` until an auth DB user exists) | Turn API authentication on. If omitted, auth auto-activates once the auth DB contains a user; an explicit `false` keeps v5.3 read-only behavior |
 | `api.auth.require_for_reads` | `false` | When off, read endpoints stay open even with auth on; writes always require a credential |
 | `api.auth.session_ttl` | `3600` | Dashboard session token lifetime, in seconds |
 | `api.auth.db_path` | `/var/lib/eneru/auth.db` | Location of the user/API-key store; CLI `--auth-db` overrides |
@@ -141,8 +143,9 @@ The rule is deliberately conservative:
 When the API is enabled but auth is off (no users, or `enabled: false`), the
 daemon logs a one-line notice at startup and the dashboard hides its **Sign-in**
 button — there is nothing to sign into. The dashboard learns the live auth state
-from `/api/v1/config`; if you create the first user while the dashboard is open,
-the **Sign-in** button appears on the next poll, usually within a few seconds.
+from `/api/v1/auth/state`, which stays open even when `require_for_reads` gates
+the read API; if you create the first user while the dashboard is open, the
+**Sign-in** button appears on the next poll, usually within a few seconds.
 
 ## Containers
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 v6.0 is a major release that turns the read-only observability API into an
 interactive product: a browser dashboard, authentication, UPS control, and config
 hot-reload. With authentication left off, the API stays read-only exactly as in
-5.x. New features only; no behavior changes to monitoring or shutdown.
+5.x. The rc11 audit fixes below harden shutdown, auth, resource handling, and
+CI coverage before release.
 
 ### Added
 
@@ -52,6 +53,41 @@ hot-reload. With authentication left off, the API stays read-only exactly as in
 
 - **NUT auto-discovery**, previously listed for 6.0, was dropped: it duplicates
   `nut-scanner` and does not fit Eneru's config-first model.
+
+### Fixed (rc11 — audit follow-through)
+
+rc11 closes the remaining confirmed findings from the whole-repository
+pre-release audit after the Critical/High tranche was already in PR review.
+
+- **API/auth hardening:** request-body reads now have a socket timeout, dynamic
+  auth fails closed when an existing auth DB cannot be inspected, `/api/v1/auth/state`
+  stays open so the dashboard can show login even when reads require auth, and
+  password resets invalidate existing user sessions.
+- **Dashboard correctness:** redundancy cards use server-computed quorum health,
+  advisory member triggers no longer show a false shutdown-imminent banner while
+  quorum is intact, event source filtering is exact, event paging sorts by
+  `(ts, source, id)`, partial event-delete responses no longer remove unconfirmed
+  rows, and the battery bar no longer relies on inline style mutation under CSP.
+- **SQLite/resource safety:** stats open failures no longer leave a half-open
+  connection, failed flushes requeue their samples, `_safe_alter()` only swallows
+  duplicate-column migration errors, readonly opens return `None` on SQLite
+  failures, monitor/coordinator shutdown closes stats handles, and deferred
+  stop-notification delivery claims rows as `delivering` rather than `sent`
+  until Apprise succeeds. A v6 stats migration timestamps those claims so daemon
+  startup recovers stale delivery work without stealing a live one-shot helper's
+  active send; recovery failures are surfaced during `open()` instead of leaving
+  delivery rows stuck silently.
+- **Packaging/docs drift:** bumped the pre-release version to `6.0.0-rc11`,
+  listed MQTT in requirements files, added package-data checks for dashboard and
+  completion resources, removed stale loopback `shutdown_order: 999` examples,
+  and updated API/testing docs to match the read-gated auth behavior and audit
+  coverage.
+- **CI/test diagnostics:** the Single UPS control E2E now uses the dummy NUT
+  server's control credential, and PTY-backed `upscmd`/`upsrw` failures preserve
+  NUT's response text instead of collapsing to a generic exit code. The NUT
+  control PTY wrapper now also validates that only fixed `upscmd`/`upsrw` argv
+  shapes reach `subprocess.Popen`, and rejects username-only control attempts
+  before they can hang waiting for a password prompt.
 
 ### Fixed (rc10 — pre-release audit hardening)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,8 +320,8 @@ The API is opt-in and binds to localhost by default when enabled. With `api.auth
 | `api.enabled` | `false` | Start the embedded HTTP API with `eneru run` |
 | `api.bind` | `127.0.0.1` | Listen address |
 | `api.port` | `9191` | Listen port |
-| `api.auth.enabled` | `false` | Opt-in API authentication. When off, the API is read-only and all write surfaces are hard disabled (v5.3 behavior) |
-| `api.auth.require_for_reads` | `false` | When off, read endpoints (incl. `/metrics`) stay open even with auth on; writes always require a credential. Set on to also gate reads |
+| `api.auth.enabled` | unset (`false` until an auth DB user exists) | Opt-in API authentication. When off, the API is read-only and all write surfaces are hard disabled (v5.3 behavior). If omitted, auth auto-activates once the auth DB contains a user |
+| `api.auth.require_for_reads` | `false` | When off, read endpoints (incl. `/metrics`) stay open even with auth on; writes always require a credential. Set on to also gate reads. `/health`, `/ready`, dashboard static files, and `/api/v1/auth/state` stay open for probes/login bootstrap |
 | `api.auth.session_ttl` | `3600` | Dashboard session token lifetime, seconds |
 | `api.auth.db_path` | `/var/lib/eneru/auth.db` | Where local users and API keys are stored (global SQLite DB, separate from per-UPS stats). CLI `--auth-db` overrides |
 | `prometheus.enabled` | `true` | Serve Prometheus text metrics at `/metrics` |
@@ -343,7 +343,7 @@ The API is opt-in and binds to localhost by default when enabled. With `api.auth
 | `nut_control.allowed_variables` | `[]` | Allowlisted writable variables for upsrw. Empty by default — opt in each one |
 | `nut_control.timeout` | `10` | Per-command subprocess timeout (seconds) |
 
-`api.bind` defaults to `127.0.0.1`. If you set it to a non-loopback address, Eneru emits a startup warning because `/api/v1/config` returns server hostnames, SSH usernames, shutdown ordering, and presence flags with no auth. Front-end the API with SSH or a reverse proxy that adds auth before exposing it beyond a trusted boundary.
+`api.bind` defaults to `127.0.0.1`. If you set it to a non-loopback address, Eneru emits a startup warning when auth is off because read endpoints can expose server hostnames, SSH usernames, shutdown ordering, and presence flags. Front-end the API with SSH or a reverse proxy that adds auth, or enable `api.auth.enabled` (and optionally `api.auth.require_for_reads`), before exposing it beyond a trusted boundary.
 
 ## Hot-reload
 

--- a/docs/observability-api.md
+++ b/docs/observability-api.md
@@ -33,6 +33,7 @@ Endpoints:
 | `/api/v1/events` | Recent event rows (`limit`, `verbosity`, `from`, `to`, `before`) | 200 / 400 (bad query) |
 | `DELETE /api/v1/ups/<name>/events` | Delete selected events (auth required) | 200 / 400 / 401 / 403 / 404 / 413 / 503 |
 | `/api/v1/config` | Sanitized config summary | 200 |
+| `/api/v1/auth/state` | Effective auth state for dashboard login bootstrap | 200 |
 | `/api/v1/remote-health` | Remote SSH health status | 200 |
 | `/metrics` | Prometheus text metrics | 200 / 404 (Prometheus disabled) |
 
@@ -48,9 +49,10 @@ is a JSON object: `{"username": "<username>", "password": "<password>"}`.
 | `/health`, `/ready` | open | open (always) |
 | `/metrics`, `/api/v1/ups*`, `/history`, `/events`, `/remote-health` | open | open unless `require_for_reads` |
 | `/api/v1/config` | sanitized | sanitized (anonymous) / **extended** (authenticated) |
+| `/api/v1/auth/state` | open | open (always) |
 | write endpoints (UPS control, config reload) | **hard-disabled (403)** | required (401 without a credential) |
 
-"Auth disabled" always means read-only: write features cannot be reached, and enabling a control feature while auth is off is a startup error. See [Authentication](authentication.md) for the user/API-key model and the `eneru user` / `eneru apikey` CLI.
+"Auth disabled" always means read-only: write features cannot be reached, and enabling a control feature while auth is off is a startup error. If `api.auth.enabled` is left unset, auth activates automatically once the auth DB contains at least one user; if the DB file exists but cannot be read, Eneru fails closed and treats auth as active. See [Authentication](authentication.md) for the user/API-key model and the `eneru user` / `eneru apikey` CLI.
 
 **Logging in.** `POST /api/v1/auth/login` with a JSON body `{"username": "<username>", "password": "<password>"}` returns a bearer token:
 
@@ -59,7 +61,7 @@ is a JSON object: `{"username": "<username>", "password": "<password>"}`.
 {"token": "…", "tokenType": "bearer", "expiresIn": 3600}
 ```
 
-Send it as `Authorization: Bearer <token>` on subsequent requests (programmatic clients send an API key the same way, or via `X-API-Key`). `POST /api/v1/auth/logout` invalidates a session token. Sessions live in memory and expire after `api.auth.session_ttl` seconds; they do not survive a daemon restart.
+Send it as `Authorization: Bearer <token>` on subsequent requests (programmatic clients send an API key the same way, or via `X-API-Key`). `POST /api/v1/auth/logout` invalidates a session token. Sessions live in memory, expire after `api.auth.session_ttl` seconds, and are invalidated if the user is deleted or their password is reset; they do not survive a daemon restart.
 
 Example response shapes:
 
@@ -91,7 +93,7 @@ Example response shapes:
 {"generatedAt": 1720000000.0, "events": [{"ts": 1720000000, "category": "power_event", "event": "ON_BATTERY", "details": "..."}]}
 ```
 
-UPS rows include a stable `groupId` derived from the configured UPS name. Multi-UPS responses also include `redundancyGroups` rows with their source UPS names, quorum target, locality flag, and remote-health rows.
+UPS rows include a stable `groupId` derived from the configured UPS name. Multi-UPS responses also include `redundancyGroups` rows with their source UPS names, quorum target, server-computed `healthyCount` / `quorumLost`, per-member raw/effective health, locality flag, and remote-health rows. During evaluator cold start, `quorumDeferred` is `true` and `quorumLost` remains `false` until members have had their first-report window.
 
 `powerQuality` mixes JSON strings and numbers by source: raw NUT readings (`inputVoltage`, `outputVoltage`, `batteryVoltage`, `temperature`, `inputFrequency`, `outputFrequency`) and state labels (`voltageState`, `avrState`, `bypassState`, `overloadState`) are strings; Eneru-derived values (`nominalVoltage`, `warningLow`, `warningHigh`) are numbers. Strings are empty when the UPS does not publish that NUT field. Consumers that compare numeric ranges should coerce the string fields with `float()` (or `| float` in Home Assistant templates) and treat empty strings as missing data.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,9 +69,14 @@ Critical-tier outcomes. The headline result: the new v6.0 security surface
 static-asset name check, and a write gate in front of every mutating route)
 held up well; the residual risk was concentrated in the shutdown decision path,
 where a plausible config typo or a slow/wedged subsystem could crash the daemon
-*before* the host poweroff. Every confirmed finding from that audit is fixed in
-the rc10 work, each accompanied by a regression test that fails against the
-pre-fix code, so the same class of bug cannot silently return.
+*before* the host poweroff. rc10 fixed the first Critical/High tranche and opened
+the upstream PR so CI could start immediately. rc11 then closed the remaining
+confirmed Medium/Low/Nit items from the same audit: request-body read bounding/timeouts,
+auth bootstrap under read-gated APIs, redundancy health reporting, SQLite
+lifecycle races, dashboard event identity, password-reset session invalidation,
+package-data drift, and docs/examples drift. Each code finding has a regression
+test that fails against the pre-fix behavior, so the same class of bug cannot
+silently return.
 
 ## CI layout
 
@@ -123,13 +128,13 @@ done
 | Multi-UPS coordinator | Group routing, `is_local`, drain policy, local shutdown locking, signal handling |
 | Redundancy runtime | Quorum evaluation, advisory triggers, connection-grace handling, idempotent group execution |
 | Health monitoring | Voltage thresholds, AVR, bypass, overload, battery anomaly filtering |
-| Notifications | Formatting, retry queue, lifecycle classification, coalescing, suppression rules, container restart/upgrade stop-row deferral |
-| Statistics and TUI | SQLite schema (incl. the v5 `events.id` AUTOINCREMENT table-rebuild migration — column added, rows/version preserved, idempotent, id-not-reused-after-delete), aggregation, event tier filtering, wide-range + composite-cursor event paging across duplicate timestamps, `delete_events` (id+ts+type guard, dedup, per-DB isolation), TUI grouping, graphs, one-shot monitor output |
+| Notifications | Formatting, retry queue, lifecycle classification, coalescing, suppression rules, container restart/upgrade stop-row deferral, deferred stop delivery claim/recovery races and mark-sent failure logging |
+| Statistics and TUI | SQLite schema (incl. the v5 `events.id` AUTOINCREMENT table-rebuild migration — column added, rows/version preserved, idempotent, id-not-reused-after-delete — and the v6 `notifications.delivering_at` migration for stale deferred-delivery claim recovery), stale-claim recovery failure propagation, aggregation, event tier filtering, wide-range + composite-cursor event paging across duplicate timestamps, `delete_events` (id+ts+type guard, dedup, per-DB isolation), TUI grouping, graphs, one-shot monitor output |
 | Observability | API routing, readiness, Prometheus escaping, power-quality metrics, remote-health sidecars, MQTT publishing |
 | Authentication | User/API-key SQLite store (bcrypt hashing, salt uniqueness, truncation, CRUD), `eneru user`/`apikey` CLI lifecycle, password-input safety (getpass/generate/stdin), lazy bcrypt import |
-| API auth middleware | Session manager (TTL/expiry), tiered authorization matrix (reads open vs `require_for_reads`, writes fail-closed when auth off), bearer/API-key resolution, session re-validation against user existence (deleted user signed out; DB error preserves the session), login/logout, body-size + JSON validation, tiered `/config` |
+| API auth middleware | Session manager (TTL/expiry), tiered authorization matrix (reads open vs `require_for_reads`, writes fail-closed when auth off), bearer/API-key resolution, session re-validation against user state (deleted user or password reset signs out; DB error preserves the session), login/logout, body-size + JSON validation including total body-read deadlines and read-error mapping, tiered `/config` |
 | Event management API | `DELETE /api/v1/ups/{name}/events` — authed delete + `EVENTS_DELETED` audit, anonymous 401 / auth-off 403, unknown UPS 404, stats-unavailable 503, malformed-body matrix (400) and oversize (413); monitor/coordinator routing to the live per-UPS store; events `from`/`to`/`before` paging and history `from > to`/`All` validation |
-| UPS control | `upscmd`/`upsrw` wrappers and output parsing, command/variable allowlist enforcement, per-group credential/allowlist overrides, feature-disabled and unknown-UPS handling, NUT-error mapping, fail-closed config validation (control requires auth), value sanitization, audit logging to the events table |
+| UPS control | `upscmd`/`upsrw` wrappers and output parsing (including PTY output on NUT errors), fixed-binary argv validation before subprocess execution, username/password pairing before PTY prompt handling, command/variable allowlist enforcement, per-group credential/allowlist overrides, feature-disabled and unknown-UPS handling, NUT-error mapping, fail-closed config validation (control requires auth), value sanitization, audit logging to the events table |
 | Config hot-reload | Strict load+validate (bad YAML / non-mapping / validation error rejected, running config kept), safe-vs-restart classification, in-place live apply across shared + per-monitor configs, subsystem reload hooks for stats/notifications/MQTT/remote-health, SIGHUP handler and API `/config/reload` endpoint |
 | Web dashboard | Static asset serving via `importlib.resources`, MIME mapping, path-traversal rejection, strict CSP + `nosniff` on HTML, bytes-body responses, dashboard open before the read gate, event filters, control variable forms, `nutControl` exposure in the config summary, and marker guards for the asset-level surfaces with no browser in CI (`[hidden]` reset, resize-safe graph, wide-history range/paging, delete-selected, drill-down, Light/Dark/System theme) |
 | Packaging | nFPM file list, package install paths, wrapper execution, OCI image smoke tests |

--- a/examples/config-container-local.yaml
+++ b/examples/config-container-local.yaml
@@ -89,7 +89,7 @@ remote_servers:
       - "StrictHostKeyChecking=no"
       - "UserKnownHostsFile=/dev/null"
     # use_sudo: true            # non-root plan B with documented sudoers
-    # shutdown_order: 999       # runs LAST — host poweroff kills the container
+    # No shutdown_order needed: loopback actions are bracketed around remotes
 
 logging:
   # Forensic log file. Mount a volume at /var/log/eneru so this survives

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -124,7 +124,7 @@ api:
   # one user, auth turns on automatically (no restart) — so `eneru user create`
   # then sign in "just works". An explicit value (true OR false) always wins.
   auth:
-    enabled: false
+    # enabled: false
     # Tiered reads: when false (default), read endpoints stay open even with
     # auth on (so Prometheus keeps scraping without a token); writes always
     # require a credential. Set true to also require auth for reads.
@@ -490,16 +490,16 @@ remote_servers:
   #   host: 127.0.0.1
   #   user: root
   #   shutdown_command: "shutdown -h now"
-  #   shutdown_order: 999
   #
   # To use the default root loopback path, append id_loopback.pub to
   # /root/.ssh/authorized_keys on the host with no forced command. Do NOT use
   # authorized_keys command="...": sshd would replace Eneru's identity probe
   # and generated shutdown actions with that one forced command.
   #
-  # Write an explicit loopback only when you need to override synthesis. The
-  # loopback shutdown_order must be greater than every other enabled remote in
-  # the same UPS group, because the host must shut down last.
+  # Write an explicit loopback only when you need to override synthesis. Do not
+  # set shutdown_order on loopback delegates: Eneru ignores it and always runs
+  # loopback local actions before regular remotes, then loopback host poweroff
+  # after regular remotes.
   # - name: "host-loopback"
   #   enabled: true
   #   host: "127.0.0.1"
@@ -512,7 +512,6 @@ remote_servers:
   #   # host_identity_command: "cat /etc/machine-id"
   #   # expected_host_identity: auto-populated from /etc/machine-id
   #   shutdown_command: "shutdown -h now"
-  #   shutdown_order: 999
   #
   # Non-root loopback hardening plan B: create a dedicated host user with
   # NOPASSWD sudo for shutdown, virsh, docker, podman, umount, and sync, then
@@ -527,7 +526,6 @@ remote_servers:
   #   use_sudo: true
   #   ssh_key_path: "/var/lib/eneru/ssh/id_loopback"
   #   shutdown_command: "shutdown -h now"
-  #   shutdown_order: 999
   #
   # Leave pre_shutdown_commands unset on loopback entries. Eneru generates the
   # VM, container, compose, rootless Podman, sync, and unmount actions from the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ pytest-timeout>=2.1.0
 PyYAML>=5.4.1
 apprise>=1.9.7
 bcrypt>=4.0.1
+paho-mqtt>=2.0.0
 mkdocs>=1.6.1
 mkdocs-material>=9.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ apprise>=1.9.7
 # Optional - for API authentication (eneru user / apikey, dashboard login)
 # Only needed when api.auth is enabled. Remove if you don't use auth.
 bcrypt>=4.0.1
+
+# Optional - for MQTT status publishing
+# Only needed when mqtt.enabled is true. Remove if you don't use MQTT.
+paho-mqtt>=2.0.0

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -323,10 +323,6 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
 
     server_version = "EneruAPI/1.0"
 
-    def setup(self) -> None:
-        super().setup()
-        self.connection.settimeout(REQUEST_READ_TIMEOUT_SECONDS)
-
     def do_GET(self):  # noqa: N802 - stdlib hook
         self._dispatch(self._route)
 
@@ -509,7 +505,13 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         if not username:
             return "ok"
         try:
-            return "ok" if store.get_user(username) is not None else "gone"
+            user = store.get_user(username)
+            if user is None:
+                return "gone"
+            issued_at = principal.get("password_changed_at")
+            if issued_at is not None and user.get("password_changed_at") != issued_at:
+                return "gone"
+            return "ok"
         except Exception:
             return "unknown"
 
@@ -549,10 +551,53 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         if length > MAX_BODY_BYTES:
             raise APIPayloadTooLarge(
                 f"body exceeds {MAX_BODY_BYTES} bytes")
+        deadline = time.monotonic() + REQUEST_READ_TIMEOUT_SECONDS
+        timeout_changed = False
+        previous_timeout = None
+        connection = getattr(self, "connection", None)
+        if length and connection is not None:
+            try:
+                previous_timeout = connection.gettimeout()
+                connection.settimeout(REQUEST_READ_TIMEOUT_SECONDS)
+                timeout_changed = True
+            except Exception:
+                # Tests and uncommon socket wrappers may not expose timeout
+                # controls. Real sockets get the read-specific timeout above.
+                pass
         try:
-            raw = self.rfile.read(length) if length else b""
-        except (socket.timeout, TimeoutError, OSError):
-            raise APIBadRequest("request body timed out")
+            try:
+                chunks = []
+                remaining = length
+                reader = getattr(self.rfile, "read1", None)
+                if not callable(reader):
+                    reader = self.rfile.read
+                while remaining:
+                    time_left = deadline - time.monotonic()
+                    if time_left <= 0:
+                        raise APIBadRequest("request body timed out")
+                    if timeout_changed:
+                        try:
+                            connection.settimeout(time_left)
+                        except Exception:
+                            pass
+                    chunk = reader(min(remaining, 65536))
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                    remaining -= len(chunk)
+                raw = b"".join(chunks) if length else b""
+            except (socket.timeout, TimeoutError):
+                raise APIBadRequest("request body timed out")
+            except OSError:
+                raise APIBadRequest("failed to read request body")
+        finally:
+            if timeout_changed:
+                try:
+                    connection.settimeout(previous_timeout)
+                except Exception:
+                    pass
+        if length and len(raw) != length:
+            raise APIBadRequest("incomplete request body")
         if not raw:
             return {}
         try:
@@ -590,10 +635,11 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         # form before it has a token.
         if path == "/api/v1/auth/state":
             auth_cfg = getattr(self.api_config.api, "auth", None)
+            auth_active = self._auth_active()
             return 200, "application/json", {
-                "enabled": self._auth_active(),
+                "enabled": auth_active,
                 "requireForReads": bool(
-                    getattr(auth_cfg, "require_for_reads", False)
+                    auth_active and getattr(auth_cfg, "require_for_reads", False)
                 ),
             }
 
@@ -1000,8 +1046,12 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
             try:
                 source.record_control_event(ups, event_type,
                                             f"{label} {target} -> {result}")
-            except Exception:
-                pass
+            except Exception as exc:
+                if self.api_log is not None:
+                    try:
+                        self.api_log(f"⚠️ control audit event failed: {exc}")
+                    except Exception:
+                        pass
 
     @staticmethod
     def _error(code: str, message: str) -> Dict[str, Dict[str, str]]:

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -6,6 +6,7 @@ import math
 import os
 import re
 import secrets
+import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -28,6 +29,9 @@ from eneru.status import (
 # Cap request bodies so a hostile/accidental huge POST can't exhaust memory in a
 # handler thread. Auth + control payloads are tiny JSON objects.
 MAX_BODY_BYTES = 64 * 1024
+# Bound reads from each client socket. Without this, a client can declare a
+# small Content-Length and drip bytes forever, pinning a non-daemon handler.
+REQUEST_READ_TIMEOUT_SECONDS = 10
 
 # Dashboard static assets (served from the eneru.web package). Only these flat
 # names are servable; the strict name check below makes path traversal impossible.
@@ -165,6 +169,7 @@ API_ENDPOINTS = (
     },
     {"path": "/api/v1/config", "description": "Configuration summary (extended when authenticated)"},
     {"path": "/api/v1/remote-health", "description": "Remote SSH health rows"},
+    {"path": "/api/v1/auth/state", "description": "Effective auth state for dashboard login bootstrap"},
     {"path": "/api/v1/auth/login", "description": "POST username/password for a session token (when auth enabled)"},
     {"path": "/api/v1/auth/logout", "description": "POST to invalidate the current session token"},
     {"path": "/api/v1/ups/{name}/commands", "description": "Allowlisted UPS commands (when nut_control enabled)"},
@@ -183,8 +188,9 @@ def _auth_is_active(config: Any) -> bool:
     left unset, auth is active iff the auth DB already has at least one user — so
     "create a user, then sign in" works **with no restart**, while a fresh
     install with no users stays open (v5.3 read-only behavior). The DB is never
-    created as a side effect of this check, and a broken/unreadable DB fails
-    closed to "inactive" (writes stay hard-disabled).
+    created as a side effect of this check. Once the DB file exists, a
+    broken/unreadable DB fails closed to "active": reads that require auth stay
+    gated and writes require credentials rather than silently reopening.
     """
     auth_cfg = getattr(getattr(config, "api", None), "auth", None)
     if auth_cfg is None:
@@ -198,7 +204,7 @@ def _auth_is_active(config: Any) -> bool:
             return False
         return AuthStore(auth_cfg.db_path).user_count() > 0
     except Exception:
-        return False
+        return True
 
 
 class EneruAPIServer:
@@ -316,6 +322,10 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
     api_log: Any = None
 
     server_version = "EneruAPI/1.0"
+
+    def setup(self) -> None:
+        super().setup()
+        self.connection.settimeout(REQUEST_READ_TIMEOUT_SECONDS)
 
     def do_GET(self):  # noqa: N802 - stdlib hook
         self._dispatch(self._route)
@@ -539,7 +549,10 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         if length > MAX_BODY_BYTES:
             raise APIPayloadTooLarge(
                 f"body exceeds {MAX_BODY_BYTES} bytes")
-        raw = self.rfile.read(length) if length else b""
+        try:
+            raw = self.rfile.read(length) if length else b""
+        except (socket.timeout, TimeoutError, OSError):
+            raise APIBadRequest("request body timed out")
         if not raw:
             return {}
         try:
@@ -571,6 +584,18 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         if path == "/ready":
             payload = readiness(self.api_source)
             return (200 if payload["ready"] else 503), "application/json", payload
+
+        # Auth bootstrap must stay open even when require_for_reads=true;
+        # otherwise the dashboard cannot learn that it should show the login
+        # form before it has a token.
+        if path == "/api/v1/auth/state":
+            auth_cfg = getattr(self.api_config.api, "auth", None)
+            return 200, "application/json", {
+                "enabled": self._auth_active(),
+                "requireForReads": bool(
+                    getattr(auth_cfg, "require_for_reads", False)
+                ),
+            }
 
         # Every remaining GET is a read: open by default, gated when
         # require_for_reads is set. principal is None for anonymous callers.
@@ -1006,6 +1031,8 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         def _visible(path: str) -> bool:
             if path == "/metrics":
                 return prometheus_enabled
+            if path == "/api/v1/auth/state":
+                return True
             if path.startswith("/api/v1/auth/") or path == "/api/v1/config/reload":
                 return auth_enabled
             if path == "/api/v1/ups/{name}/events":

--- a/src/eneru/auth.py
+++ b/src/eneru/auth.py
@@ -250,13 +250,16 @@ class AuthStore:
 
     def set_password(self, username: str, password: str) -> None:
         """Reset a user's password. Raises :class:`UserNotFoundError` if absent."""
-        now = int(time.time())
         pw_hash = hash_password(password)
         with self._session() as conn:
+            # Like moving a one-way turnstile: compute the next marker inside
+            # the UPDATE so concurrent password resets cannot both reuse the
+            # same password_changed_at value and leave an old session valid.
             cur = conn.execute(
-                "UPDATE users SET password_hash = ?, password_changed_at = ? "
+                "UPDATE users SET password_hash = ?, "
+                "password_changed_at = max(?, password_changed_at + 1) "
                 "WHERE username = ?",
-                (pw_hash, now, username),
+                (pw_hash, int(time.time()), username),
             )
             if cur.rowcount == 0:
                 raise UserNotFoundError(f"user {username!r} not found")
@@ -299,7 +302,8 @@ class AuthStore:
         """
         with self._session() as conn:
             row = conn.execute(
-                "SELECT username, password_hash, role FROM users WHERE username = ?",
+                "SELECT username, password_hash, role, password_changed_at "
+                "FROM users WHERE username = ?",
                 (username,),
             ).fetchone()
         if row is None:
@@ -307,7 +311,12 @@ class AuthStore:
             return None
         if not verify_password(password, row["password_hash"]):
             return None
-        return {"username": row["username"], "role": row["role"], "kind": "user"}
+        return {
+            "username": row["username"],
+            "role": row["role"],
+            "password_changed_at": row["password_changed_at"],
+            "kind": "user",
+        }
 
     # ----- api keys -----
 

--- a/src/eneru/deferred_delivery.py
+++ b/src/eneru/deferred_delivery.py
@@ -26,8 +26,8 @@ When the timer fires:
   ``status != 'pending'`` and exits silently. The user gets a single
   ``🔄 Restarted`` notification.
 - If no replacement came up (``systemctl stop``), the row is still
-  ``pending``. The deliver helper opens the per-UPS Apprise instance,
-  sends the row, and marks it ``sent``. The user gets a single
+  ``pending``. The deliver helper claims it as ``delivering``, opens the
+  per-UPS Apprise instance, sends the row, and marks it ``sent``. The user gets a single
   ``🛑 Service Stopped`` notification.
 
 Fallback path: when ``systemd-run`` isn't available in a foreground
@@ -42,6 +42,7 @@ it with one Restarted/Upgraded lifecycle notification.
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -49,6 +50,9 @@ import sqlite3
 import time
 from pathlib import Path
 from typing import Callable, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 # Window between OUR exit and the deferred-delivery timer firing.
@@ -354,7 +358,7 @@ def _eager_send(
     try:
         from eneru.stats import StatsStore
         store = StatsStore(db_path)
-        store.open()
+        store.open(recover_delivering=False)
         try:
             store.mark_notification_sent(notification_id)
         finally:
@@ -413,13 +417,18 @@ def deliver_pending_stop(
         # AND mark_notification_sent would overwrite the row's
         # `cancelled` status back to `sent` — reopening the
         # duplicate-lifecycle race the v5.2.1 fix exists to close.
-        # Claim by transitioning pending→sent in a single statement;
-        # only proceed with delivery if we actually won the row.
+        # Claim by transitioning pending→delivering in a single statement;
+        # only proceed with delivery if we actually won the row. Do not mark
+        # sent until Apprise returns success — a crash between claim and send is
+        # recovered by the next daemon open moving stale delivering rows to
+        # pending.
+        now = int(time.time())
         with store._db_lock:
             cur = store._conn.execute(
-                "UPDATE notifications SET status='sent', sent_at=?, "
-                "attempts=attempts+1 WHERE id=? AND status='pending'",
-                (int(time.time()), notification_id),
+                "UPDATE notifications SET status='delivering', sent_at=NULL, "
+                "delivering_at=?, attempts=attempts+1 "
+                "WHERE id=? AND status='pending'",
+                (now, notification_id),
             )
             store._conn.commit()
             won = cur.rowcount > 0
@@ -434,12 +443,13 @@ def deliver_pending_stop(
         if not worker.start():
             # apprise unavailable / no urls — revert the claim so a
             # future start can retry instead of leaving a row marked
-            # `sent` with no actual delivery.
+            # `delivering` with no actual delivery.
             try:
                 with store._db_lock:
                     store._conn.execute(
                         "UPDATE notifications SET status='pending', "
-                        "sent_at=NULL WHERE id=?",
+                        "sent_at=NULL, delivering_at=NULL "
+                        "WHERE id=? AND status='delivering'",
                         (notification_id,),
                     )
                     store._conn.commit()
@@ -447,14 +457,41 @@ def deliver_pending_stop(
                 pass
             return 0
         try:
-            if not worker._send_via_apprise(body, notify_type):
+            try:
+                delivered = worker._send_via_apprise(body, notify_type)
+            except Exception:
+                logger.exception(
+                    "Deferred stop notification delivery failed; "
+                    "notification_id=%s notify_type=%s",
+                    notification_id,
+                    notify_type,
+                )
+                delivered = False
+            if delivered:
+                try:
+                    with store._db_lock:
+                        store._conn.execute(
+                            "UPDATE notifications SET status='sent', sent_at=?, "
+                            "delivering_at=NULL "
+                            "WHERE id=? AND status='delivering'",
+                            (int(time.time()), notification_id),
+                        )
+                        store._conn.commit()
+                except sqlite3.Error:
+                    logger.exception(
+                        "Deferred stop notification sent but mark-sent failed; "
+                        "notification_id=%s",
+                        notification_id,
+                    )
+            else:
                 # Apprise rejected — revert claim to give the next
                 # daemon a chance to retry.
                 try:
                     with store._db_lock:
                         store._conn.execute(
                             "UPDATE notifications SET status='pending', "
-                            "sent_at=NULL WHERE id=?",
+                            "sent_at=NULL, delivering_at=NULL "
+                            "WHERE id=? AND status='delivering'",
                             (notification_id,),
                         )
                         store._conn.commit()

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -207,8 +207,13 @@ class UPSGroupMonitor(
 
     def _stop_stats(self):
         """Flush + close the stats store. Safe to call multiple times."""
-        if self._stats_writer is not None:
-            self._stats_writer = None  # daemon thread; stop_event was set
+        writer = self._stats_writer
+        self._stats_writer = None
+        if writer is not None and writer is not threading.current_thread():
+            try:
+                writer.join(timeout=2)
+            except RuntimeError:
+                pass
         try:
             self._stats_store.close()
         except Exception:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -889,7 +889,27 @@ class UPSGroupMonitor(
                 key, value = line.split(':', 1)
                 ups_data[key.strip()] = value.strip()
 
+        if not ups_data.get('ups.status'):
+            return False, {}, "Missing ups.status"
+
         return True, ups_data, ""
+
+    def _mark_shutdown_in_progress(self, context: str) -> bool:
+        """Best-effort persistent shutdown guard.
+
+        The flag prevents duplicate shutdown sequences. It is still just
+        bookkeeping: if the flag path is unavailable during a power event, the
+        daemon must keep moving toward the actual poweroff.
+        """
+        try:
+            self._shutdown_flag_path.touch()
+            return True
+        except OSError as exc:
+            self._log_message(
+                f"⚠️ Could not write shutdown flag {self._shutdown_flag_path} "
+                f"while {context}: {exc}. Continuing without the on-disk guard."
+            )
+            return False
 
     def _run_upsc(self, args: List[str], *, full_poll: bool) -> Tuple[int, str, str]:
         cmd = ["upsc", self.config.ups.name] + list(args)
@@ -1071,7 +1091,7 @@ class UPSGroupMonitor(
 
     def _execute_shutdown_sequence(self):
         """Execute the controlled shutdown sequence."""
-        self._shutdown_flag_path.touch()
+        self._mark_shutdown_in_progress("starting shutdown sequence")
         sequence_start = time.monotonic()
 
         delegated = self._uses_loopback_delegate
@@ -1338,7 +1358,7 @@ class UPSGroupMonitor(
             )
             return
 
-        self._shutdown_flag_path.touch()
+        self._mark_shutdown_in_progress("triggering immediate shutdown")
 
         # Send notification (non-blocking - fire and forget)
         self._send_notification(
@@ -1493,7 +1513,7 @@ class UPSGroupMonitor(
             self._stop_stats()
             sys.exit(0)
 
-        self._shutdown_flag_path.touch()
+        self._mark_shutdown_in_progress("recording service stop")
 
         self._log_message("🛑 Service stopped by signal (SIGTERM/SIGINT). Monitoring is inactive.")
 
@@ -1962,7 +1982,7 @@ class UPSGroupMonitor(
                         )
                     else:
                         self._failsafe_initiated = True
-                        self._shutdown_flag_path.touch()
+                        self._mark_shutdown_in_progress("starting failsafe shutdown")
                         self._log_message(
                             "🚨 FAILSAFE TRIGGERED (FSB): Connection lost or data persistently stale "
                             "while On Battery. Initiating emergency shutdown."

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -140,6 +140,8 @@ class UPSGroupMonitor(
         # Per-group state file paths (suffix for multi-UPS)
         sfx = f".{state_file_suffix}" if state_file_suffix else ""
         self._shutdown_flag_path = Path(config.logging.shutdown_flag_file + sfx)
+        self._shutdown_in_progress = False
+        self._shutdown_flag_unusable = False
         self._battery_history_path = Path(config.logging.battery_history_file + sfx)
         self._state_file_path = Path(config.logging.state_file + sfx)
         self._remote_health_path = remote_health_sidecar_path(self._state_file_path)
@@ -219,6 +221,36 @@ class UPSGroupMonitor(
         except Exception:
             pass
 
+    def _shutdown_guard_active(self) -> bool:
+        """Return whether a shutdown sequence is already admitted."""
+        if self._shutdown_in_progress:
+            return True
+        if self._shutdown_flag_unusable:
+            return False
+        try:
+            return self._shutdown_flag_path.exists()
+        except OSError as exc:
+            self._shutdown_flag_unusable = True
+            self._log_message(
+                f"⚠️ Could not inspect shutdown flag {self._shutdown_flag_path}: "
+                f"{exc}. Ignoring the on-disk guard for this process."
+            )
+            return False
+
+    def _clear_shutdown_in_progress(self) -> None:
+        """Clear both in-memory and on-disk duplicate-shutdown guards."""
+        try:
+            self._shutdown_flag_path.unlink(missing_ok=True)
+            self._shutdown_flag_unusable = False
+        except OSError as exc:
+            self._shutdown_flag_unusable = True
+            self._log_message(
+                f"⚠️ Could not clear shutdown flag {self._shutdown_flag_path}: "
+                f"{exc}. Ignoring the on-disk guard for this process."
+            )
+        finally:
+            self._shutdown_in_progress = False
+
     def _record_advisory_trigger(self, reason: str):
         """Record an advisory trigger for the redundancy-group evaluator.
 
@@ -294,7 +326,7 @@ class UPSGroupMonitor(
             except PermissionError:
                 pass
 
-        self._shutdown_flag_path.unlink(missing_ok=True)
+        self._clear_shutdown_in_progress()
 
         try:
             self._battery_history_path.write_text("")
@@ -745,7 +777,7 @@ class UPSGroupMonitor(
         # always lands; this only affects whether the operator gets
         # pinged by Apprise). The stats events row records which path
         # we took via notification_sent.
-        skipped_during_shutdown = self._shutdown_flag_path.exists()
+        skipped_during_shutdown = self._shutdown_guard_active()
         always_silent = event in ("VOLTAGE_NORMALIZED", "AVR_INACTIVE",
                                    "VOLTAGE_FLAP_SUPPRESSED",
                                    "VOLTAGE_AUTODETECT_MISMATCH")
@@ -906,10 +938,13 @@ class UPSGroupMonitor(
         bookkeeping: if the flag path is unavailable during a power event, the
         daemon must keep moving toward the actual poweroff.
         """
+        self._shutdown_in_progress = True
         try:
             self._shutdown_flag_path.touch()
+            self._shutdown_flag_unusable = False
             return True
         except OSError as exc:
+            self._shutdown_flag_unusable = True
             self._log_message(
                 f"⚠️ Could not write shutdown flag {self._shutdown_flag_path} "
                 f"while {context}: {exc}. Continuing without the on-disk guard."
@@ -1210,7 +1245,7 @@ class UPSGroupMonitor(
                 self._log_message("✅ SHUTDOWN SEQUENCE COMPLETE")
                 self._log_message(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
                 self._log_message("🧪 [DRY-RUN] Shutdown sequence completed successfully (no actual shutdown)")
-                self._shutdown_flag_path.unlink(missing_ok=True)
+                self._clear_shutdown_in_progress()
             else:
                 # Validate the poweroff command BEFORE recording the run as a
                 # completed shutdown (CodeRabbit). Config validation rejects an
@@ -1232,7 +1267,7 @@ class UPSGroupMonitor(
                         self.config.NOTIFY_FAILURE,
                         category="shutdown_summary",
                     )
-                    self._shutdown_flag_path.unlink(missing_ok=True)
+                    self._clear_shutdown_in_progress()
                     return
 
                 record_sequence_complete()
@@ -1304,7 +1339,7 @@ class UPSGroupMonitor(
                 # stays touched because the container is going down with
                 # the host; here the container stays up, so any subsequent
                 # trigger has to be allowed through.
-                self._shutdown_flag_path.unlink(missing_ok=True)
+                self._clear_shutdown_in_progress()
                 return
             record_sequence_complete()
             self._log_message(
@@ -1317,7 +1352,7 @@ class UPSGroupMonitor(
                     "🧪 [DRY-RUN] Would have delegated host poweroff to loopback "
                     "SSH (no actual shutdown performed)."
                 )
-                self._shutdown_flag_path.unlink(missing_ok=True)
+                self._clear_shutdown_in_progress()
             else:
                 self._send_notification(
                     f"✅ **Shutdown Sequence Complete** (took {elapsed}s)\n"
@@ -1342,7 +1377,7 @@ class UPSGroupMonitor(
                 self.config.NOTIFY_INFO,
                 category="shutdown_summary",
             )
-            self._shutdown_flag_path.unlink(missing_ok=True)
+            self._clear_shutdown_in_progress()
 
             # Exit if --exit-after-shutdown was specified
             if self._exit_after_shutdown:
@@ -1351,7 +1386,7 @@ class UPSGroupMonitor(
 
     def _trigger_immediate_shutdown(self, reason: str):
         """Trigger an immediate shutdown if not already in progress."""
-        if self._shutdown_flag_path.exists():
+        if self._shutdown_guard_active():
             # Surface gated re-triggers (bug #4). The early return used
             # to be silent, which made correlating "trigger conditions
             # met but nothing fired" with the stuck flag much harder
@@ -1509,7 +1544,7 @@ class UPSGroupMonitor(
         if self._api_server is not None:
             self._api_server.stop()
 
-        if self._shutdown_flag_path.exists():
+        if self._shutdown_guard_active():
             if self._notification_worker:
                 # Mid-shutdown signal: still try to drain any in-flight
                 # rows; whatever's left persists for the next start.
@@ -1624,7 +1659,7 @@ class UPSGroupMonitor(
                 stats_dir, version=__version__, reason=REASON_SIGNAL,
             )
 
-        self._shutdown_flag_path.unlink(missing_ok=True)
+        self._clear_shutdown_in_progress()
         sys.exit(0)
 
     # ==========================================================================
@@ -1800,7 +1835,7 @@ class UPSGroupMonitor(
             # outage's trigger silently no-ops. Clearing the flag here
             # means: "power came back, daemon is still alive ⇒ the
             # previous attempt did not actually halt the host ⇒ re-arm".
-            self._shutdown_flag_path.unlink(missing_ok=True)
+            self._clear_shutdown_in_progress()
             # Coordinator hook: in multi-UPS mode the per-monitor flag
             # above is suffixed; the coordinator owns a separate
             # unsuffixed flag + an in-memory _local_shutdown_initiated

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -87,6 +87,52 @@ class MultiUPSCoordinator:
             for name in rg.ups_sources
         }
 
+    def _clear_global_shutdown_flag(self, context: str) -> None:
+        """Best-effort cleanup for the coordinator's cross-process guard."""
+        try:
+            self._global_shutdown_flag.unlink(missing_ok=True)
+        except OSError as exc:
+            self._log(
+                f"⚠️ Could not clear global shutdown flag "
+                f"{self._global_shutdown_flag} during {context}: {exc}"
+            )
+
+    def _global_shutdown_guard_active(self) -> bool:
+        """Return whether the coordinator-level shutdown guard is active."""
+        try:
+            return self._global_shutdown_flag.exists()
+        except OSError as exc:
+            self._log(
+                f"⚠️ Could not inspect global shutdown flag "
+                f"{self._global_shutdown_flag}: {exc}"
+            )
+            return False
+
+    def _monitor_shutdown_guard_active(self, monitor: UPSGroupMonitor) -> bool:
+        """Return whether a child monitor has admitted a shutdown sequence."""
+        guard = getattr(type(monitor), "_shutdown_guard_active", None)
+        if callable(guard):
+            try:
+                return bool(guard(monitor))
+            except Exception as exc:
+                self._log(
+                    "  ⚠️ Could not inspect monitor shutdown guard via helper: "
+                    f"{exc}. Falling back to raw guard fields."
+                )
+
+        if bool(vars(monitor).get("_shutdown_in_progress", False)):
+            return True
+        flag_path = getattr(monitor, "_shutdown_flag_path", None)
+        if flag_path is None:
+            return False
+        try:
+            return bool(flag_path.exists())
+        except OSError as exc:
+            self._log(
+                f"  ⚠️ Could not inspect monitor shutdown flag {flag_path}: {exc}"
+            )
+            return False
+
     def run(self):
         """Start all UPS group monitors and wait for shutdown or signal."""
         try:
@@ -112,7 +158,7 @@ class MultiUPSCoordinator:
             except PermissionError:
                 pass
 
-        self._global_shutdown_flag.unlink(missing_ok=True)
+        self._clear_global_shutdown_flag("startup")
 
         # Initialize shared notification worker
         if self.config.notifications.enabled and APPRISE_AVAILABLE:
@@ -548,7 +594,7 @@ class MultiUPSCoordinator:
                 self._rearm_after_inflight = True
                 return
             self._local_shutdown_initiated = False
-            self._global_shutdown_flag.unlink(missing_ok=True)
+            self._clear_global_shutdown_flag("power recovery")
 
     def _handle_local_shutdown(self, triggered_by: str):
         """Execute local shutdown with defense-in-depth protection."""
@@ -590,7 +636,7 @@ class MultiUPSCoordinator:
                 self._log("🔌 Shutting down local server NOW")
                 if self.config.behavior.dry_run:
                     self._log(f"🧪 [DRY-RUN] Would execute: {self.config.local_shutdown.command}")
-                    self._global_shutdown_flag.unlink(missing_ok=True)
+                    self._clear_global_shutdown_flag("dry-run local shutdown")
                 else:
                     if self._notification_worker:
                         self._notification_worker.send(
@@ -642,7 +688,7 @@ class MultiUPSCoordinator:
                         # H2 failsafe re-fire).
             else:
                 self._log("✅ Local shutdown disabled. Group shutdown complete.")
-                self._global_shutdown_flag.unlink(missing_ok=True)
+                self._clear_global_shutdown_flag("disabled local shutdown")
 
             # Exit if --exit-after-shutdown was specified
             if self._exit_after_shutdown:
@@ -660,7 +706,7 @@ class MultiUPSCoordinator:
                 if self._rearm_after_inflight:
                     self._rearm_after_inflight = False
                     self._local_shutdown_initiated = False
-                    self._global_shutdown_flag.unlink(missing_ok=True)
+                    self._clear_global_shutdown_flag("deferred power recovery")
 
     def _drain_all_groups(self, timeout: int = 120):
         """Shut down all groups' resources, then stop monitor threads.
@@ -699,7 +745,8 @@ class MultiUPSCoordinator:
 
         # Phase 2: run each monitor's shutdown sequence sequentially.
         for monitor in self._monitors:
-            if not monitor._shutdown_flag_path.exists():
+            already_shutting_down = self._monitor_shutdown_guard_active(monitor)
+            if not already_shutting_down:
                 self._log(f"  ➡️ Triggering shutdown for {monitor._log_prefix.strip()}")
                 try:
                     monitor._execute_shutdown_sequence()
@@ -924,9 +971,12 @@ class MultiUPSCoordinator:
         # would kill that thread before the poweroff runs -- a missed shutdown.
         # When in flight, wait a generous, config-derived, bounded deadline so
         # the sequence can finish; otherwise keep the brisk 5 s exit.
+        with self._local_shutdown_lock:
+            local_shutdown_in_flight = self._local_shutdown_in_flight
         shutdown_in_flight = (
-            self._global_shutdown_flag.exists()
-            or any(m._shutdown_flag_path.exists() for m in self._monitors)
+            local_shutdown_in_flight
+            or self._global_shutdown_guard_active()
+            or any(self._monitor_shutdown_guard_active(m) for m in self._monitors)
         )
         if shutdown_in_flight:
             join_budget = self._shutdown_join_deadline()
@@ -1019,8 +1069,11 @@ class MultiUPSCoordinator:
                     store = getattr(monitor, "_stats_store", None)
                     if store is not None:
                         store.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                self._log(
+                    "⚠️ Failed to close monitor stats during coordinator "
+                    f"shutdown: {exc}"
+                )
 
         # Slice 3: tag this exit so the next start can emit "🔄 Restarted"
         # if it comes back within RESTART_DOWNTIME_THRESHOLD_SECS, else
@@ -1041,7 +1094,7 @@ class MultiUPSCoordinator:
                 reason=REASON_SIGNAL,
             )
 
-        self._global_shutdown_flag.unlink(missing_ok=True)
+        self._clear_global_shutdown_flag("signal shutdown")
         # 5.3.0 contract: clear redundancy executor flags too on
         # graceful exit so the next daemon instance starts from a
         # known-clean state. Defensive try-block: a flag-cleanup

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -1006,6 +1006,22 @@ class MultiUPSCoordinator:
                 except Exception:
                     pass
 
+        # Per-monitor threads normally close their own StatsStore in their
+        # cleanup path. Do it again here after notification drain/scheduling so a
+        # stuck monitor thread cannot leave SQLite handles open at coordinator
+        # exit.
+        for monitor in self._monitors:
+            try:
+                stop_stats = getattr(monitor, "_stop_stats", None)
+                if callable(stop_stats):
+                    stop_stats()
+                else:
+                    store = getattr(monitor, "_stats_store", None)
+                    if store is not None:
+                        store.close()
+            except Exception:
+                pass
+
         # Slice 3: tag this exit so the next start can emit "🔄 Restarted"
         # if it comes back within RESTART_DOWNTIME_THRESHOLD_SECS, else
         # "🚀 Started (last seen Nh ago)". Coordinator mode was missing

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -569,7 +569,14 @@ class MultiUPSCoordinator:
 
         try:
             # Defense layer 2: filesystem flag
-            self._global_shutdown_flag.touch()
+            try:
+                self._global_shutdown_flag.touch()
+            except OSError as exc:
+                self._log(
+                    f"⚠️ Could not write shutdown flag "
+                    f"{self._global_shutdown_flag}: {exc}. Continuing "
+                    "without the on-disk guard."
+                )
 
             self._log(f"🚨 Local shutdown triggered by {triggered_by}")
 

--- a/src/eneru/nut_control.py
+++ b/src/eneru/nut_control.py
@@ -9,12 +9,17 @@ Security model (enforced by the API layer, not here):
   (a config-validation invariant), so control is never reachable unauthenticated.
 - Command/variable names are allowlisted by the caller before reaching here.
 
-Credentials are passed on the argv (``-u``/``-p``), which is visible in ``ps`` —
-an accepted tradeoff (a local user who can read ``ps`` can already do worse), and
-identical to how operators run these CLIs by hand.
+Passwords are not passed on argv. ``upscmd``/``upsrw`` prompt for the password
+when ``-p`` is omitted, so authenticated calls run behind a pseudo-terminal and
+answer that prompt without exposing the reusable secret to ``ps``.
 """
 
+import os
+import pty
 import re
+import select
+import subprocess
+import time
 from typing import Dict, List, Optional, Tuple
 
 from eneru.utils import run_command
@@ -24,9 +29,91 @@ def _creds_args(username: str, password: str) -> List[str]:
     args: List[str] = []
     if username:
         args += ["-u", username]
-    if password:
-        args += ["-p", password]
     return args
+
+
+def _run_auth_command(
+    cmd: List[str],
+    password: str,
+    *,
+    timeout: int = 10,
+) -> Tuple[int, str, str]:
+    """Run a NUT auth command without putting the password in argv."""
+    if not password:
+        return run_command(cmd, timeout=timeout)
+
+    master_fd: Optional[int] = None
+    slave_fd: Optional[int] = None
+    proc: Optional[subprocess.Popen] = None
+    output = bytearray()
+    password_sent = False
+    deadline = time.monotonic() + max(1, int(timeout))
+
+    try:
+        master_fd, slave_fd = pty.openpty()
+        proc = subprocess.Popen(
+            cmd,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        slave_fd = None
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+                text = output.decode("utf-8", errors="replace")
+                return 124, text, "Command timed out"
+
+            readable, _, _ = select.select(
+                [master_fd], [], [], min(0.1, remaining)
+            )
+            if readable:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError:
+                    chunk = b""
+                if chunk:
+                    output.extend(chunk)
+                    if not password_sent and b"password" in output.lower():
+                        os.write(master_fd, (password + "\n").encode("utf-8"))
+                        password_sent = True
+
+            rc = proc.poll()
+            if rc is not None:
+                while True:
+                    try:
+                        chunk = os.read(master_fd, 4096)
+                    except OSError:
+                        break
+                    if not chunk:
+                        break
+                    output.extend(chunk)
+                text = output.decode("utf-8", errors="replace")
+                return rc, text, ""
+    except FileNotFoundError as exc:
+        return 127, "", str(exc)
+    except Exception as exc:
+        text = output.decode("utf-8", errors="replace")
+        return 1, text, str(exc)
+    finally:
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        for fd in (master_fd, slave_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
 
 def list_commands(ups_name: str, *, timeout: int = 10) -> Tuple[bool, List[str], str]:
@@ -62,12 +149,12 @@ def run_instant_command(
     ups_name: str, command: str, username: str, password: str,
     *, timeout: int = 10,
 ) -> Tuple[bool, str, str]:
-    """Run an instant command (``upscmd -u … -p … ups command``).
+    """Run an instant command (``upscmd -u … ups command``).
 
     Returns ``(ok, output, error)``.
     """
     cmd = ["upscmd"] + _creds_args(username, password) + [ups_name, command]
-    code, out, err = run_command(cmd, timeout=timeout)
+    code, out, err = _run_auth_command(cmd, password, timeout=timeout)
     if code != 0:
         return False, out.strip(), (err.strip() or f"upscmd exited {code}")
     return True, out.strip(), ""
@@ -117,7 +204,7 @@ def set_variable(
     ups_name: str, variable: str, value: str, username: str, password: str,
     *, timeout: int = 10,
 ) -> Tuple[bool, str, str]:
-    """Write a UPS variable (``upsrw -s var=value -u … -p … ups``).
+    """Write a UPS variable (``upsrw -s var=value -u … ups``).
 
     Returns ``(ok, output, error)``.
 
@@ -129,7 +216,7 @@ def set_variable(
     """
     cmd = (["upsrw", "-s", f"{variable}={value}"]
            + _creds_args(username, password) + [ups_name])
-    code, out, err = run_command(cmd, timeout=timeout)
+    code, out, err = _run_auth_command(cmd, password, timeout=timeout)
     if code != 0:
         return False, out.strip(), (err.strip() or f"upsrw exited {code}")
     return True, out.strip(), ""

--- a/src/eneru/nut_control.py
+++ b/src/eneru/nut_control.py
@@ -24,12 +24,163 @@ from typing import Dict, List, Optional, Tuple
 
 from eneru.utils import run_command
 
+_AUTH_COMMAND_BINARIES = {"upscmd", "upsrw"}
+_SAFE_AUTH_ARG = re.compile(r"\A[A-Za-z0-9 ._:@+%/,\-=\[\]]{1,256}\Z")
+_PASSWORD_PROMPT_RE = re.compile(
+    rb"password[^\r\n]{0,40}[:?]\s*\Z",
+    re.IGNORECASE,
+)
+
 
 def _creds_args(username: str, password: str) -> List[str]:
     args: List[str] = []
     if username:
         args += ["-u", username]
     return args
+
+
+def _safe_auth_data_arg(arg: object) -> Tuple[Optional[str], str]:
+    """Return one validated argv data value, or an error message."""
+    if not isinstance(arg, str) or not arg:
+        return None, "empty NUT control argument"
+    if "\x00" in arg:
+        return None, "NUT control argument contains NUL"
+    if arg.startswith("-"):
+        return None, "NUT control argument looks like an option"
+    if not _SAFE_AUTH_ARG.match(arg):
+        return None, "NUT control argument contains unsupported characters"
+    return arg, ""
+
+
+def _validated_auth_command_argv(cmd: List[str]) -> Tuple[Optional[List[str]], str]:
+    """Build a normalized NUT auth argv before it reaches ``subprocess``.
+
+    The API already allowlists command and variable names, but this wrapper is
+    the last gate before exec. Keeping the binary and option positions fixed
+    makes the invariant visible to readers and static analysis.
+    """
+    if (not cmd or not isinstance(cmd[0], str)
+            or cmd[0] not in _AUTH_COMMAND_BINARIES):
+        return None, "unsupported NUT control binary"
+
+    binary = cmd[0]
+    args = cmd[1:]
+    if binary == "upscmd":
+        if len(args) == 2:
+            ups_name, error = _safe_auth_data_arg(args[0])
+            if error:
+                return None, error
+            command, error = _safe_auth_data_arg(args[1])
+            if error:
+                return None, error
+            return ["upscmd", ups_name, command], ""
+        elif len(args) == 4 and args[0] == "-u":
+            username, error = _safe_auth_data_arg(args[1])
+            if error:
+                return None, error
+            ups_name, error = _safe_auth_data_arg(args[2])
+            if error:
+                return None, error
+            command, error = _safe_auth_data_arg(args[3])
+            if error:
+                return None, error
+            return ["upscmd", "-u", username, ups_name, command], ""
+        else:
+            return None, "invalid upscmd argument shape"
+    elif binary == "upsrw":
+        if len(args) == 3 and args[0] == "-s":
+            assignment, error = _safe_auth_data_arg(args[1])
+            if error:
+                return None, error
+            ups_name, error = _safe_auth_data_arg(args[2])
+            if error:
+                return None, error
+            return ["upsrw", "-s", assignment, ups_name], ""
+        elif len(args) == 5 and args[0] == "-s" and args[2] == "-u":
+            assignment, error = _safe_auth_data_arg(args[1])
+            if error:
+                return None, error
+            username, error = _safe_auth_data_arg(args[3])
+            if error:
+                return None, error
+            ups_name, error = _safe_auth_data_arg(args[4])
+            if error:
+                return None, error
+            return ["upsrw", "-s", assignment, "-u", username, ups_name], ""
+        else:
+            return None, "invalid upsrw argument shape"
+    return None, "unsupported NUT control binary"
+
+
+def _validate_auth_command_argv(cmd: List[str]) -> Tuple[bool, str]:
+    """Validate a NUT auth argv shape."""
+    safe_cmd, error = _validated_auth_command_argv(cmd)
+    return safe_cmd is not None, error
+
+
+def _auth_command_has_username(safe_cmd: List[str]) -> bool:
+    """Return True when a normalized command includes ``-u username``."""
+    if safe_cmd[0] == "upscmd":
+        return len(safe_cmd) == 5 and safe_cmd[1] == "-u"
+    if safe_cmd[0] == "upsrw":
+        return len(safe_cmd) == 6 and safe_cmd[3] == "-u"
+    return False
+
+
+def _popen_validated_auth_command(
+    safe_cmd: List[str],
+    slave_fd: int,
+) -> subprocess.Popen:
+    """Spawn a previously normalized NUT auth command on a PTY.
+
+    CodeQL treats a fully data-derived argv list as command-injection tainted,
+    even after validation. Keep the executable and option positions as fixed
+    literals at each spawn site; only validated data values are copied in.
+    """
+    if safe_cmd[0] == "upscmd":
+        if len(safe_cmd) == 3:
+            return subprocess.Popen(
+                ["upscmd", safe_cmd[1], safe_cmd[2]],
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                close_fds=True,
+            )
+        return subprocess.Popen(
+            ["upscmd", "-u", safe_cmd[2], safe_cmd[3], safe_cmd[4]],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+
+    if len(safe_cmd) == 4:
+        return subprocess.Popen(
+            ["upsrw", "-s", safe_cmd[2], safe_cmd[3]],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+    return subprocess.Popen(
+        ["upsrw", "-s", safe_cmd[2], "-u", safe_cmd[4], safe_cmd[5]],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+    )
+
+
+def _kill_and_reap(proc: subprocess.Popen) -> None:
+    """Best-effort terminate + wait so timed-out PTY children do not zombie."""
+    try:
+        proc.kill()
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=1)
+    except Exception:
+        pass
 
 
 def _run_auth_command(
@@ -39,8 +190,16 @@ def _run_auth_command(
     timeout: int = 10,
 ) -> Tuple[int, str, str]:
     """Run a NUT auth command without putting the password in argv."""
+    safe_cmd, error = _validated_auth_command_argv(cmd)
+    if safe_cmd is None:
+        return 2, "", error
+    has_username = _auth_command_has_username(safe_cmd)
+    if password and not has_username:
+        return 2, "", "NUT control password requires username (-u)"
+    if has_username and not password:
+        return 2, "", "NUT control username requires password (-p)"
     if not password:
-        return run_command(cmd, timeout=timeout)
+        return run_command(safe_cmd, timeout=timeout)
 
     master_fd: Optional[int] = None
     slave_fd: Optional[int] = None
@@ -51,23 +210,15 @@ def _run_auth_command(
 
     try:
         master_fd, slave_fd = pty.openpty()
-        proc = subprocess.Popen(
-            cmd,
-            stdin=slave_fd,
-            stdout=slave_fd,
-            stderr=slave_fd,
-            close_fds=True,
-        )
+        proc = _popen_validated_auth_command(safe_cmd, slave_fd)
         os.close(slave_fd)
         slave_fd = None
 
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                try:
-                    proc.kill()
-                except Exception:
-                    pass
+                _kill_and_reap(proc)
+                proc = None
                 text = output.decode("utf-8", errors="replace")
                 return 124, text, "Command timed out"
 
@@ -81,7 +232,9 @@ def _run_auth_command(
                     chunk = b""
                 if chunk:
                     output.extend(chunk)
-                    if not password_sent and b"password" in output.lower():
+                    prompt_tail = bytes(output[-256:])
+                    if (not password_sent
+                            and _PASSWORD_PROMPT_RE.search(prompt_tail)):
                         os.write(master_fd, (password + "\n").encode("utf-8"))
                         password_sent = True
 
@@ -104,10 +257,7 @@ def _run_auth_command(
         return 1, text, str(exc)
     finally:
         if proc is not None and proc.poll() is None:
-            try:
-                proc.kill()
-            except Exception:
-                pass
+            _kill_and_reap(proc)
         for fd in (master_fd, slave_fd):
             if fd is not None:
                 try:
@@ -156,7 +306,8 @@ def run_instant_command(
     cmd = ["upscmd"] + _creds_args(username, password) + [ups_name, command]
     code, out, err = _run_auth_command(cmd, password, timeout=timeout)
     if code != 0:
-        return False, out.strip(), (err.strip() or f"upscmd exited {code}")
+        return False, out.strip(), (err.strip() or out.strip()
+                                    or f"upscmd exited {code}")
     return True, out.strip(), ""
 
 
@@ -218,5 +369,6 @@ def set_variable(
            + _creds_args(username, password) + [ups_name])
     code, out, err = _run_auth_command(cmd, password, timeout=timeout)
     if code != 0:
-        return False, out.strip(), (err.strip() or f"upsrw exited {code}")
+        return False, out.strip(), (err.strip() or out.strip()
+                                    or f"upsrw exited {code}")
     return True, out.strip(), ""

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -394,11 +394,63 @@ class RedundancyGroupExecutor(
         try:
             delegating = self._uses_loopback_delegate
             if self._group.is_local and not delegating:
-                self._shutdown_vms()
-                self._shutdown_containers()
-                self._sync_filesystems()
-                self._unmount_filesystems()
-            self._shutdown_remote_servers()
+                local_phases = [
+                    ("VM shutdown", self._shutdown_vms),
+                    ("Container shutdown", self._shutdown_containers),
+                    ("Filesystem sync", self._sync_filesystems),
+                    ("Filesystem unmount", self._unmount_filesystems),
+                ]
+                for label, func in local_phases:
+                    try:
+                        func()
+                    except Exception as exc:
+                        self._log_message(
+                            f"  ❌ {label} failed: {exc}. Continuing shutdown."
+                        )
+
+            try:
+                remote_results = self._shutdown_remote_servers() or []
+            except Exception as exc:
+                self._log_message(
+                    f"❌ Remote shutdown phase failed: {exc}. Continuing shutdown."
+                )
+                remote_results = []
+
+            if self._group.is_local and delegating:
+                loopback_results = [
+                    result for result in remote_results
+                    if any(
+                        server.enabled
+                        and server.is_host_loopback is True
+                        and (server.name or server.host) == result.server
+                        and server.host == result.host
+                        for server in self.config.remote_servers
+                    )
+                ]
+                if not loopback_results or not all(
+                    result.success for result in loopback_results
+                ):
+                    details = "; ".join(
+                        result.error or "shutdown command was not sent"
+                        for result in loopback_results
+                        if not result.success
+                    ) or "loopback shutdown result missing"
+                    self._log_message(
+                        "❌ Delegated redundancy host poweroff failed; shutdown "
+                        f"sequence is incomplete: {details}"
+                    )
+                    self._send_notification(
+                        f"❌ **Redundancy Group Shutdown Incomplete:** "
+                        f"{self._group.name}\n"
+                        f"Host poweroff delegation failed: {details}",
+                        "failure",
+                        category="shutdown_summary",
+                    )
+                    self._shutdown_flag_path.unlink(missing_ok=True)
+                    with self._lock:
+                        self._shutdown_done = False
+                    return False
+
             self._log_message(
                 f"✅ REDUNDANCY GROUP SHUTDOWN COMPLETE: {self._group.name}"
             )

--- a/src/eneru/redundancy.py
+++ b/src/eneru/redundancy.py
@@ -20,7 +20,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from eneru.config import (
     Config,
@@ -32,7 +32,7 @@ from eneru.logger import UPSLogger
 from eneru.notifications import NotificationWorker
 from eneru.shutdown.containers import ContainerShutdownMixin
 from eneru.shutdown.filesystems import FilesystemShutdownMixin
-from eneru.shutdown.remote import RemoteShutdownMixin
+from eneru.shutdown.remote import RemoteShutdownMixin, RemoteShutdownResult
 from eneru.shutdown.vms import VMShutdownMixin
 from eneru.state import MonitorState
 
@@ -40,6 +40,22 @@ from eneru.state import MonitorState
 def _sanitize(name: str) -> str:
     """Sanitize a group name for filesystem flag-file names."""
     return (name or "unnamed").replace("@", "-").replace(":", "-").replace("/", "-")
+
+
+def effective_redundancy_health(group: Any, raw: UPSHealth) -> UPSHealth:
+    """Return how a member's raw health contributes to group quorum."""
+    if raw == UPSHealth.DEGRADED:
+        if getattr(group, "degraded_counts_as", "healthy") == "critical":
+            return UPSHealth.CRITICAL
+        return UPSHealth.HEALTHY
+    if raw == UPSHealth.UNKNOWN:
+        policy = getattr(group, "unknown_counts_as", "critical")
+        if policy == "healthy":
+            return UPSHealth.HEALTHY
+        if policy == "degraded":
+            return effective_redundancy_health(group, UPSHealth.DEGRADED)
+        return UPSHealth.CRITICAL
+    return raw
 
 
 class RedundancyGroupExecutor(
@@ -276,6 +292,30 @@ class RedundancyGroupExecutor(
                 os.close(fd)
             probe.unlink(missing_ok=True)
 
+    @staticmethod
+    def _loopback_poweroff_sent(result: RemoteShutdownResult) -> bool:
+        """True once the delegated host poweroff command was accepted."""
+        return bool(
+            result.completed
+            and result.shutdown_sent
+            and not result.timed_out
+        )
+
+    def _clear_failed_loopback_shutdown_state(self) -> None:
+        """Best-effort re-arm after delegated host poweroff did not happen."""
+        error: Optional[Exception] = None
+        with self._lock:
+            self._shutdown_done = False
+            try:
+                self._shutdown_flag_path.unlink(missing_ok=True)
+            except Exception as exc:
+                error = exc
+        if error is not None:
+            self._log_message(
+                "⚠️ Could not clear redundancy shutdown flag after failed "
+                f"loopback delegation: {error}"
+            )
+
     def clear_shutdown_state(self, *, refuse_active_peer: bool = False) -> None:
         """Reset the in-process and on-disk re-entry guards.
 
@@ -391,6 +431,7 @@ class RedundancyGroupExecutor(
         if self.config.behavior.dry_run:
             self._log_message("🧪 *** DRY-RUN MODE: No actual shutdown will occur ***")
 
+        phase_failed = False
         try:
             delegating = self._uses_loopback_delegate
             if self._group.is_local and not delegating:
@@ -404,6 +445,7 @@ class RedundancyGroupExecutor(
                     try:
                         func()
                     except Exception as exc:
+                        phase_failed = True
                         self._log_message(
                             f"  ❌ {label} failed: {exc}. Continuing shutdown."
                         )
@@ -411,10 +453,13 @@ class RedundancyGroupExecutor(
             try:
                 remote_results = self._shutdown_remote_servers() or []
             except Exception as exc:
+                phase_failed = True
                 self._log_message(
                     f"❌ Remote shutdown phase failed: {exc}. Continuing shutdown."
                 )
                 remote_results = []
+            if any(not result.success for result in remote_results):
+                phase_failed = True
 
             if self._group.is_local and delegating:
                 loopback_results = [
@@ -428,12 +473,13 @@ class RedundancyGroupExecutor(
                     )
                 ]
                 if not loopback_results or not all(
-                    result.success for result in loopback_results
+                    self._loopback_poweroff_sent(result)
+                    for result in loopback_results
                 ):
                     details = "; ".join(
                         result.error or "shutdown command was not sent"
                         for result in loopback_results
-                        if not result.success
+                        if not self._loopback_poweroff_sent(result)
                     ) or "loopback shutdown result missing"
                     self._log_message(
                         "❌ Delegated redundancy host poweroff failed; shutdown "
@@ -446,14 +492,18 @@ class RedundancyGroupExecutor(
                         "failure",
                         category="shutdown_summary",
                     )
-                    self._shutdown_flag_path.unlink(missing_ok=True)
-                    with self._lock:
-                        self._shutdown_done = False
+                    self._clear_failed_loopback_shutdown_state()
                     return False
 
-            self._log_message(
-                f"✅ REDUNDANCY GROUP SHUTDOWN COMPLETE: {self._group.name}"
-            )
+            if phase_failed:
+                self._log_message(
+                    "⚠️ REDUNDANCY GROUP SHUTDOWN FINISHED WITH ERRORS: "
+                    f"{self._group.name}"
+                )
+            else:
+                self._log_message(
+                    f"✅ REDUNDANCY GROUP SHUTDOWN COMPLETE: {self._group.name}"
+                )
             # is_local quorum-loss must also fire the local poweroff.
             # Without this, the executor stops local services and remote
             # peers but leaves the host running. Delegate to the
@@ -476,7 +526,13 @@ class RedundancyGroupExecutor(
         finally:
             # In dry-run we clear the flag so repeated test runs aren't pinned.
             if self.config.behavior.dry_run:
-                self._shutdown_flag_path.unlink(missing_ok=True)
+                try:
+                    self._shutdown_flag_path.unlink(missing_ok=True)
+                except Exception as exc:
+                    self._log_message(
+                        "⚠️ Could not clear redundancy shutdown flag after "
+                        f"dry-run: {exc}"
+                    )
                 with self._lock:
                     self._shutdown_done = False
 
@@ -572,6 +628,7 @@ class RedundancyGroupEvaluator(threading.Thread):
                 pass
         base_grace = max(grace_durations) if grace_durations else 0
         self._readiness_window = self._startup_grace + base_grace + 10
+        self._state_lock = threading.Lock()
         self._ever_reported = set()
         self._start_monotonic = time.monotonic()
         self._cold_start_logged = False
@@ -584,24 +641,33 @@ class RedundancyGroupEvaluator(threading.Thread):
             print(prefixed)
 
     def _map_degraded(self) -> UPSHealth:
-        if self._group.degraded_counts_as == "critical":
-            return UPSHealth.CRITICAL
-        return UPSHealth.HEALTHY
+        return effective_redundancy_health(self._group, UPSHealth.DEGRADED)
 
     def _map_unknown(self) -> UPSHealth:
-        policy = self._group.unknown_counts_as
-        if policy == "healthy":
-            return UPSHealth.HEALTHY
-        if policy == "degraded":
-            return self._map_degraded()
-        return UPSHealth.CRITICAL
+        return effective_redundancy_health(self._group, UPSHealth.UNKNOWN)
 
     def _effective_health(self, raw: UPSHealth) -> UPSHealth:
-        if raw == UPSHealth.UNKNOWN:
-            return self._map_unknown()
-        if raw == UPSHealth.DEGRADED:
-            return self._map_degraded()
-        return raw
+        return effective_redundancy_health(self._group, raw)
+
+    def _mark_reported(self, ups_name: str) -> None:
+        """Remember that a member published at least one real snapshot."""
+        with self._state_lock:
+            self._ever_reported.add(ups_name)
+
+    def cold_start_pending_members(self) -> List[str]:
+        """Return member names still covered by cold-start protection."""
+        with self._state_lock:
+            reported = set(self._ever_reported)
+        return [
+            name for name in self._group.ups_sources
+            if self._monitors.get(name) is not None and name not in reported
+        ]
+
+    def cold_start_hold_active(self) -> bool:
+        """Return True while evaluator quorum-loss firing is startup-held."""
+        return bool(self.cold_start_pending_members()) and (
+            (time.monotonic() - self._start_monotonic) < self._readiness_window
+        )
 
     def evaluate_once(self):
         """Single evaluation pass -- exposed so tests can drive it directly."""
@@ -620,7 +686,7 @@ class RedundancyGroupEvaluator(threading.Thread):
                 # goes stale/FAILED it counts per policy. Only never-reported
                 # members are held back below.
                 if getattr(snap, "last_update_time", 0):
-                    self._ever_reported.add(ups_name)
+                    self._mark_reported(ups_name)
                 check_interval = monitor.config.ups.check_interval
                 max_stale_data_tolerance = (
                     monitor.config.ups.max_stale_data_tolerance
@@ -652,14 +718,8 @@ class RedundancyGroupEvaluator(threading.Thread):
         # triggers protection per policy. A member with NO monitor in the map is
         # a permanent (config/wiring) condition, not a boot delay, so it counts
         # as UNKNOWN immediately and is excluded from the hold.
-        never_reported = [
-            n for n in self._group.ups_sources
-            if self._monitors.get(n) is not None and n not in self._ever_reported
-        ]
-        within_readiness = (
-            (time.monotonic() - self._start_monotonic) < self._readiness_window
-        )
-        cold_start_hold = bool(never_reported) and within_readiness
+        never_reported = self.cold_start_pending_members()
+        cold_start_hold = self.cold_start_hold_active()
         if cold_start_hold and raw_quorum_lost and not self._cold_start_logged:
             self._cold_start_logged = True
             self._log(

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -45,7 +45,13 @@ SAMPLE_FIELDS: Tuple[str, ...] = (
 # Bump and add a migration block in StatsStore._init_schema whenever the
 # samples / agg_5min / agg_hourly / events / meta / notifications schema
 # gains a column or table. See src/eneru/AGENTS.md "Stats schema evolution".
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
+
+# If the daemon or one-shot deferred-delivery helper dies after claiming a
+# notification but before marking it sent/pending, the next daemon open moves
+# the in-flight claim back to pending so it can be retried instead of looking
+# delivered forever.
+DELIVERING_RECOVERY_GRACE_SECONDS = 5 * 60
 
 # Bucket sizes for aggregation tiers.
 BUCKET_5MIN = 5 * 60
@@ -177,12 +183,15 @@ class StatsStore:
 
     # ----- lifecycle -----
 
-    def open(self) -> None:
+    def open(self, *, recover_delivering: bool = True) -> None:
         """Open the SQLite connection and ensure the schema exists.
 
         Creates the parent directory if missing. Pragmas: WAL mode for
         concurrent reads, NORMAL synchronous mode (safe with WAL),
-        foreign_keys off (we have none).
+        foreign_keys off (we have none). Daemon startup should keep
+        ``recover_delivering`` at the default so rows claimed by a crashed
+        process are retried; one-shot helpers that already own a live claim can
+        disable it so their own verification reads do not reset the claim.
         """
         # Defensive: pip installs don't run nfpm's directory entry, so
         # the daemon must be willing to create /var/lib/eneru itself.
@@ -212,6 +221,8 @@ class StatsStore:
             conn.execute("PRAGMA busy_timeout = 500")
             self._conn = conn
             self._init_schema()
+            if recover_delivering:
+                self._recover_delivering_notifications()
         except Exception:
             self._conn = None
             try:
@@ -341,6 +352,7 @@ class StatsStore:
                     status TEXT NOT NULL DEFAULT 'pending',
                     attempts INTEGER NOT NULL DEFAULT 0,
                     sent_at INTEGER,
+                    delivering_at INTEGER,
                     cancel_reason TEXT
                 );
                 CREATE INDEX IF NOT EXISTS idx_notifications_status_ts
@@ -427,6 +439,7 @@ class StatsStore:
                     status TEXT NOT NULL DEFAULT 'pending',
                     attempts INTEGER NOT NULL DEFAULT 0,
                     sent_at INTEGER,
+                    delivering_at INTEGER,
                     cancel_reason TEXT
                 );
                 CREATE INDEX IF NOT EXISTS idx_notifications_status_ts
@@ -441,6 +454,12 @@ class StatsStore:
             # event's id is never handed to a later row -- that's what makes the
             # API's delete-by-id safe.
             self._migrate_events_to_v5()
+
+        if current < 6:
+            # v5 -> v6: timestamp claimed deferred-delivery rows. Startup
+            # recovery only steals stale claims, so a live one-shot helper that
+            # is actively sending a stop notification is not duplicated.
+            self._safe_alter("notifications", "delivering_at INTEGER")
 
     def _migrate_events_to_v5(self) -> None:
         """Rebuild ``events`` with a stable id column.
@@ -516,6 +535,25 @@ class StatsStore:
             for row in self._conn.execute("PRAGMA table_info(events)")
         )
 
+    def _recover_delivering_notifications(self) -> None:
+        """Move abandoned deferred-delivery claims back to pending."""
+        if self._conn is None:
+            return
+        cutoff = int(time.time()) - DELIVERING_RECOVERY_GRACE_SECONDS
+        try:
+            with self._conn:
+                self._conn.execute(
+                    "UPDATE notifications SET status='pending', sent_at=NULL, "
+                    "delivering_at=NULL WHERE status='delivering' "
+                    "AND (delivering_at IS NULL OR delivering_at <= ?)",
+                    (cutoff,),
+                )
+        except (sqlite3.Error, OSError) as e:
+            self._log_error_once(
+                f"stats: recover notification deliveries failed: {e}"
+            )
+            raise
+
     def _safe_alter(self, table: str, column_def: str) -> None:
         """Idempotent ``ALTER TABLE ... ADD COLUMN``; ignores duplicates."""
         try:
@@ -561,8 +599,9 @@ class StatsStore:
         with self._buffer_lock:
             if not self._buffer:
                 return 0
-            batch: List[Tuple] = list(self._buffer)
-            self._buffer.clear()
+            in_flight = self._buffer
+            self._buffer = deque(maxlen=in_flight.maxlen)
+            batch: List[Tuple] = list(in_flight)
         try:
             with self._db_lock:
                 conn = self._conn
@@ -578,8 +617,11 @@ class StatsStore:
             return len(batch)
         except (sqlite3.Error, OSError) as e:
             with self._buffer_lock:
-                for sample in reversed(batch):
-                    self._buffer.appendleft(sample)
+                maxlen = self._buffer.maxlen
+                merged = list(in_flight) + list(self._buffer)
+                if maxlen is not None and len(merged) > maxlen:
+                    merged = merged[-maxlen:]
+                self._buffer = deque(merged, maxlen=maxlen)
             self._log_error_once(f"stats: flush failed: {e}")
             return 0
 
@@ -932,7 +974,8 @@ class StatsStore:
         try:
             with self._db_lock, self._conn:
                 self._conn.execute(
-                    "UPDATE notifications SET status='sent', sent_at=? "
+                    "UPDATE notifications SET status='sent', sent_at=?, "
+                    "delivering_at=NULL "
                     "WHERE id=?",
                     (sent_at, int(notification_id)),
                 )
@@ -969,7 +1012,7 @@ class StatsStore:
             with self._db_lock, self._conn:
                 self._conn.execute(
                     "UPDATE notifications SET status='cancelled', "
-                    "cancel_reason=? WHERE id=?",
+                    "sent_at=NULL, delivering_at=NULL, cancel_reason=? WHERE id=?",
                     (str(reason), int(notification_id)),
                 )
         except (sqlite3.Error, OSError) as e:
@@ -1208,11 +1251,24 @@ class StatsStore:
         # filesystems, illegal in a SQLite URI without escaping) doesn't
         # truncate the path or get parsed as the URI's query / fragment.
         uri = f"file:{urlquote(str(path))}?mode=ro"
-        conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
-        # Same bound as the writer connection: a slow query against the
-        # writer's WAL can't stall the TUI refresh for more than 500 ms.
-        conn.execute("PRAGMA busy_timeout = 500")
-        return conn
+        conn = None
+        try:
+            conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+            # Same bound as the writer connection: a slow query against the
+            # writer's WAL can't stall the TUI refresh for more than 500 ms.
+            conn.execute("PRAGMA busy_timeout = 500")
+            # sqlite3.connect() can return a handle for a corrupt file; force a
+            # schema read now so callers receive None instead of a later
+            # DatabaseError from their first real query.
+            conn.execute("SELECT name FROM sqlite_master LIMIT 1").fetchone()
+            return conn
+        except (sqlite3.Error, OSError):
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            return None
 
     @classmethod
     def from_connection(cls, conn: sqlite3.Connection) -> "StatsStore":

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -197,19 +197,28 @@ class StatsStore:
         # the connection runs in autocommit mode and the `with` blocks
         # become no-ops, so executemany() would have committed every
         # row individually instead of batching the flush.
-        self._conn = sqlite3.connect(
+        conn = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
         )
-        self._conn.execute("PRAGMA journal_mode = WAL")
-        self._conn.execute("PRAGMA synchronous = NORMAL")
-        self._conn.execute("PRAGMA temp_store = MEMORY")
-        # Bound the writer's wait if a slow reader (TUI) is mid-query
-        # on slow storage (SD card on a Raspberry Pi). 500 ms is well
-        # under the 10 s flush interval, so a stalled reader can never
-        # hold up the writer thread for longer than that bound.
-        self._conn.execute("PRAGMA busy_timeout = 500")
-        self._init_schema()
+        try:
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA synchronous = NORMAL")
+            conn.execute("PRAGMA temp_store = MEMORY")
+            # Bound the writer's wait if a slow reader (TUI) is mid-query
+            # on slow storage (SD card on a Raspberry Pi). 500 ms is well
+            # under the 10 s flush interval, so a stalled reader can never
+            # hold up the writer thread for longer than that bound.
+            conn.execute("PRAGMA busy_timeout = 500")
+            self._conn = conn
+            self._init_schema()
+        except Exception:
+            self._conn = None
+            try:
+                conn.close()
+            except Exception:
+                pass
+            raise
 
     def apply_reload(self, stats_config) -> bool:
         """Live-apply retention changes from a reloaded config.
@@ -233,16 +242,19 @@ class StatsStore:
         return self._conn is not None
 
     def close(self) -> None:
-        if self._conn is not None:
-            try:
-                self.flush()
-            except Exception:  # pragma: no cover -- defensive
-                pass
-            try:
-                self._conn.close()
-            except Exception:  # pragma: no cover -- defensive
-                pass
+        try:
+            self.flush()
+        except Exception:  # pragma: no cover -- defensive
+            pass
+        with self._db_lock:
+            conn = self._conn
             self._conn = None
+            if conn is None:
+                return
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover -- defensive
+                pass
 
     # ----- schema -----
 
@@ -508,9 +520,11 @@ class StatsStore:
         """Idempotent ``ALTER TABLE ... ADD COLUMN``; ignores duplicates."""
         try:
             self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column_def}")
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
             # Column already exists -- benign on retries / partial migrations.
-            pass
+            if "duplicate column name" in str(exc).lower():
+                return
+            raise
 
     # ----- hot path: zero-I/O sample buffering -----
 
@@ -550,15 +564,22 @@ class StatsStore:
             batch: List[Tuple] = list(self._buffer)
             self._buffer.clear()
         try:
-            with self._db_lock, self._conn:
+            with self._db_lock:
+                conn = self._conn
+                if conn is None:
+                    raise sqlite3.Error("connection closed")
                 placeholders = ", ".join("?" for _ in SAMPLE_FIELDS)
-                self._conn.executemany(
-                    f"INSERT INTO samples ({', '.join(SAMPLE_FIELDS)}) "
-                    f"VALUES ({placeholders})",
-                    batch,
-                )
+                with conn:
+                    conn.executemany(
+                        f"INSERT INTO samples ({', '.join(SAMPLE_FIELDS)}) "
+                        f"VALUES ({placeholders})",
+                        batch,
+                    )
             return len(batch)
         except (sqlite3.Error, OSError) as e:
+            with self._buffer_lock:
+                for sample in reversed(batch):
+                    self._buffer.appendleft(sample)
             self._log_error_once(f"stats: flush failed: {e}")
             return 0
 

--- a/src/eneru/status.py
+++ b/src/eneru/status.py
@@ -14,6 +14,7 @@ from eneru.remote_health import (
     read_remote_health_sidecar,
     remote_health_sidecar_path,
 )
+from eneru.redundancy import effective_redundancy_health
 from eneru.stats import StatsStore
 from eneru.utils import command_exists
 
@@ -161,40 +162,46 @@ def collect_status(source: Any) -> Dict[str, Any]:
     return payload
 
 
-def _map_redundancy_degraded(group: Any) -> UPSHealth:
-    """Map DEGRADED through the group's quorum policy."""
-    if getattr(group, "degraded_counts_as", "healthy") == "critical":
-        return UPSHealth.CRITICAL
-    return UPSHealth.HEALTHY
+def _redundancy_evaluators_by_group(source: Any) -> Dict[str, Any]:
+    """Return live redundancy evaluators keyed by group name."""
+    out: Dict[str, Any] = {}
+    for evaluator in getattr(source, "_evaluator_threads", []) or []:
+        group = getattr(evaluator, "_group", None)
+        name = getattr(group, "name", None)
+        if name:
+            out[str(name)] = evaluator
+    return out
 
 
-def _effective_redundancy_health(group: Any, raw: UPSHealth) -> UPSHealth:
-    """Return how a raw UPS health tier contributes to group quorum."""
-    if raw == UPSHealth.DEGRADED:
-        return _map_redundancy_degraded(group)
-    if raw == UPSHealth.UNKNOWN:
-        policy = getattr(group, "unknown_counts_as", "critical")
-        if policy == "healthy":
-            return UPSHealth.HEALTHY
-        if policy == "degraded":
-            return _map_redundancy_degraded(group)
-        return UPSHealth.CRITICAL
-    return raw
+def _redundancy_cold_start_hold(evaluator: Any) -> bool:
+    """Mirror the evaluator's startup hold when a live evaluator is present."""
+    if evaluator is None:
+        return False
+    checker = getattr(evaluator, "cold_start_hold_active", None)
+    if not callable(checker):
+        return False
+    try:
+        return bool(checker())
+    except Exception:
+        return False
 
 
 def _redundancy_member_health(monitor: Any, group: Any) -> UPSHealth:
     """Assess one redundancy member using the same inputs as the evaluator."""
-    snap = monitor.state.snapshot()
-    ups_cfg = monitor.config.ups
-    grace_cfg = ups_cfg.connection_loss_grace_period
-    return assess_health(
-        snap,
-        group.triggers,
-        ups_cfg.check_interval,
-        max_stale_data_tolerance=ups_cfg.max_stale_data_tolerance,
-        connection_grace_enabled=grace_cfg.enabled,
-        connection_grace_duration=grace_cfg.duration,
-    )
+    try:
+        snap = monitor.state.snapshot()
+        ups_cfg = monitor.config.ups
+        grace_cfg = ups_cfg.connection_loss_grace_period
+        return assess_health(
+            snap,
+            group.triggers,
+            ups_cfg.check_interval,
+            max_stale_data_tolerance=ups_cfg.max_stale_data_tolerance,
+            connection_grace_enabled=grace_cfg.enabled,
+            connection_grace_duration=grace_cfg.duration,
+        )
+    except Exception:
+        return UPSHealth.UNKNOWN
 
 
 def redundancy_group_statuses(source: Any, config: Optional[Config]) -> List[dict]:
@@ -210,6 +217,7 @@ def redundancy_group_statuses(source: Any, config: Optional[Config]) -> List[dic
         getattr(manager, "group_label", ""): manager
         for manager in getattr(source, "_redundancy_remote_health_managers", []) or []
     }
+    evaluators = _redundancy_evaluators_by_group(source)
     for group in config.redundancy_groups:
         members = []
         healthy_count = 0
@@ -219,7 +227,7 @@ def redundancy_group_statuses(source: Any, config: Optional[Config]) -> List[dic
                 _redundancy_member_health(monitor, group)
                 if monitor is not None else UPSHealth.UNKNOWN
             )
-            effective = _effective_redundancy_health(group, raw)
+            effective = effective_redundancy_health(group, raw)
             if effective == UPSHealth.HEALTHY:
                 healthy_count += 1
             members.append({
@@ -236,13 +244,19 @@ def redundancy_group_statuses(source: Any, config: Optional[Config]) -> List[dic
                 remote_health_sidecar_path(redundancy_state_file_path(config, group.name))
             )
         )
+        raw_quorum_lost = healthy_count < group.min_healthy
+        cold_start_hold = (
+            raw_quorum_lost
+            and _redundancy_cold_start_hold(evaluators.get(group.name))
+        )
         rows.append({
             "groupId": f"redundancy-{sanitize_name(group.name)}",
             "name": group.name,
             "upsSources": list(group.ups_sources),
             "minHealthy": group.min_healthy,
             "healthyCount": healthy_count,
-            "quorumLost": healthy_count < group.min_healthy,
+            "quorumLost": raw_quorum_lost and not cold_start_hold,
+            "quorumDeferred": cold_start_hold,
             "members": members,
             "isLocal": group.is_local,
             "remoteHealth": remote_health,
@@ -479,10 +493,15 @@ def readiness(source: Any) -> Dict[str, Any]:
             nut_failed_any = True
         else:
             nut_visible_any = True
-    if not rows or config is None:
+    if not rows:
         return {
             "ready": False, "reason": "no monitors", "reasons": ["no monitors"],
             "ups": [], "capabilities": [],
+        }
+    if config is None:
+        return {
+            "ready": False, "reason": "no config", "reasons": ["no config"],
+            "ups": rows, "capabilities": [],
         }
 
     # Build merged remote-health snapshot for capability scoring.

--- a/src/eneru/status.py
+++ b/src/eneru/status.py
@@ -401,16 +401,16 @@ def readiness(source: Any) -> Dict[str, Any]:
     unachievable — see _capability_achievable() for the per-runtime rules.
     """
     rows = []
-    config = None
+    config = getattr(source, "config", None)
     nut_failed_any = False
     nut_visible_any = False
     for monitor in iter_monitors(source):
-        config = monitor.config
+        monitor_config = monitor.config
         snap = monitor.state.snapshot()
         row = {
-            "groupId": sanitize_name(config.ups.name),
-            "name": config.ups.name,
-            "label": config.ups.label,
+            "groupId": sanitize_name(monitor_config.ups.name),
+            "name": monitor_config.ups.name,
+            "label": monitor_config.ups.label,
             "connectionState": snap.connection_state,
             "lastUpdateTime": snap.last_update_time,
         }

--- a/src/eneru/status.py
+++ b/src/eneru/status.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from eneru.config import Config, UPSGroupConfig
+from eneru.health_model import UPSHealth, assess_health
 from eneru.remote_health import (
     REMOTE_HEALTH_DISABLED,
     REMOTE_HEALTH_HEALTHY,
@@ -160,16 +161,72 @@ def collect_status(source: Any) -> Dict[str, Any]:
     return payload
 
 
+def _map_redundancy_degraded(group: Any) -> UPSHealth:
+    """Map DEGRADED through the group's quorum policy."""
+    if getattr(group, "degraded_counts_as", "healthy") == "critical":
+        return UPSHealth.CRITICAL
+    return UPSHealth.HEALTHY
+
+
+def _effective_redundancy_health(group: Any, raw: UPSHealth) -> UPSHealth:
+    """Return how a raw UPS health tier contributes to group quorum."""
+    if raw == UPSHealth.DEGRADED:
+        return _map_redundancy_degraded(group)
+    if raw == UPSHealth.UNKNOWN:
+        policy = getattr(group, "unknown_counts_as", "critical")
+        if policy == "healthy":
+            return UPSHealth.HEALTHY
+        if policy == "degraded":
+            return _map_redundancy_degraded(group)
+        return UPSHealth.CRITICAL
+    return raw
+
+
+def _redundancy_member_health(monitor: Any, group: Any) -> UPSHealth:
+    """Assess one redundancy member using the same inputs as the evaluator."""
+    snap = monitor.state.snapshot()
+    ups_cfg = monitor.config.ups
+    grace_cfg = ups_cfg.connection_loss_grace_period
+    return assess_health(
+        snap,
+        group.triggers,
+        ups_cfg.check_interval,
+        max_stale_data_tolerance=ups_cfg.max_stale_data_tolerance,
+        connection_grace_enabled=grace_cfg.enabled,
+        connection_grace_duration=grace_cfg.duration,
+    )
+
+
 def redundancy_group_statuses(source: Any, config: Optional[Config]) -> List[dict]:
     """Return status rows for redundancy groups configured on a coordinator."""
     if config is None:
         return []
     rows = []
+    monitors_by_name = {
+        monitor.config.ups.name: monitor
+        for monitor in iter_monitors(source)
+    }
     live_managers = {
         getattr(manager, "group_label", ""): manager
         for manager in getattr(source, "_redundancy_remote_health_managers", []) or []
     }
     for group in config.redundancy_groups:
+        members = []
+        healthy_count = 0
+        for ups_name in group.ups_sources:
+            monitor = monitors_by_name.get(ups_name)
+            raw = (
+                _redundancy_member_health(monitor, group)
+                if monitor is not None else UPSHealth.UNKNOWN
+            )
+            effective = _effective_redundancy_health(group, raw)
+            if effective == UPSHealth.HEALTHY:
+                healthy_count += 1
+            members.append({
+                "name": ups_name,
+                "health": raw.value,
+                "effectiveHealth": effective.value,
+            })
         label = f"redundancy:{group.name}"
         manager = live_managers.get(label)
         remote_health = (
@@ -184,6 +241,9 @@ def redundancy_group_statuses(source: Any, config: Optional[Config]) -> List[dic
             "name": group.name,
             "upsSources": list(group.ups_sources),
             "minHealthy": group.min_healthy,
+            "healthyCount": healthy_count,
+            "quorumLost": healthy_count < group.min_healthy,
+            "members": members,
             "isLocal": group.is_local,
             "remoteHealth": remote_health,
         })

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.0.0-rc10"
+__version__ = "6.0.0-rc11"

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -97,7 +97,8 @@ function statusClass(status) {
 // A UPS counts as healthy for a redundancy rollup when it is reachable and not
 // on battery / low / replace-battery.
 function upsHealthy(u) {
-  if (u.connectionState && u.connectionState !== "connected") return false;
+  const state = (u.connectionState || "").toUpperCase();
+  if (state && state !== "OK" && state !== "CONNECTED") return false;
   const s = (u.status || "").toUpperCase();
   return !(s.includes("OB") || s.includes("LB") || s.includes("RB")
            || s.includes("FSD") || s === "");
@@ -156,9 +157,12 @@ function renderUps(payload) {
   rows.forEach((u) => { byName[u.name] = u; });
   groups.forEach((g) => {
     const sources = g.upsSources || [];
-    const healthy = sources.filter((n) => byName[n] && upsHealthy(byName[n])).length;
+    const healthy = (typeof g.healthyCount === "number")
+      ? g.healthyCount
+      : sources.filter((n) => byName[n] && upsHealthy(byName[n])).length;
     const min = g.minHealthy;
-    const cls = healthy < min ? "crit" : (healthy === min ? "warn" : "ok");
+    const quorumLost = (g.quorumLost === true) || healthy < min;
+    const cls = quorumLost ? "crit" : (healthy === min ? "warn" : "ok");
     gwrap.appendChild(el("div", { class: "card" }, [
       el("h3", { text: g.name }),
       el("div", { class: "row" }, [el("span", { text: "Healthy" }),
@@ -288,7 +292,10 @@ function renderBanner() {
   for (const u of rows) {
     const s = (u.status || "").toUpperCase();
     if (s.includes("LB") || s.includes("FSD") || u.triggerActive) {
-      crit = u; break;
+      const groups = lastGroups.filter((g) => (g.upsSources || []).includes(u.name));
+      const causesShutdown = groups.length === 0 || groups.some((g) => g.quorumLost === true);
+      if (causesShutdown) { crit = u; break; }
+      if (!warn) warn = u;
     }
     if (s.includes("OB") && !warn) warn = u;
   }
@@ -718,12 +725,11 @@ function refreshAuthUI() {
   if (authed) who.textContent = "Signed in";
 }
 
-// Learn whether auth is enabled server-side. /api/v1/config is open (sanitized)
-// and reports api.auth.enabled even to anonymous callers.
+// Learn whether auth is enabled server-side. This route stays open even when
+// read endpoints require credentials, so the login form remains reachable.
 async function loadAuthState() {
-  const res = await api("/api/v1/config");
-  authEnabled = !!(res.ok && res.data && res.data.api &&
-                   res.data.api.auth && res.data.api.auth.enabled);
+  const res = await api("/api/v1/auth/state");
+  authEnabled = !!(res.ok && res.data && res.data.enabled);
 }
 
 function openLogin() {

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -104,6 +104,19 @@ function upsHealthy(u) {
            || s.includes("FSD") || s === "");
 }
 
+function groupHealthyCount(g, rows) {
+  if (typeof g.healthyCount === "number") return g.healthyCount;
+  const byName = {};
+  rows.forEach((u) => { byName[u.name] = u; });
+  return (g.upsSources || []).filter((n) => byName[n] && upsHealthy(byName[n])).length;
+}
+
+function groupQuorumLost(g, rows) {
+  if (typeof g.quorumLost === "boolean") return g.quorumLost;
+  if (typeof g.minHealthy !== "number") return false;
+  return groupHealthyCount(g, rows) < g.minHealthy;
+}
+
 function batteryClass(charge) {
   if (isNaN(charge)) return "";
   if (charge < 20) return "crit";
@@ -121,6 +134,7 @@ function renderUps(payload) {
   sel.replaceChildren();
   rows.forEach((u) => {
     const charge = parseFloat(u.batteryCharge);
+    const barValue = isNaN(charge) ? 0 : Math.max(0, Math.min(100, charge));
     const card = el("div", { class: "card card-click", tabindex: "0",
       role: "button", title: "View details" }, [
       el("h3", { text: u.label || u.name }),
@@ -130,14 +144,16 @@ function renderUps(payload) {
       ]),
       el("div", { class: "row" }, [el("span", { text: "Battery" }),
         el("b", { class: batteryClass(charge), text: isNaN(charge) ? "—" : charge + "%" })]),
-      el("div", { class: "bar" }, [el("span", { class: batteryClass(charge) }, [])]),
+      el("meter", {
+        class: "bar " + batteryClass(charge),
+        min: "0", max: "100", value: String(barValue),
+        "aria-label": "Battery charge",
+      }),
       el("div", { class: "row" }, [el("span", { text: "Runtime" }),
         el("b", { text: u.runtime != null ? u.runtime + "s" : "—" })]),
       el("div", { class: "row" }, [el("span", { text: "Load" }),
         el("b", { text: u.load != null ? u.load + "%" : "—" })]),
     ]);
-    if (!isNaN(charge)) card.querySelector(".bar > span").style.width =
-      Math.max(0, Math.min(100, charge)) + "%";
     card.addEventListener("click", () => openDetail(u.name));
     card.addEventListener("keydown", (ev) => {
       if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); openDetail(u.name); }
@@ -153,15 +169,11 @@ function renderUps(payload) {
   const gwrap = document.getElementById("group-cards");
   gwrap.replaceChildren();
   gsec.hidden = groups.length === 0;
-  const byName = {};
-  rows.forEach((u) => { byName[u.name] = u; });
   groups.forEach((g) => {
     const sources = g.upsSources || [];
-    const healthy = (typeof g.healthyCount === "number")
-      ? g.healthyCount
-      : sources.filter((n) => byName[n] && upsHealthy(byName[n])).length;
+    const healthy = groupHealthyCount(g, rows);
     const min = g.minHealthy;
-    const quorumLost = (g.quorumLost === true) || healthy < min;
+    const quorumLost = groupQuorumLost(g, rows);
     const cls = quorumLost ? "crit" : (healthy === min ? "warn" : "ok");
     gwrap.appendChild(el("div", { class: "card" }, [
       el("h3", { text: g.name }),
@@ -293,7 +305,8 @@ function renderBanner() {
     const s = (u.status || "").toUpperCase();
     if (s.includes("LB") || s.includes("FSD") || u.triggerActive) {
       const groups = lastGroups.filter((g) => (g.upsSources || []).includes(u.name));
-      const causesShutdown = groups.length === 0 || groups.some((g) => g.quorumLost === true);
+      const causesShutdown = groups.length === 0
+        || groups.some((g) => groupQuorumLost(g, rows));
       if (causesShutdown) { crit = u; break; }
       if (!warn) warn = u;
     }
@@ -331,7 +344,13 @@ function mergeEvents(incoming) {
   for (const e of lastEvents) map.set(eventKey(e), e);
   for (const e of (incoming || [])) map.set(eventKey(e), e);
   lastEvents = Array.from(map.values())
-    .sort((a, b) => (a.ts - b.ts) || ((a.id || 0) - (b.id || 0)));
+    .sort((a, b) => {
+      const as = String(a.source || "");
+      const bs = String(b.source || "");
+      return (a.ts - b.ts) ||
+        (as < bs ? -1 : as > bs ? 1 : 0) ||
+        ((a.id || 0) - (b.id || 0));
+    });
   if (lastEvents.length > 2000) lastEvents = lastEvents.slice(-2000);
   updateEventTypeFilter(lastEvents);
   applyEventFilters();
@@ -406,14 +425,7 @@ function updateEventTypeFilter(rows) {
 
 function eventMatchesSource(event, source) {
   if (!source) return true;
-  const haystack = [
-    event.group || "",
-    event.ups || "",
-    event.source || "",
-    event.detail || "",
-    event.details || "",
-  ].join(" ").toLowerCase();
-  return haystack.includes(source.toLowerCase());
+  return event.ups === source || event.source === source || event.group === source;
 }
 
 // Selected event keys ((source,id)). Preserved across passive polling so an
@@ -517,8 +529,12 @@ async function deleteSelected() {
     const items = evs.map((e) => ({ id: e.id, ts: e.ts, eventType: e.eventType || e.event }));
     const res = await api("/api/v1/ups/" + encodeURIComponent(ups) + "/events",
       { method: "DELETE", body: JSON.stringify({ items }) });
-    if (res.ok) evs.forEach((e) => gone.add(eventKey(e)));
-    else failed += evs.length;
+    const deleted = res.ok && res.data ? Number(res.data.deleted) : 0;
+    if (res.ok && deleted === items.length) {
+      evs.forEach((e) => gone.add(eventKey(e)));
+    } else {
+      failed += evs.length;
+    }
   }
   if (gone.size) lastEvents = lastEvents.filter((e) => !gone.has(eventKey(e)));
   selectedEvents = new Set();
@@ -788,16 +804,12 @@ async function loadGraph() {
 async function refresh() {
   // One shared config + remote-health snapshot per cycle so the drill-down reads
   // from memory instead of firing per-card requests.
-  const [cfg, rh] = await Promise.all([
-    api("/api/v1/config"), api("/api/v1/remote-health"),
+  const [authState, cfg, rh] = await Promise.all([
+    api("/api/v1/auth/state"), api("/api/v1/config"), api("/api/v1/remote-health"),
   ]);
+  authEnabled = !!(authState.ok && authState.data && authState.data.enabled);
   if (cfg.ok && cfg.data) {
     cfgSnapshot = cfg.data;
-    // Re-read auth-enabled every poll, not just at init: with dynamic
-    // auto-enable the server can turn auth on at runtime, and the Sign-in button
-    // must appear without a reload.
-    const a = cfg.data.api && cfg.data.api.auth;
-    authEnabled = !!(a && a.enabled);
     // If we hold a token but the server treats us as anonymous (sanitized
     // config), the session was invalidated server-side — e.g. the account was
     // deleted. Reads stay open (no 401 to trip the api() handler), so detect it

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -55,8 +55,12 @@ h2 { font-size: 1rem; color: var(--muted); text-transform: uppercase;
 .badge.ok { background: rgba(91,214,114,0.15); color: var(--ok); }
 .badge.warn { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge.crit { background: rgba(255,92,92,0.15); color: var(--crit); }
-.bar { height: 8px; background: var(--panel-2); border-radius: 4px; overflow: hidden; margin-top: 0.35rem; }
-.bar > span { display: block; height: 100%; background: var(--accent); }
+meter.bar { -webkit-appearance: none; appearance: none;
+  display: block; width: 100%; height: 8px; margin-top: 0.35rem;
+  border: 0; border-radius: 4px; background: var(--panel-2); }
+meter.bar::-webkit-meter-bar { background: var(--panel-2); border: 0; border-radius: 4px; }
+meter.bar::-webkit-meter-optimum-value { background: var(--accent); border-radius: 4px; }
+meter.bar::-moz-meter-bar { background: var(--accent); border-radius: 4px; }
 .graph-controls, .event-filters { display: flex; gap: 1rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
 .graph-controls label, .event-filters label { color: var(--muted); font-size: 0.9rem; }
 select, input { background: var(--panel-2); color: var(--text); border: 1px solid var(--line);
@@ -115,9 +119,12 @@ footer { padding: 0.6rem 1.25rem; color: var(--muted); font-size: 0.85rem;
 .card .row b.ok, .detail-section .row b.ok { color: var(--ok); }
 .card .row b.warn, .detail-section .row b.warn { color: var(--warn); }
 .card .row b.crit, .detail-section .row b.crit { color: var(--crit); }
-.bar > span.ok { background: var(--ok); }
-.bar > span.warn { background: var(--warn); }
-.bar > span.crit { background: var(--crit); }
+meter.bar.ok::-webkit-meter-optimum-value { background: var(--ok); }
+meter.bar.warn::-webkit-meter-optimum-value { background: var(--warn); }
+meter.bar.crit::-webkit-meter-optimum-value { background: var(--crit); }
+meter.bar.ok::-moz-meter-bar { background: var(--ok); }
+meter.bar.warn::-moz-meter-bar { background: var(--warn); }
+meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 
 /* Event actions row */
 .event-actions { display: flex; gap: 0.6rem; margin-bottom: 0.6rem; }

--- a/tests/e2e/groups/single-ups.sh
+++ b/tests/e2e/groups/single-ups.sh
@@ -1200,8 +1200,8 @@ api:
     db_path: "$AUTH_DB"
 nut_control:
   enabled: true
-  username: "operator"
-  password: "s3cret-pw"
+  username: "admin"
+  password: "testpass"
   allowed_commands: ["beeper.toggle"]
 notifications:
   enabled: false
@@ -1240,25 +1240,34 @@ ANON=$(curl -sS -o /dev/null -w '%{http_code}' \
   http://127.0.0.1:9100/api/v1/ups/TestUPS@localhost:3493/command)
 if [ "$ANON" != "401" ]; then echo "FAIL: anonymous control returned $ANON, expected 401"; exit 1; fi
 
-# An allowlisted command reaches NUT. dummy-ups in dummy mode does not support
-# instant commands, so the expected response is NUT's own CMD-NOT-SUPPORTED
-# error mapped through Eneru as 502. A 401/403 here would mean Eneru blocked the
-# request before NUT; CMD-NOT-SUPPORTED means the allowlisted request crossed
-# the API -> upscmd -> upsd boundary.
+# An allowlisted command reaches NUT. Most dummy-ups versions do not support
+# instant commands, so the normal response is NUT's own CMD-NOT-SUPPORTED
+# error mapped through Eneru as 502. If a future dummy driver accepts the
+# command, a 200 is also proof that the request crossed the API -> upscmd ->
+# upsd boundary. A 401/403 here would mean Eneru blocked the request first.
 ALLOWED=$(curl -sS -o /tmp/test53-allowed.json -w '%{http_code}' \
   -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   -d '{"command":"beeper.toggle"}' \
   http://127.0.0.1:9100/api/v1/ups/TestUPS@localhost:3493/command)
-if [ "$ALLOWED" != "502" ]; then
-  echo "FAIL: allowed command returned $ALLOWED, expected dummy-ups NUT_ERROR 502"
+if [ "$ALLOWED" = "200" ]; then
+  grep -q '"status": "ok"' /tmp/test53-allowed.json \
+    || { echo "FAIL: allowed command returned 200 without ok status"; cat /tmp/test53-allowed.json; exit 1; }
+elif [ "$ALLOWED" = "502" ]; then
+  grep -q '"code": "NUT_ERROR"' /tmp/test53-allowed.json \
+    || { echo "FAIL: allowed command did not return a NUT_ERROR"; cat /tmp/test53-allowed.json; exit 1; }
+  grep -q 'CMD-NOT-SUPPORTED' /tmp/test53-allowed.json \
+    || { echo "FAIL: allowed command did not expose the expected dummy-ups unsupported-command response"; cat /tmp/test53-allowed.json; exit 1; }
+  if grep -q 'ACCESS-DENIED' /tmp/test53-allowed.json; then
+    echo "FAIL: allowed command used invalid NUT credentials"
+    cat /tmp/test53-allowed.json
+    exit 1
+  fi
+else
+  echo "FAIL: allowed command returned $ALLOWED, expected 200 or dummy-ups NUT_ERROR 502"
   cat /tmp/test53-allowed.json
   cat /tmp/test53-daemon.log
   exit 1
 fi
-grep -q '"code": "NUT_ERROR"' /tmp/test53-allowed.json \
-  || { echo "FAIL: allowed command did not return a NUT_ERROR"; cat /tmp/test53-allowed.json; exit 1; }
-grep -q 'CMD-NOT-SUPPORTED' /tmp/test53-allowed.json \
-  || { echo "FAIL: allowed command did not reach dummy-ups"; cat /tmp/test53-allowed.json; exit 1; }
 
 kill "$DAEMON_PID" 2>/dev/null || true
 wait "$DAEMON_PID" 2>/dev/null || true

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import eneru.api as api_module
 from eneru.api import (
     APIBadRequest,
     APIForbidden,
@@ -15,6 +16,7 @@ from eneru.api import (
     APIUnauthorized,
     EneruAPIHandler,
     MAX_BODY_BYTES,
+    REQUEST_READ_TIMEOUT_SECONDS,
     SessionManager,
 )
 from eneru.auth import AuthStore
@@ -187,6 +189,23 @@ def test_session_invalidated_when_user_deleted(minimal_config, tmp_path):
     store.delete_user("alice")
     assert h._authenticate_request() is None                  # now rejected
     assert sessions.validate(token) is None                   # token reaped
+
+
+@pytest.mark.unit
+def test_session_invalidated_when_password_changes(minimal_config, tmp_path):
+    store = AuthStore(tmp_path / "auth.db")
+    store.create_user("alice", "pw1")
+    principal = store.authenticate("alice", "pw1")
+    sessions = SessionManager(3600)
+    token = sessions.create(principal)
+    h = _handler(minimal_config, auth_store=store, sessions=sessions,
+                 headers={"Authorization": f"Bearer {token}"})
+
+    assert h._authenticate_request()["username"] == "alice"
+    store.set_password("alice", "pw2")
+
+    assert h._authenticate_request() is None
+    assert sessions.validate(token) is None
 
 
 @pytest.mark.unit
@@ -383,6 +402,73 @@ def test_read_json_body_timeout_is_bad_request(minimal_config):
         h._read_json_body()
 
 
+@pytest.mark.unit
+def test_read_json_body_non_timeout_read_error_is_bad_request(minimal_config):
+    class BrokenBody:
+        def read(self, _length):
+            raise BrokenPipeError("client went away")
+
+    h = _handler(minimal_config, headers={"Content-Length": "2"})
+    h.rfile = BrokenBody()
+    with pytest.raises(APIBadRequest, match="failed to read request body"):
+        h._read_json_body()
+
+
+@pytest.mark.unit
+def test_read_json_body_enforces_total_deadline(minimal_config, monkeypatch):
+    class DripBody:
+        def __init__(self):
+            self.chunks = [b"{", b"}"]
+
+        def read1(self, _length):
+            return self.chunks.pop(0)
+
+    times = iter([
+        100.0,  # deadline setup
+        100.0,  # first chunk is inside the deadline
+        111.0,  # second chunk would arrive after the 10s total budget
+    ])
+    monkeypatch.setattr(api_module.time, "monotonic", lambda: next(times))
+
+    h = _handler(minimal_config, headers={"Content-Length": "2"})
+    h.rfile = DripBody()
+    with pytest.raises(APIBadRequest, match="request body timed out"):
+        h._read_json_body()
+
+
+@pytest.mark.unit
+def test_read_json_body_rejects_short_read(minimal_config):
+    h = _handler(
+        minimal_config,
+        headers={"Content-Length": "10"},
+        body=b"{}",
+    )
+    with pytest.raises(APIBadRequest):
+        h._read_json_body()
+
+
+@pytest.mark.unit
+def test_read_json_body_timeout_is_restored_after_read(minimal_config):
+    class FakeConnection:
+        def __init__(self):
+            self.timeout = None
+            self.set_calls = []
+
+        def gettimeout(self):
+            return self.timeout
+
+        def settimeout(self, timeout):
+            self.timeout = timeout
+            self.set_calls.append(timeout)
+
+    h = _handler(minimal_config, body=b"{}")
+    h.connection = FakeConnection()
+
+    assert h._read_json_body() == {}
+    assert h.connection.set_calls[0] == REQUEST_READ_TIMEOUT_SECONDS
+    assert h.connection.set_calls[-1] is None
+
+
 # ----- tiered /config + read gating via _route -----
 
 @pytest.mark.unit
@@ -420,6 +506,17 @@ def test_auth_state_open_when_reads_require_auth(minimal_config):
     status, _, payload = h._route()
     assert status == 200
     assert payload == {"enabled": True, "requireForReads": True}
+
+
+@pytest.mark.unit
+def test_auth_state_reports_effective_read_gate(minimal_config):
+    minimal_config.api.auth.enabled = False
+    minimal_config.api.auth.enabled_explicitly_set = True
+    minimal_config.api.auth.require_for_reads = True
+    h = _handler(minimal_config, path="/api/v1/auth/state")
+    status, _, payload = h._route()
+    assert status == 200
+    assert payload == {"enabled": False, "requireForReads": False}
 
 
 @pytest.mark.unit

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,6 +1,7 @@
 """Unit tests for the v6.0 API auth middleware + write-path (api.py)."""
 
 import json
+import socket
 import time
 from io import BytesIO
 from unittest.mock import MagicMock
@@ -370,6 +371,18 @@ def test_read_json_body_empty_is_dict(minimal_config):
     assert _handler(minimal_config)._read_json_body() == {}
 
 
+@pytest.mark.unit
+def test_read_json_body_timeout_is_bad_request(minimal_config):
+    class TimeoutBody:
+        def read(self, _length):
+            raise socket.timeout("slow client")
+
+    h = _handler(minimal_config, headers={"Content-Length": "2"})
+    h.rfile = TimeoutBody()
+    with pytest.raises(APIBadRequest):
+        h._read_json_body()
+
+
 # ----- tiered /config + read gating via _route -----
 
 @pytest.mark.unit
@@ -397,6 +410,16 @@ def test_read_gating_blocks_anonymous(minimal_config):
                  path="/api/v1/ups")
     with pytest.raises(APIUnauthorized):
         h._route()
+
+
+@pytest.mark.unit
+def test_auth_state_open_when_reads_require_auth(minimal_config):
+    _enable_auth(minimal_config, require_for_reads=True)
+    h = _handler(minimal_config, sessions=SessionManager(3600),
+                 path="/api/v1/auth/state")
+    status, _, payload = h._route()
+    assert status == 200
+    assert payload == {"enabled": True, "requireForReads": True}
 
 
 @pytest.mark.unit

--- a/tests/test_api_control.py
+++ b/tests/test_api_control.py
@@ -331,6 +331,19 @@ def test_audit_noop_without_log_and_swallows_errors(minimal_config):
     h._audit({"username": "x"}, "command", "t", "ok")  # swallowed
 
 
+@pytest.mark.unit
+def test_audit_logs_when_event_record_fails(minimal_config):
+    h = object.__new__(EneruAPIHandler)
+    logs = []
+    h.api_log = logs.append
+    h.api_source = MagicMock()
+    h.api_source.record_control_event.side_effect = OSError("db locked")
+
+    h._audit({"username": "x"}, "command", "UPS@h:test", "ok")
+
+    assert any("control audit event failed" in msg for msg in logs)
+
+
 # ----- config reload endpoint -----
 
 @pytest.mark.unit

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -117,6 +117,15 @@ def test_set_password_updates_and_missing_raises(store):
 
 
 @pytest.mark.unit
+def test_set_password_bumps_timestamp_inside_same_second(store, monkeypatch):
+    monkeypatch.setattr(auth.time, "time", lambda: 1000)
+    store.create_user("alice", "pw1")
+    before = store.get_user("alice")["password_changed_at"]
+    store.set_password("alice", "pw2")
+    assert store.get_user("alice")["password_changed_at"] == before + 1
+
+
+@pytest.mark.unit
 def test_delete_user_and_missing_raises(store):
     store.create_user("alice", "pw1")
     store.delete_user("alice")
@@ -128,8 +137,11 @@ def test_delete_user_and_missing_raises(store):
 @pytest.mark.unit
 def test_authenticate_paths(store):
     store.create_user("alice", "pw1")
-    assert store.authenticate("alice", "pw1") == {
-        "username": "alice", "role": "admin", "kind": "user"}
+    principal = store.authenticate("alice", "pw1")
+    assert principal["username"] == "alice"
+    assert principal["role"] == "admin"
+    assert principal["kind"] == "user"
+    assert isinstance(principal["password_changed_at"], int)
     assert store.authenticate("alice", "bad") is None
     assert store.authenticate("ghost", "pw1") is None  # dummy-hash path
 

--- a/tests/test_auth_autoenable.py
+++ b/tests/test_auth_autoenable.py
@@ -95,16 +95,15 @@ def test_explicit_true_wins_even_with_no_users(tmp_path):
 
 
 @pytest.mark.unit
-def test_inactive_when_unpinned_and_db_unreadable(tmp_path):
-    # Unpinned auth + an unreadable DB -> auth INACTIVE. This is still fail-closed
-    # on the write surface: with auth inactive, reads stay open (as always) but
-    # every write is hard-disabled (403), so a corrupt/unreadable DB can never
-    # open up control. (It is not "auth active with a dead DB", which would only
-    # make every login fail while blocking the same writes.)
+def test_active_when_unpinned_existing_db_is_unreadable(tmp_path):
+    # Unpinned auth + an existing but unreadable/corrupt DB fails closed to
+    # ACTIVE. Think of the DB file as the building's badge reader: if the reader
+    # is present but malfunctioning, keep the secure door locked rather than
+    # treating the building as public.
     cfg, db = _cfg_with_db(tmp_path)
     with open(db, "w") as fh:
         fh.write("not a sqlite database")
-    assert _auth_is_active(cfg) is False
+    assert _auth_is_active(cfg) is True
 
 
 @pytest.mark.unit

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,9 +1,13 @@
 """Tests for Config defaults and YAML file-loading paths."""
 
-import pytest
-import yaml
+import builtins
+import importlib
+import sys
 from pathlib import Path
 
+import pytest
+
+import eneru.config as config_module
 from eneru import (
     Config,
     ConfigLoader,
@@ -64,6 +68,18 @@ class TestConfigDefaults:
         assert default_config.containers.enabled is False
         assert default_config.filesystems.sync_enabled is True
         assert default_config.local_shutdown.enabled is True
+
+    @pytest.mark.unit
+    def test_legacy_accessors_return_defaults_without_groups(self) -> None:
+        """Programmatic empty Config objects still expose safe legacy defaults."""
+        config = Config(ups_groups=[])
+
+        assert config.ups.name == "UPS@localhost"
+        assert config.triggers.low_battery_threshold == 20
+        assert config.remote_servers == []
+        assert config.virtual_machines.enabled is False
+        assert config.containers.enabled is False
+        assert config.filesystems.sync_enabled is True
 
 
 class TestConfigLoading:
@@ -159,6 +175,59 @@ local_shutdown:
         assert config.ups.name == "UPS@localhost"
 
     @pytest.mark.unit
+    def test_load_without_pyyaml_returns_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If PyYAML is unavailable, loading falls back to default config."""
+        real_import = builtins.__import__
+
+        def blocked_yaml_import(
+            name,
+            globals=None,
+            locals=None,
+            fromlist=(),
+            level=0,
+        ):
+            if name == "yaml":
+                raise ImportError("blocked for test")
+            return real_import(name, globals, locals, fromlist, level)
+
+        module_name = "_eneru_config_no_yaml_test"
+        spec = importlib.util.spec_from_file_location(
+            module_name, config_module.__file__,
+        )
+        assert spec is not None and spec.loader is not None
+        fresh_config = importlib.util.module_from_spec(spec)
+        try:
+            with monkeypatch.context() as m:
+                m.setattr(builtins, "__import__", blocked_yaml_import)
+                m.setitem(sys.modules, module_name, fresh_config)
+                spec.loader.exec_module(fresh_config)
+                assert fresh_config.YAML_AVAILABLE is False
+                config = fresh_config.ConfigLoader.load()
+        finally:
+            sys.modules.pop(module_name, None)
+
+        assert config.ups.name == "UPS@localhost"
+        assert "PyYAML not installed" in capsys.readouterr().out
+
+    @pytest.mark.unit
+    def test_load_with_no_default_paths_returns_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """No explicit config and no default files should not be fatal."""
+        monkeypatch.setattr(ConfigLoader, "DEFAULT_CONFIG_PATHS", [])
+
+        config = ConfigLoader.load()
+
+        assert config.ups.name == "UPS@localhost"
+        assert "No config file found" in capsys.readouterr().out
+
+    @pytest.mark.unit
     def test_load_empty_file(self, temp_config_file):
         """Test loading an empty file returns defaults."""
         temp_config_file.write_text("")
@@ -179,6 +248,11 @@ local_shutdown:
         config = ConfigLoader.load(str(temp_config_file))
         assert config.ups.name == "UPS@localhost"
         assert "root must be a YAML mapping" in capsys.readouterr().out
+
+    @pytest.mark.unit
+    def test_unknown_key_errors_ignores_non_mapping_data(self):
+        """The helper is tolerant because callers validate section shape later."""
+        assert ConfigLoader._unknown_key_errors("section", [], {"known"}) == []
 
 
 class TestRedundancyGroupLoading:
@@ -385,4 +459,3 @@ redundancy_groups:
         assert config.redundancy_groups[0].name == "12345"
         assert all(isinstance(s, str)
                    for s in config.redundancy_groups[0].ups_sources)
-

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -137,6 +137,9 @@ def test_dashboard_has_wide_history_surfaces(minimal_config):
     assert "loadOlderEvents" in js
     assert "mergeEvents" in js
     assert "eventKey" in js
+    assert "as < bs ? -1 : as > bs ? 1 : 0" in js
+    assert "localeCompare" not in js
+    assert "event.ups === source" in js
     # Cursor paging must keep the selected lower bound, and rendered rows should
     # still honor the range if older rows are already cached client-side.
     assert 'if (from !== null) q += "&from=" + from' in js
@@ -158,6 +161,8 @@ def test_dashboard_has_event_delete_surface(minimal_config):
     assert "clearSelection" in js
     assert "loadEvents(undefined, true)" in js
     assert "Delete selected (" in js
+    assert "deleted === items.length" in js
+    assert "JSON.stringify({ items })" in js
 
 
 @pytest.mark.unit
@@ -172,8 +177,12 @@ def test_dashboard_has_drilldown_and_theme_surfaces(minimal_config):
         "/app.js")[1].decode("utf-8")
     assert "openDetail" in js and "renderDetail" in js
     assert "renderBanner" in js
+    assert "groupQuorumLost" in js
     assert "quorumLost" in js
     assert "/api/v1/auth/state" in js
+    assert "const [authState, cfg, rh]" in js
+    assert "authState.ok" in js
+    assert ".style.width" not in js
     assert "applyTheme" in js
     # Drill-down must read the shared snapshot, not fetch per card.
     assert "remoteHealthSnapshot" in js

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -172,6 +172,8 @@ def test_dashboard_has_drilldown_and_theme_surfaces(minimal_config):
         "/app.js")[1].decode("utf-8")
     assert "openDetail" in js and "renderDetail" in js
     assert "renderBanner" in js
+    assert "quorumLost" in js
+    assert "/api/v1/auth/state" in js
     assert "applyTheme" in js
     # Drill-down must read the shared snapshot, not fetch per card.
     assert "remoteHealthSnapshot" in js

--- a/tests/test_deferred_delivery.py
+++ b/tests/test_deferred_delivery.py
@@ -1,6 +1,8 @@
 """Tests for ``src/eneru/deferred_delivery.py`` — the v5.2.1 systemd-run
 based deferred-stop notification mechanism."""
 
+import logging
+import sqlite3
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -726,6 +728,159 @@ class TestDeliverPendingStop:
         assert row[0] == "sent"
 
     @pytest.mark.unit
+    def test_claim_is_delivering_until_apprise_succeeds(self, tmp_path):
+        """A claimed row must not look sent before the send actually succeeds."""
+        db_path = tmp_path / "ups.db"
+        row_id = self._make_pending_row(db_path)
+        seen_status = []
+
+        def send_and_observe(_body, _notify_type):
+            store = StatsStore(db_path)
+            store.open(recover_delivering=False)
+            try:
+                row = store._conn.execute(
+                    "SELECT status FROM notifications WHERE id = ?",
+                    (row_id,),
+                ).fetchone()
+                seen_status.append(row[0])
+            finally:
+                store.close()
+            return True
+
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker:
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.side_effect = send_and_observe
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+
+        assert rc == 0
+        assert seen_status == ["delivering"]
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status FROM notifications WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row[0] == "sent"
+
+    @pytest.mark.unit
+    def test_success_does_not_overwrite_cancelled_delivering_row(self, tmp_path):
+        """If a newer daemon cancels the claimed row while Apprise is sending,
+        the success mark must not resurrect that lifecycle event as sent."""
+        db_path = tmp_path / "ups.db"
+        row_id = self._make_pending_row(db_path)
+
+        def send_and_cancel(_body, _notify_type):
+            store = StatsStore(db_path)
+            store.open(recover_delivering=False)
+            try:
+                store.cancel_notification(row_id, "superseded")
+            finally:
+                store.close()
+            return True
+
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker:
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.side_effect = send_and_cancel
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+
+        assert rc == 0
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status, sent_at, cancel_reason FROM notifications "
+                "WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row == ("cancelled", None, "superseded")
+
+    @pytest.mark.unit
+    def test_success_logs_when_mark_sent_fails(self, tmp_path, caplog):
+        """A delivered one-shot still needs an audit breadcrumb if SQLite dies
+        before the row can be marked sent."""
+        db_path = tmp_path / "ups.db"
+        row_id = self._make_pending_row(db_path)
+
+        def send_and_drop_table(_body, _notify_type):
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute("DROP TABLE notifications")
+                conn.commit()
+            finally:
+                conn.close()
+            return True
+
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker, \
+                caplog.at_level(logging.ERROR, logger="eneru.deferred_delivery"):
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.side_effect = send_and_drop_table
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+
+        assert rc == 0
+        assert "sent but mark-sent failed" in caplog.text
+
+    @pytest.mark.unit
+    def test_exception_requeues_claim_and_logs(self, tmp_path, caplog):
+        """Unexpected Apprise errors leave the row retryable and visible in logs."""
+        db_path = tmp_path / "ups.db"
+        row_id = self._make_pending_row(db_path)
+        seen_status = []
+
+        def send_and_raise(_body, _notify_type):
+            store = StatsStore(db_path)
+            store.open(recover_delivering=False)
+            try:
+                row = store._conn.execute(
+                    "SELECT status FROM notifications WHERE id = ?",
+                    (row_id,),
+                ).fetchone()
+                seen_status.append(row[0])
+            finally:
+                store.close()
+            raise RuntimeError("apprise blew up")
+
+        cfg = self._make_config()
+        with patch("eneru.notifications.NotificationWorker") as Worker, \
+                caplog.at_level(logging.ERROR, logger="eneru.deferred_delivery"):
+            worker = Worker.return_value
+            worker.start.return_value = True
+            worker._send_via_apprise.side_effect = send_and_raise
+            rc = deliver_pending_stop(
+                notification_id=row_id, db_path=db_path, config=cfg,
+            )
+
+        assert rc == 0
+        assert seen_status == ["delivering"]
+        assert "Deferred stop notification delivery failed" in caplog.text
+        store = StatsStore(db_path)
+        store.open()
+        try:
+            row = store._conn.execute(
+                "SELECT status, sent_at FROM notifications WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            store.close()
+        assert row == ("pending", None)
+
+    @pytest.mark.unit
     def test_returns_zero_when_row_is_purged(self, tmp_path):
         """Row was purged (e.g., max_age_days TTL) between scheduling
         and timer fire → silent no-op."""
@@ -900,6 +1055,13 @@ class TestDeliverPendingStopErrorBranches:
                 return self._action(sql, params)
             return self._real.execute(sql, params)
 
+        def __enter__(self):
+            self._real.__enter__()
+            return self
+
+        def __exit__(self, *exc):
+            return self._real.__exit__(*exc)
+
         def commit(self):
             return self._real.commit()
 
@@ -923,7 +1085,7 @@ class TestDeliverPendingStopErrorBranches:
             # the real connection so the SELECT still finds the pending row.
             self._conn = TestDeliverPendingStopErrorBranches._ProxyConn(
                 real_conn,
-                "UPDATE NOTIFICATIONS SET STATUS='SENT'",
+                "UPDATE NOTIFICATIONS SET STATUS='DELIVERING'",
                 lambda sql, params: _ZeroRowCursor(),
             )
 

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -3838,13 +3838,15 @@ class TestStopStatsDefensive:
     @pytest.mark.unit
     def test_writer_cleared_and_close_called(self, tmp_path):
         monitor = make_monitor(tmp_path)
-        monitor._stats_writer = MagicMock()  # truthy
+        writer = MagicMock()  # truthy
+        monitor._stats_writer = writer
         store = MagicMock()
         monitor._stats_store = store
 
         monitor._stop_stats()
 
         assert monitor._stats_writer is None
+        writer.join.assert_called_once_with(timeout=2)
         store.close.assert_called_once()
 
     @pytest.mark.unit

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -2703,6 +2703,25 @@ class TestTriggerImmediateShutdown:
 
         monitor._execute_shutdown_sequence.assert_called_once()
 
+    @pytest.mark.unit
+    def test_shutdown_flag_write_failure_does_not_block_shutdown(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        monitor._stats_store = MagicMock()
+        monitor._execute_shutdown_sequence = MagicMock()
+
+        with patch.object(
+            type(monitor._shutdown_flag_path),
+            "touch",
+            side_effect=OSError("read-only filesystem"),
+        ):
+            monitor._trigger_immediate_shutdown("test reason")
+
+        monitor._execute_shutdown_sequence.assert_called_once()
+        assert any(
+            "Could not write shutdown flag" in str(call)
+            for call in monitor.logger.log.call_args_list
+        )
+
 
 class TestCleanupAndExit:
     """`_cleanup_and_exit` handles SIGTERM/SIGINT. Three distinct paths:
@@ -3099,6 +3118,18 @@ class TestGetAllUpsDataFailurePaths:
         assert success is False
         assert data == {}
         assert err == "Data stale"
+
+    @pytest.mark.unit
+    def test_missing_status_returns_failed_poll(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        with patch.object(
+            monitor, "_run_upsc",
+            return_value=(0, "battery.charge: 5\nbattery.runtime: 30\n", ""),
+        ):
+            success, data, err = monitor._get_all_ups_data()
+        assert success is False
+        assert data == {}
+        assert err == "Missing ups.status"
 
 
 class TestRecordRemoteHealthEvent:

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -2704,7 +2704,9 @@ class TestTriggerImmediateShutdown:
         monitor._execute_shutdown_sequence.assert_called_once()
 
     @pytest.mark.unit
-    def test_shutdown_flag_write_failure_does_not_block_shutdown(self, tmp_path):
+    def test_shutdown_flag_write_failure_does_not_block_shutdown(
+        self, tmp_path: Path,
+    ) -> None:
         monitor = make_monitor(tmp_path)
         monitor._stats_store = MagicMock()
         monitor._execute_shutdown_sequence = MagicMock()
@@ -2719,6 +2721,52 @@ class TestTriggerImmediateShutdown:
         monitor._execute_shutdown_sequence.assert_called_once()
         assert any(
             "Could not write shutdown flag" in str(call)
+            for call in monitor.logger.log.call_args_list
+        )
+
+    @pytest.mark.unit
+    def test_shutdown_flag_write_failure_still_blocks_duplicate_shutdowns(
+        self, tmp_path: Path,
+    ) -> None:
+        monitor = make_monitor(tmp_path)
+        monitor._stats_store = MagicMock()
+        monitor._execute_shutdown_sequence = MagicMock()
+
+        with patch.object(
+            type(monitor._shutdown_flag_path),
+            "touch",
+            side_effect=OSError("read-only filesystem"),
+        ):
+            monitor._trigger_immediate_shutdown("first trigger")
+
+        monitor._trigger_immediate_shutdown("second trigger")
+
+        monitor._execute_shutdown_sequence.assert_called_once()
+        assert any(
+            "already in progress" in str(call)
+            for call in monitor.logger.log.call_args_list
+        )
+
+    @pytest.mark.unit
+    def test_shutdown_flag_clear_failure_disables_disk_guard(
+        self, tmp_path: Path,
+    ) -> None:
+        monitor = make_monitor(tmp_path)
+        monitor._shutdown_in_progress = True
+        monitor._shutdown_flag_path.touch()
+
+        with patch.object(
+            type(monitor._shutdown_flag_path),
+            "unlink",
+            side_effect=OSError("read-only filesystem"),
+        ):
+            monitor._clear_shutdown_in_progress()
+
+        assert monitor._shutdown_in_progress is False
+        assert monitor._shutdown_flag_unusable is True
+        assert monitor._shutdown_guard_active() is False
+        assert any(
+            "Ignoring the on-disk guard" in str(call)
             for call in monitor.logger.log.call_args_list
         )
 
@@ -2758,6 +2806,30 @@ class TestCleanupAndExit:
         monitor._remote_health_manager.stop.assert_called_once()
         monitor._mqtt_publisher.stop.assert_called_once()
         monitor._api_server.stop.assert_called_once()
+
+    @pytest.mark.unit
+    def test_mid_shutdown_signal_uses_in_memory_guard_when_flag_missing(
+        self, tmp_path: Path,
+    ) -> None:
+        """If the flag write failed, the in-memory guard still identifies a
+        real shutdown sequence and prevents the graceful-stop path."""
+        monitor = make_monitor(tmp_path)
+        monitor._stats_store = MagicMock()
+        monitor._stop_stats = MagicMock()
+        monitor._shutdown_in_progress = True
+        monitor._shutdown_flag_path.unlink(missing_ok=True)
+
+        worker = MagicMock()
+        monitor._notification_worker = worker
+        monitor._send_notification = MagicMock()
+
+        with pytest.raises(SystemExit) as exc_info:
+            monitor._cleanup_and_exit(15, None)
+
+        assert exc_info.value.code == 0
+        worker.flush.assert_called_once()
+        worker.stop.assert_called_once()
+        monitor._send_notification.assert_not_called()
 
     @pytest.mark.unit
     def test_graceful_stop_enqueues_lifecycle_notification(self, tmp_path):
@@ -3120,7 +3192,7 @@ class TestGetAllUpsDataFailurePaths:
         assert err == "Data stale"
 
     @pytest.mark.unit
-    def test_missing_status_returns_failed_poll(self, tmp_path):
+    def test_missing_status_returns_failed_poll(self, tmp_path: Path) -> None:
         monitor = make_monitor(tmp_path)
         with patch.object(
             monitor, "_run_upsc",

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1286,6 +1286,33 @@ class TestCoordinatorRealLocalShutdown:
         coord._notification_worker.send.assert_called_once()
 
     @pytest.mark.unit
+    def test_flag_write_failure_does_not_skip_local_shutdown(self, tmp_path):
+        config = _coord_config(
+            tmp_path,
+            behavior=BehaviorConfig(dry_run=False),
+            local_shutdown=LocalShutdownConfig(
+                enabled=True,
+                command="/sbin/poweroff",
+            ),
+        )
+        coord = MultiUPSCoordinator(config)
+        logs = []
+        coord._log = logs.append
+        coord._notification_worker = None
+
+        with patch.object(
+            type(coord._global_shutdown_flag),
+            "touch",
+            side_effect=OSError("read-only filesystem"),
+        ), patch("eneru.multi_ups.time.sleep"), \
+             patch("eneru.multi_ups.run_command") as mock_run:
+            coord._handle_local_shutdown("UPS1")
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args.args[0][0] == "/sbin/poweroff"
+        assert any("Could not write shutdown flag" in line for line in logs)
+
+    @pytest.mark.unit
     def test_real_shutdown_without_message(self, tmp_path):
         """Empty message means no extra arg appended to the command."""
         config = _coord_config(

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -2117,6 +2117,9 @@ ups:
         t2 = MagicMock()
         coord._threads = [t1, t2]
         coord._evaluator_threads = []
+        mon = MagicMock()
+        mon._shutdown_flag_path = tmp_path / "no-monitor-shutdown"
+        coord._monitors = [mon]
         coord._notification_worker = None
         coord._stats_stores = []
         coord._stats_writers = []
@@ -2137,6 +2140,7 @@ ups:
         for thread in (t1, t2):
             thread.join.assert_called_once()
             assert 0 < thread.join.call_args.kwargs["timeout"] <= 5
+        mon._stop_stats.assert_called_once()
 
     @pytest.mark.unit
     def test_handle_signal_skips_lifecycle_notif_during_upgrade(self, tmp_path):

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -1336,6 +1336,27 @@ class TestCoordinatorRealLocalShutdown:
         assert cmd_parts == ["/sbin/poweroff"]
 
     @pytest.mark.unit
+    def test_real_shutdown_empty_command_logs_and_skips_poweroff(self, tmp_path):
+        """Programmatic configs can bypass validation; fail closed if the local
+        shutdown command is blank instead of trying to exec an empty argv."""
+        config = _coord_config(
+            tmp_path,
+            behavior=BehaviorConfig(dry_run=False),
+            local_shutdown=LocalShutdownConfig(enabled=True, command="   "),
+        )
+        coord = MultiUPSCoordinator(config)
+        logs = []
+        coord._log = logs.append
+        coord._notification_worker = None
+
+        with patch("eneru.multi_ups.time.sleep"), \
+             patch("eneru.multi_ups.run_command") as mock_run:
+            coord._handle_local_shutdown("UPS1")
+
+        mock_run.assert_not_called()
+        assert any("local_shutdown.command is empty" in line for line in logs)
+
+    @pytest.mark.unit
     def test_disabled_local_shutdown_clears_flag(self, tmp_path):
         """When local_shutdown.enabled=False, the global flag is removed."""
         config = _coord_config(
@@ -2143,6 +2164,33 @@ ups:
         mon._stop_stats.assert_called_once()
 
     @pytest.mark.unit
+    def test_handle_signal_logs_monitor_stats_close_failure(self, tmp_path):
+        import signal as _signal
+
+        config = _coord_config(tmp_path)
+        coord = MultiUPSCoordinator(config)
+        logs = []
+        coord._log = logs.append
+        coord._notification_worker = None
+        coord._threads = []
+        coord._evaluator_threads = []
+        mon = MagicMock()
+        mon._stop_stats.side_effect = RuntimeError("sqlite busy")
+        coord._monitors = [mon]
+        coord._redundancy_executors = {}
+
+        with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
+             patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
+             patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.sys.exit"):
+            coord._handle_signal(_signal.SIGTERM, None)
+
+        assert any(
+            "Failed to close monitor stats" in line and "sqlite busy" in line
+            for line in logs
+        )
+
+    @pytest.mark.unit
     def test_handle_signal_skips_lifecycle_notif_during_upgrade(self, tmp_path):
         """An in-flight deb/rpm upgrade (read_upgrade_marker returns truthy)
         means the next daemon will emit 'Upgraded vX → vY' — suppress the
@@ -2410,6 +2458,113 @@ class TestCoordinatorStartServersIdempotent:
             coord._start_mqtt_publisher()
         cls.assert_not_called()
         assert coord._mqtt_publisher is sentinel
+
+
+class TestCoordinatorReloadNotificationWorker:
+    """Notification reload should leave every monitor/executor with a coherent
+    worker reference, including disabled and failed-reload branches."""
+
+    @pytest.mark.unit
+    def test_reload_notification_worker_disabled_clears_existing_refs(
+        self, tmp_path: Path,
+    ) -> None:
+        coord = MultiUPSCoordinator(_coord_config(
+            tmp_path, notifications=NotificationsConfig(enabled=False)))
+        old_worker = MagicMock()
+        coord._notification_worker = old_worker
+        mon = MagicMock()
+        executor = MagicMock()
+        coord._monitors = [mon]
+        coord._redundancy_executors = {"rg": executor}
+        logs = []
+        coord._log = logs.append
+
+        coord._reload_notification_worker()
+
+        old_worker.stop.assert_called_once()
+        assert coord._notification_worker is None
+        assert mon._notification_worker is None
+        assert executor._notification_worker is None
+        assert any("Notifications: disabled" in line for line in logs)
+
+    @pytest.mark.unit
+    def test_reload_notification_worker_logs_when_apprise_missing(
+        self, tmp_path: Path,
+    ) -> None:
+        coord = MultiUPSCoordinator(_coord_config(
+            tmp_path,
+            notifications=NotificationsConfig(enabled=True, urls=["json://x"]),
+        ))
+        logs = []
+        coord._log = logs.append
+
+        with patch("eneru.multi_ups.APPRISE_AVAILABLE", False), \
+             patch("eneru.multi_ups.NotificationWorker") as worker_cls:
+            coord._reload_notification_worker()
+
+        worker_cls.assert_not_called()
+        assert coord._notification_worker is None
+        assert any("apprise not installed" in line for line in logs)
+
+    @pytest.mark.unit
+    def test_reload_notification_worker_start_failure_clears_refs(
+        self, tmp_path: Path,
+    ) -> None:
+        coord = MultiUPSCoordinator(_coord_config(
+            tmp_path,
+            notifications=NotificationsConfig(enabled=True, urls=["json://x"]),
+        ))
+        mon = MagicMock()
+        executor = MagicMock()
+        coord._monitors = [mon]
+        coord._redundancy_executors = {"rg": executor}
+        worker = MagicMock()
+        worker.start.return_value = False
+        logs = []
+        coord._log = logs.append
+
+        with patch("eneru.multi_ups.APPRISE_AVAILABLE", True), \
+             patch("eneru.multi_ups.NotificationWorker", return_value=worker):
+            coord._reload_notification_worker()
+
+        assert coord._notification_worker is None
+        assert mon._notification_worker is None
+        assert executor._notification_worker is None
+        assert any("Failed to reload notifications" in line for line in logs)
+
+    @pytest.mark.unit
+    def test_reload_notification_worker_registers_open_stores(
+        self, tmp_path: Path,
+    ) -> None:
+        coord = MultiUPSCoordinator(_coord_config(
+            tmp_path,
+            notifications=NotificationsConfig(enabled=True, urls=["json://x"]),
+        ))
+        open_store = MagicMock()
+        open_store._conn = object()
+        closed_store = MagicMock()
+        closed_store._conn = None
+        mon_open = MagicMock(_stats_store=open_store)
+        mon_closed = MagicMock(_stats_store=closed_store)
+        executor = MagicMock()
+        coord._monitors = [mon_open, mon_closed]
+        coord._redundancy_executors = {"rg": executor}
+        worker = MagicMock()
+        worker.start.return_value = True
+        worker.get_service_count.return_value = 1
+        logs = []
+        coord._log = logs.append
+
+        with patch("eneru.multi_ups.APPRISE_AVAILABLE", True), \
+             patch("eneru.multi_ups.NotificationWorker", return_value=worker):
+            coord._reload_notification_worker()
+
+        assert coord._notification_worker is worker
+        assert mon_open._notification_worker is worker
+        assert mon_closed._notification_worker is worker
+        assert executor._notification_worker is worker
+        worker.register_store.assert_called_once_with(open_store)
+        assert any("Notifications reloaded" in line for line in logs)
 
 
 class TestRunMonitorCrashStoreSelection:
@@ -2683,6 +2838,84 @@ class TestCoordinatorShutdownJoinAndAudit:
         assert coord._shutdown_join_deadline() == 120
 
     @pytest.mark.unit
+    def test_clear_global_shutdown_flag_logs_unlink_errors(self, tmp_path):
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        logs = []
+        coord._log = logs.append
+
+        with patch.object(
+            type(coord._global_shutdown_flag),
+            "unlink",
+            side_effect=OSError("read-only"),
+        ):
+            coord._clear_global_shutdown_flag("test")
+
+        assert any("Could not clear global shutdown flag" in m for m in logs)
+
+    @pytest.mark.unit
+    def test_global_shutdown_guard_logs_exists_errors(self, tmp_path):
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        logs = []
+        coord._log = logs.append
+
+        with patch.object(
+            type(coord._global_shutdown_flag),
+            "exists",
+            side_effect=OSError("permission denied"),
+        ):
+            assert coord._global_shutdown_guard_active() is False
+
+        assert any("Could not inspect global shutdown flag" in m for m in logs)
+
+    @pytest.mark.unit
+    def test_monitor_shutdown_guard_uses_monitor_helper(self, tmp_path):
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+
+        class MonitorWithGuard:
+            def _shutdown_guard_active(self):
+                return True
+
+        assert coord._monitor_shutdown_guard_active(MonitorWithGuard()) is True
+
+    @pytest.mark.unit
+    def test_monitor_shutdown_guard_falls_back_after_helper_error(self, tmp_path):
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        logs = []
+        coord._log = logs.append
+
+        class MonitorWithBrokenGuard:
+            def __init__(self):
+                self._shutdown_in_progress = True
+
+            def _shutdown_guard_active(self):
+                raise RuntimeError("boom")
+
+        assert coord._monitor_shutdown_guard_active(MonitorWithBrokenGuard()) is True
+        assert any("Could not inspect monitor shutdown guard" in m for m in logs)
+
+    @pytest.mark.unit
+    def test_monitor_shutdown_guard_handles_missing_or_unreadable_flag(self, tmp_path):
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        logs = []
+        coord._log = logs.append
+
+        class MonitorWithoutFlag:
+            _shutdown_in_progress = False
+
+        assert coord._monitor_shutdown_guard_active(MonitorWithoutFlag()) is False
+
+        mon = MonitorWithoutFlag()
+        mon._shutdown_flag_path = tmp_path / "flag-ups"
+        with patch.object(
+            type(mon._shutdown_flag_path),
+            "exists",
+            side_effect=OSError("permission denied"),
+        ):
+            assert coord._monitor_shutdown_guard_active(mon) is False
+
+        assert any("Could not inspect monitor shutdown flag" in m for m in logs)
+
+    @pytest.mark.unit
     def test_inflight_recovery_defers_rearm(self, tmp_path):
         """cubic P1: a recovery that races the in-flight window does not drop the
         re-arm -- _clear_local_shutdown_state defers it, and the finally of
@@ -2733,6 +2966,26 @@ class TestCoordinatorShutdownJoinAndAudit:
         coord._threads = []
         coord._evaluator_threads = []
         coord._global_shutdown_flag.touch()  # shutdown in flight
+        with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
+             patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
+             patch("eneru.multi_ups.write_shutdown_marker"), \
+             patch("eneru.multi_ups.sys.exit"):
+            coord._handle_signal(15, None)
+        assert any("Shutdown sequence in progress" in m for m in logs), logs
+
+    @pytest.mark.unit
+    def test_handle_signal_in_memory_in_flight_waits_longer(self, tmp_path):
+        """If the global flag write failed, the in-memory in-flight bit still
+        protects the host poweroff thread from a short signal teardown."""
+        coord = MultiUPSCoordinator(self._cfg(tmp_path))
+        logs = []
+        coord._log = lambda m: logs.append(m)
+        coord._notification_worker = None
+        coord._threads = []
+        coord._evaluator_threads = []
+        coord._global_shutdown_flag.unlink(missing_ok=True)
+        with coord._local_shutdown_lock:
+            coord._local_shutdown_in_flight = True
         with patch("eneru.multi_ups.read_upgrade_marker", return_value=None), \
              patch("eneru.multi_ups.read_shutdown_marker", return_value=None), \
              patch("eneru.multi_ups.write_shutdown_marker"), \

--- a/tests/test_nut_control.py
+++ b/tests/test_nut_control.py
@@ -11,6 +11,7 @@ def test_parse_command_list_skips_header_and_junk():
         "Instant commands supported on UPS [dummy]:\n"
         "  beeper.toggle - Toggle the beeper\n"
         "  test.battery.start - Start a battery test\n"
+        "  bad name - ignored\n"
         "noise line without separator\n"
     )
     assert nc._parse_command_list(text) == ["beeper.toggle", "test.battery.start"]
@@ -83,6 +84,16 @@ def test_run_instant_command_failure(monkeypatch):
 
 
 @pytest.mark.unit
+def test_run_instant_command_failure_uses_pty_output_when_stderr_empty(monkeypatch):
+    monkeypatch.setattr(nc, "_run_auth_command", lambda cmd, password, timeout=10: (
+        1, "Unexpected response from upsd: ERR CMD-NOT-SUPPORTED", ""))
+    ok, out, err = nc.run_instant_command("UPS@h", "x", "u", "p")
+    assert ok is False
+    assert out == "Unexpected response from upsd: ERR CMD-NOT-SUPPORTED"
+    assert "CMD-NOT-SUPPORTED" in err
+
+
+@pytest.mark.unit
 def test_list_variables_success_and_failure(monkeypatch):
     monkeypatch.setattr(nc, "run_command", lambda cmd, timeout=10: (
         0, "[input.transfer.low]\nType: STRING\nValue: 196\n", ""))
@@ -121,6 +132,16 @@ def test_set_variable_failure(monkeypatch):
 
 
 @pytest.mark.unit
+def test_set_variable_failure_uses_pty_output_when_stderr_empty(monkeypatch):
+    monkeypatch.setattr(nc, "_run_auth_command", lambda cmd, password, timeout=10: (
+        1, "Unexpected response from upsd: ERR ACCESS-DENIED", ""))
+    ok, out, err = nc.set_variable("UPS@h", "v", "x", "u", "p")
+    assert ok is False
+    assert out == "Unexpected response from upsd: ERR ACCESS-DENIED"
+    assert "ACCESS-DENIED" in err
+
+
+@pytest.mark.unit
 def test_run_auth_command_without_password_uses_regular_runner(monkeypatch):
     captured = {}
 
@@ -133,3 +154,474 @@ def test_run_auth_command_without_password_uses_regular_runner(monkeypatch):
     code, out, err = nc._run_auth_command(["upscmd", "UPS@h", "cmd"], "", timeout=7)
     assert (code, out, err) == (0, "ok", "")
     assert captured == {"cmd": ["upscmd", "UPS@h", "cmd"], "timeout": 7}
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_upscmd_username_without_password():
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "", timeout=1)
+
+    assert (code, out) == (2, "")
+    assert "username requires password" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_accepts_upsrw_without_username(monkeypatch):
+    captured = []
+
+    def fake(cmd, timeout=10):
+        captured.append(cmd)
+        return 0, "ok", ""
+
+    monkeypatch.setattr(nc, "run_command", fake)
+
+    assert nc._run_auth_command(
+        ["upsrw", "-s", "input.transfer.low=200", "UPS@h"], "", timeout=1
+    ) == (0, "ok", "")
+    assert captured == [
+        ["upsrw", "-s", "input.transfer.low=200", "UPS@h"],
+    ]
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_upsrw_username_without_password():
+    code, out, err = nc._run_auth_command(
+        ["upsrw", "-s", "input.transfer.low=200", "-u", "adm", "UPS@h"],
+        "",
+        timeout=1,
+    )
+
+    assert (code, out) == (2, "")
+    assert "username requires password" in err
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cmd", "message"),
+    [
+        (["upscmd", "", "beeper.toggle"], "empty"),
+        (["upscmd", "-u", "", "UPS@h", "beeper.toggle"], "empty"),
+        (["upscmd", "-u", "adm", "UPS;id", "beeper.toggle"], "unsupported"),
+        (["upscmd", "-u", "adm", "UPS@h", ""], "empty"),
+        (["upsrw", "-s", "", "UPS@h"], "empty"),
+        (["upsrw", "-s", "input.transfer.low=200", ""], "empty"),
+        (["upsrw", "-s", "", "-u", "adm", "UPS@h"], "empty"),
+        (["upsrw", "-s", "input.transfer.low=200", "-u", "", "UPS@h"], "empty"),
+        (["upsrw", "-s", "input.transfer.low=200", "-u", "adm", ""], "empty"),
+    ],
+)
+def test_validated_auth_command_rejects_each_data_position(cmd, message):
+    safe_cmd, err = nc._validated_auth_command_argv(cmd)
+
+    assert safe_cmd is None
+    assert message in err
+
+
+@pytest.mark.unit
+def test_validate_auth_command_wrapper_reports_bool_and_error():
+    ok, err = nc._validate_auth_command_argv(
+        ["upscmd", "-u", "adm", "UPS@h", "beeper.toggle"])
+    assert ok is True
+    assert err == ""
+
+    ok, err = nc._validate_auth_command_argv(["upscmd", "UPS@h"])
+    assert ok is False
+    assert "invalid upscmd argument shape" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_unexpected_binary():
+    code, out, err = nc._run_auth_command(["sh", "-c", "id"], "", timeout=1)
+    assert code == 2
+    assert out == ""
+    assert "unsupported NUT control binary" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_option_like_data_arg():
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "UPS@h", "--help"], "pw", timeout=1)
+    assert code == 2
+    assert out == ""
+    assert "looks like an option" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_allowed_option_in_data_position():
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "UPS@h", "-u"], "pw", timeout=1)
+    assert code == 2
+    assert out == ""
+    assert "looks like an option" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_bad_upsrw_shape():
+    code, out, err = nc._run_auth_command(
+        ["upsrw", "-u", "adm", "-s", "input.transfer.low=200", "UPS@h"],
+        "pw",
+        timeout=1,
+    )
+    assert code == 2
+    assert out == ""
+    assert "invalid upsrw argument shape" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_bad_upscmd_shape():
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h"], "pw", timeout=1)
+    assert code == 2
+    assert out == ""
+    assert "invalid upscmd argument shape" in err
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("cmd", [
+    ["upscmd", "UPS@h", "beeper.toggle"],
+    ["upsrw", "-s", "input.transfer.low=200", "UPS@h"],
+])
+def test_run_auth_command_rejects_password_without_username(monkeypatch, cmd):
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (_ for _ in ()).throw(
+        AssertionError("PTY must not open without a username")))
+
+    code, out, err = nc._run_auth_command(cmd, "pw", timeout=1)
+
+    assert (code, out) == (2, "")
+    assert "password requires username" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_rejects_shell_metacharacters():
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "UPS@h", "beeper.toggle;id"], "pw", timeout=1)
+    assert code == 2
+    assert out == ""
+    assert "unsupported characters" in err
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ["", "bad\x00arg"])
+def test_run_auth_command_rejects_empty_and_nul_args(bad):
+    code, out, err = nc._run_auth_command(["upscmd", "UPS@h", bad], "", timeout=1)
+    assert code == 2
+    assert out == ""
+    assert err
+
+
+@pytest.mark.unit
+def test_run_auth_command_with_password_drives_pty_prompt(monkeypatch):
+    from types import SimpleNamespace
+
+    captured = {}
+    closed = []
+    writes = []
+
+    class FakeProc:
+        def __init__(self):
+            self.polls = [None, 0]
+
+        def poll(self):
+            return self.polls.pop(0) if self.polls else 0
+
+        def kill(self):
+            raise AssertionError("successful command must not be killed")
+
+    def fake_popen(cmd, stdin, stdout, stderr, close_fds):
+        captured.update({
+            "cmd": cmd, "stdin": stdin, "stdout": stdout,
+            "stderr": stderr, "close_fds": close_fds,
+        })
+        return FakeProc()
+
+    reads = iter([b"Password: ", b"OK\n", OSError("eof")])
+
+    def fake_read(fd, size):
+        item = next(reads)
+        if isinstance(item, OSError):
+            raise item
+        return item
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(nc.os, "close", closed.append)
+    monkeypatch.setattr(nc.os, "read", fake_read)
+    monkeypatch.setattr(nc.os, "write", lambda fd, data: writes.append((fd, data)))
+    monkeypatch.setattr(nc.select, "select", lambda r, w, x, t: (r, [], []))
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=lambda: 0.0))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret", timeout=1)
+
+    assert (code, err) == (0, "")
+    assert "Password:" in out and "OK" in out
+    assert captured == {
+        "cmd": ["upscmd", "-u", "adm", "UPS@h", "cmd"],
+        "stdin": 11,
+        "stdout": 11,
+        "stderr": 11,
+        "close_fds": True,
+    }
+    assert writes == [(10, b"secret\n")]
+    assert closed == [11, 10]
+
+
+@pytest.mark.unit
+def test_run_auth_command_does_not_answer_non_prompt_password_text(monkeypatch):
+    from types import SimpleNamespace
+
+    writes = []
+
+    class FakeProc:
+        def poll(self):
+            return 1
+
+        def kill(self):
+            raise AssertionError("completed command must not be killed")
+
+    reads = iter([b"ERR PASSWORD-REQUIRED\n", OSError("eof")])
+
+    def fake_read(fd, size):
+        item = next(reads)
+        if isinstance(item, OSError):
+            raise item
+        return item
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(nc.os, "close", lambda fd: None)
+    monkeypatch.setattr(nc.os, "read", fake_read)
+    monkeypatch.setattr(nc.os, "write", lambda fd, data: writes.append((fd, data)))
+    monkeypatch.setattr(nc.select, "select", lambda r, w, x, t: (r, [], []))
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=lambda: 0.0))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret", timeout=1)
+
+    assert (code, err) == (1, "")
+    assert "PASSWORD-REQUIRED" in out
+    assert writes == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cmd", "expected"),
+    [
+        (
+            ["upscmd", "-u", "adm", "UPS@h", "beeper.toggle"],
+            ["upscmd", "-u", "adm", "UPS@h", "beeper.toggle"],
+        ),
+        (
+            ["upsrw", "-s", "input.transfer.low=200", "-u", "adm", "UPS@h"],
+            ["upsrw", "-s", "input.transfer.low=200", "-u", "adm", "UPS@h"],
+        ),
+    ],
+)
+def test_run_auth_command_with_password_spawns_each_fixed_shape(
+    monkeypatch, cmd, expected,
+):
+    from types import SimpleNamespace
+
+    captured = {}
+
+    class FakeProc:
+        def poll(self):
+            return 0
+
+        def kill(self):
+            raise AssertionError("completed command must not be killed")
+
+    def fake_popen(cmd, stdin, stdout, stderr, close_fds):
+        captured.update({
+            "cmd": cmd, "stdin": stdin, "stdout": stdout,
+            "stderr": stderr, "close_fds": close_fds,
+        })
+        return FakeProc()
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(nc.os, "close", lambda fd: None)
+    monkeypatch.setattr(nc.os, "read", lambda fd, size: b"")
+    monkeypatch.setattr(nc.select, "select", lambda r, w, x, t: ([], [], []))
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=lambda: 0.0))
+
+    code, out, err = nc._run_auth_command(cmd, "secret", timeout=1)
+
+    assert (code, out, err) == (0, "", "")
+    assert captured == {
+        "cmd": expected,
+        "stdin": 11,
+        "stdout": 11,
+        "stderr": 11,
+        "close_fds": True,
+    }
+
+
+@pytest.mark.unit
+def test_run_auth_command_timeout_kills_process_and_closes_fds(monkeypatch):
+    from types import SimpleNamespace
+
+    closed = []
+
+    class FakeProc:
+        def __init__(self):
+            self.killed = False
+            self.waited = False
+
+        def poll(self):
+            return None
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self, timeout=None):
+            self.waited = True
+
+    proc = FakeProc()
+    calls = {"count": 0}
+
+    def fake_monotonic():
+        calls["count"] += 1
+        return 0.0 if calls["count"] == 1 else 2.0
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", lambda *a, **k: proc)
+    monkeypatch.setattr(nc.os, "close", closed.append)
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=fake_monotonic))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret", timeout=1)
+
+    assert (code, out, err) == (124, "", "Command timed out")
+    assert proc.killed is True
+    assert proc.waited is True
+    assert closed == [11, 10]
+
+
+@pytest.mark.unit
+def test_run_auth_command_timeout_swallows_kill_errors(monkeypatch):
+    from types import SimpleNamespace
+
+    class FakeProc:
+        def poll(self):
+            return None
+
+        def kill(self):
+            raise RuntimeError("already gone")
+
+    calls = {"count": 0}
+
+    def fake_monotonic():
+        calls["count"] += 1
+        return 0.0 if calls["count"] == 1 else 2.0
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(nc.os, "close", lambda fd: None)
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=fake_monotonic))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret", timeout=1)
+
+    assert (code, out, err) == (124, "", "Command timed out")
+
+
+@pytest.mark.unit
+def test_run_auth_command_read_error_and_close_error_are_swallowed(monkeypatch):
+    from types import SimpleNamespace
+
+    class FakeProc:
+        def __init__(self):
+            self.polls = [0]
+
+        def poll(self):
+            return self.polls.pop(0) if self.polls else 0
+
+        def kill(self):
+            raise AssertionError("completed command must not be killed")
+
+    reads = iter([OSError("eio"), b""])
+    closed = []
+
+    def fake_read(fd, size):
+        item = next(reads)
+        if isinstance(item, OSError):
+            raise item
+        return item
+
+    def fake_close(fd):
+        if fd == 10:
+            raise OSError("close failed")
+        closed.append(fd)
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(nc.os, "close", fake_close)
+    monkeypatch.setattr(nc.os, "read", fake_read)
+    monkeypatch.setattr(nc.select, "select", lambda r, w, x, t: (r, [], []))
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=lambda: 0.0))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret")
+
+    assert (code, out, err) == (0, "", "")
+    assert closed == [11]
+
+
+@pytest.mark.unit
+def test_run_auth_command_no_readable_fd_still_drains_final_output(monkeypatch):
+    from types import SimpleNamespace
+
+    class FakeProc:
+        def poll(self):
+            return 0
+
+        def kill(self):
+            raise AssertionError("completed command must not be killed")
+
+    reads = iter([b"final output\n", b""])
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(nc.os, "close", lambda fd: None)
+    monkeypatch.setattr(nc.os, "read", lambda fd, size: next(reads))
+    monkeypatch.setattr(nc.select, "select", lambda r, w, x, t: ([], [], []))
+    monkeypatch.setattr(nc, "time", SimpleNamespace(monotonic=lambda: 0.0))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret")
+
+    assert (code, out, err) == (0, "final output\n", "")
+
+
+@pytest.mark.unit
+def test_run_auth_command_file_not_found_closes_fds(monkeypatch):
+    closed = []
+
+    def missing(*args, **kwargs):
+        raise FileNotFoundError("upscmd missing")
+
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(nc.subprocess, "Popen", missing)
+    monkeypatch.setattr(nc.os, "close", closed.append)
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret")
+
+    assert code == 127
+    assert out == ""
+    assert "upscmd missing" in err
+    assert closed == [10, 11]
+
+
+@pytest.mark.unit
+def test_run_auth_command_generic_exception_returns_output(monkeypatch):
+    monkeypatch.setattr(nc.pty, "openpty", lambda: (_ for _ in ()).throw(
+        RuntimeError("pty gone")))
+
+    code, out, err = nc._run_auth_command(
+        ["upscmd", "-u", "adm", "UPS@h", "cmd"], "secret")
+
+    assert code == 1
+    assert out == ""
+    assert "pty gone" in err

--- a/tests/test_nut_control.py
+++ b/tests/test_nut_control.py
@@ -37,7 +37,7 @@ def test_parse_variable_list_ignores_orphan_lines():
 
 @pytest.mark.unit
 def test_creds_args():
-    assert nc._creds_args("u", "p") == ["-u", "u", "-p", "p"]
+    assert nc._creds_args("u", "p") == ["-u", "u"]
     assert nc._creds_args("", "") == []
 
 
@@ -58,24 +58,26 @@ def test_list_commands_failure(monkeypatch):
 
 
 @pytest.mark.unit
-def test_run_instant_command_builds_argv(monkeypatch):
+def test_run_instant_command_does_not_put_password_in_argv(monkeypatch):
     captured = {}
 
-    def fake(cmd, timeout=10):
+    def fake(cmd, password, timeout=10):
         captured["cmd"] = cmd
+        captured["password"] = password
         return 0, "done", ""
 
-    monkeypatch.setattr(nc, "run_command", fake)
+    monkeypatch.setattr(nc, "_run_auth_command", fake)
     ok, out, err = nc.run_instant_command("UPS@h", "beeper.toggle", "adm", "pw")
     assert ok and out == "done"
-    assert captured["cmd"] == ["upscmd", "-u", "adm", "-p", "pw",
-                               "UPS@h", "beeper.toggle"]
+    assert captured["cmd"] == ["upscmd", "-u", "adm", "UPS@h", "beeper.toggle"]
+    assert "pw" not in captured["cmd"]
+    assert captured["password"] == "pw"
 
 
 @pytest.mark.unit
 def test_run_instant_command_failure(monkeypatch):
-    monkeypatch.setattr(nc, "run_command",
-                        lambda cmd, timeout=10: (1, "", "access denied"))
+    monkeypatch.setattr(nc, "_run_auth_command",
+                        lambda cmd, password, timeout=10: (1, "", "access denied"))
     ok, out, err = nc.run_instant_command("UPS@h", "x", "u", "p")
     assert ok is False and "access denied" in err
 
@@ -93,23 +95,41 @@ def test_list_variables_success_and_failure(monkeypatch):
 
 
 @pytest.mark.unit
-def test_set_variable_builds_argv(monkeypatch):
+def test_set_variable_does_not_put_password_in_argv(monkeypatch):
     captured = {}
 
-    def fake(cmd, timeout=10):
+    def fake(cmd, password, timeout=10):
         captured["cmd"] = cmd
+        captured["password"] = password
         return 0, "", ""
 
-    monkeypatch.setattr(nc, "run_command", fake)
+    monkeypatch.setattr(nc, "_run_auth_command", fake)
     ok, _, _ = nc.set_variable("UPS@h", "input.transfer.low", "200", "adm", "pw")
     assert ok
     assert captured["cmd"] == ["upsrw", "-s", "input.transfer.low=200",
-                               "-u", "adm", "-p", "pw", "UPS@h"]
+                               "-u", "adm", "UPS@h"]
+    assert "pw" not in captured["cmd"]
+    assert captured["password"] == "pw"
 
 
 @pytest.mark.unit
 def test_set_variable_failure(monkeypatch):
-    monkeypatch.setattr(nc, "run_command",
-                        lambda cmd, timeout=10: (1, "", "out of range"))
+    monkeypatch.setattr(nc, "_run_auth_command",
+                        lambda cmd, password, timeout=10: (1, "", "out of range"))
     ok, _, err = nc.set_variable("UPS@h", "v", "x", "u", "p")
     assert ok is False and "out of range" in err
+
+
+@pytest.mark.unit
+def test_run_auth_command_without_password_uses_regular_runner(monkeypatch):
+    captured = {}
+
+    def fake(cmd, timeout=10):
+        captured["cmd"] = cmd
+        captured["timeout"] = timeout
+        return 0, "ok", ""
+
+    monkeypatch.setattr(nc, "run_command", fake)
+    code, out, err = nc._run_auth_command(["upscmd", "UPS@h", "cmd"], "", timeout=7)
+    assert (code, out, err) == (0, "ok", "")
+    assert captured == {"cmd": ["upscmd", "UPS@h", "cmd"], "timeout": 7}

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -35,6 +35,12 @@ def _nfpm_src_paths() -> set:
     return set(re.findall(r"src:\s*(src/eneru/[^\s]+\.py)", text))
 
 
+def _nfpm_all_src_paths() -> set:
+    """Return every ``src: src/eneru/...`` path listed in nfpm.yaml."""
+    text = NFPM_YAML.read_text()
+    return set(re.findall(r"src:\s*(src/eneru/[^\s]+)", text))
+
+
 class TestNfpmModuleListing:
 
     @pytest.mark.unit
@@ -79,3 +85,27 @@ class TestNfpmModuleListing:
             "Stats databases are written there; the deb/rpm package must "
             "create the directory at install time."
         )
+
+    @pytest.mark.unit
+    def test_dashboard_and_completion_assets_are_packaged(self):
+        """deb/rpm and wheel installs must both ship importlib.resources data."""
+        required = {
+            "src/eneru/web/__init__.py",
+            "src/eneru/web/index.html",
+            "src/eneru/web/app.js",
+            "src/eneru/web/style.css",
+            "src/eneru/completion/__init__.py",
+            "src/eneru/completion/eneru.bash",
+            "src/eneru/completion/eneru.zsh",
+            "src/eneru/completion/eneru.fish",
+        }
+        in_nfpm = _nfpm_all_src_paths()
+        missing = sorted(required - in_nfpm)
+        assert not missing, (
+            "nfpm.yaml is missing package data files:\n  "
+            + "\n  ".join(missing)
+        )
+
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+        assert '"eneru.web" = ["*.html", "*.css", "*.js"]' in pyproject
+        assert '"eneru.completion" = ["*.bash", "*.zsh", "*.fish"]' in pyproject

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -1107,7 +1107,9 @@ class TestExecutorShutdown:
         assert calls == ["vms", "containers", "sync", "unmount", "remote"]
 
     @pytest.mark.unit
-    def test_local_phase_exception_does_not_skip_poweroff_callback(self, tmp_path):
+    def test_local_phase_exception_does_not_skip_poweroff_callback(
+        self, tmp_path: Path,
+    ) -> None:
         callback = MagicMock()
         group = _redundancy_group(
             is_local=True,
@@ -1134,7 +1136,9 @@ class TestExecutorShutdown:
         callback.assert_called_once_with("redundancy:rg")
 
     @pytest.mark.unit
-    def test_loopback_delegate_skips_local_phases_and_callback(self, tmp_path):
+    def test_loopback_delegate_skips_local_phases_and_callback(
+        self, tmp_path: Path,
+    ) -> None:
         """Containerized local redundancy groups delegate host work to SSH.
 
         The remote phase must still run because that is where the loopback
@@ -1181,6 +1185,8 @@ class TestExecutorShutdown:
                                host="127.0.0.1",
                                completed=True,
                                shutdown_sent=True,
+                               crashed=True,
+                               error="local drain failed after poweroff queued",
                            )
                        ])
             assert ex.shutdown(reason="x") is True
@@ -1189,7 +1195,9 @@ class TestExecutorShutdown:
         callback.assert_not_called()
 
     @pytest.mark.unit
-    def test_loopback_delegate_failure_rearms_and_reports_incomplete(self, tmp_path):
+    def test_loopback_delegate_failure_rearms_and_reports_incomplete(
+        self, tmp_path: Path,
+    ) -> None:
         group = _redundancy_group(
             is_local=True,
             remote_servers=[RemoteServerConfig(
@@ -1230,6 +1238,46 @@ class TestExecutorShutdown:
             if call.kwargs.get("category") == "shutdown_summary"
         ]
         assert len(summary_calls) == 1
+
+    @pytest.mark.unit
+    def test_loopback_delegate_failure_unlink_error_still_returns_false(
+        self, tmp_path: Path,
+    ) -> None:
+        group = _redundancy_group(
+            is_local=True,
+            remote_servers=[RemoteServerConfig(
+                name="host-loopback",
+                enabled=True,
+                host="127.0.0.1",
+                user="root",
+                is_host_loopback=True,
+            )],
+        )
+        ex = RedundancyGroupExecutor(
+            group,
+            base_config=_base_config(dry_run=False, tmp_path=tmp_path),
+        )
+        ex.logger = MagicMock()
+        ex._notification_worker = MagicMock()
+
+        with pytest.MonkeyPatch.context() as mp, \
+             patch.object(Path, "unlink", side_effect=PermissionError("no unlink")):
+            mp.setattr("eneru.cli._detect_runtime_context",
+                       lambda: "container (Docker)")
+            mp.setattr(ex, "_shutdown_remote_servers", lambda: [
+                RemoteShutdownResult(
+                    server="host-loopback",
+                    host="127.0.0.1",
+                    completed=True,
+                    shutdown_sent=False,
+                    error="ssh refused",
+                )
+            ])
+            assert ex.shutdown(reason="x") is False
+
+        assert ex._shutdown_done is False
+        logged = " ".join(call.args[0] for call in ex.logger.log.call_args_list)
+        assert "Could not clear redundancy shutdown flag" in logged
 
     @pytest.mark.unit
     def test_logging_uses_prefix(self, tmp_path):
@@ -1374,7 +1422,9 @@ class TestLocalShutdownCallback:
     host still running."""
 
     @pytest.mark.unit
-    def test_callback_fires_on_is_local_quorum_loss(self, tmp_path):
+    def test_callback_fires_on_is_local_quorum_loss(
+        self, tmp_path: Path,
+    ) -> None:
         callback = MagicMock()
         group = _redundancy_group(name="rack-local", is_local=True)
         ex = RedundancyGroupExecutor(
@@ -1414,7 +1464,9 @@ class TestLocalShutdownCallback:
         assert ex.shutdown(reason="quorum lost") is True
 
     @pytest.mark.unit
-    def test_callback_still_fires_when_remote_shutdown_raises(self, tmp_path):
+    def test_callback_still_fires_when_remote_shutdown_raises(
+        self, tmp_path: Path,
+    ) -> None:
         # Remote drain is a best-effort sink. If it breaks, the executor must
         # still notify the coordinator to power off the local host.
         callback = MagicMock()

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -30,6 +30,7 @@ from eneru import (
 )
 from eneru.state import HealthSnapshot, MonitorState
 from eneru.health_model import assess_health
+from eneru.shutdown.remote import RemoteShutdownResult
 
 
 _IMPOSSIBLE_PID = 999_999_999
@@ -1106,6 +1107,33 @@ class TestExecutorShutdown:
         assert calls == ["vms", "containers", "sync", "unmount", "remote"]
 
     @pytest.mark.unit
+    def test_local_phase_exception_does_not_skip_poweroff_callback(self, tmp_path):
+        callback = MagicMock()
+        group = _redundancy_group(
+            is_local=True,
+            containers=ContainersConfig(enabled=True),
+        )
+        ex = RedundancyGroupExecutor(
+            group,
+            base_config=_base_config(tmp_path=tmp_path),
+            local_shutdown_callback=callback,
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            calls = []
+            mp.setattr(ex, "_shutdown_vms", lambda: calls.append("vms"))
+            mp.setattr(
+                ex, "_shutdown_containers",
+                lambda: (_ for _ in ()).throw(RuntimeError("docker wedged")),
+            )
+            mp.setattr(ex, "_sync_filesystems", lambda: calls.append("sync"))
+            mp.setattr(ex, "_unmount_filesystems", lambda: calls.append("unmount"))
+            mp.setattr(ex, "_shutdown_remote_servers", lambda: calls.append("remote"))
+            assert ex.shutdown(reason="x") is True
+
+        assert calls == ["vms", "sync", "unmount", "remote"]
+        callback.assert_called_once_with("redundancy:rg")
+
+    @pytest.mark.unit
     def test_loopback_delegate_skips_local_phases_and_callback(self, tmp_path):
         """Containerized local redundancy groups delegate host work to SSH.
 
@@ -1147,11 +1175,61 @@ class TestExecutorShutdown:
             mp.setattr(ex, "_unmount_filesystems",
                        lambda: calls.append("unmount"))
             mp.setattr(ex, "_shutdown_remote_servers",
-                       lambda: calls.append("remote"))
+                       lambda: calls.append("remote") or [
+                           RemoteShutdownResult(
+                               server="host-loopback",
+                               host="127.0.0.1",
+                               completed=True,
+                               shutdown_sent=True,
+                           )
+                       ])
             assert ex.shutdown(reason="x") is True
 
         assert calls == ["remote"]
         callback.assert_not_called()
+
+    @pytest.mark.unit
+    def test_loopback_delegate_failure_rearms_and_reports_incomplete(self, tmp_path):
+        group = _redundancy_group(
+            is_local=True,
+            remote_servers=[RemoteServerConfig(
+                name="host-loopback",
+                enabled=True,
+                host="127.0.0.1",
+                user="root",
+                is_host_loopback=True,
+            )],
+        )
+        ex = RedundancyGroupExecutor(
+            group,
+            base_config=_base_config(dry_run=False, tmp_path=tmp_path),
+        )
+        ex.logger = MagicMock()
+        ex._notification_worker = MagicMock()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("eneru.cli._detect_runtime_context",
+                       lambda: "container (Docker)")
+            mp.setattr(ex, "_shutdown_remote_servers", lambda: [
+                RemoteShutdownResult(
+                    server="host-loopback",
+                    host="127.0.0.1",
+                    completed=True,
+                    shutdown_sent=False,
+                    error="ssh refused",
+                )
+            ])
+            assert ex.shutdown(reason="x") is False
+
+        assert not ex._shutdown_flag_path.exists()
+        assert ex._shutdown_done is False
+        logged = " ".join(call.args[0] for call in ex.logger.log.call_args_list)
+        assert "Delegated redundancy host poweroff failed" in logged
+        summary_calls = [
+            call for call in ex._notification_worker.send.call_args_list
+            if call.kwargs.get("category") == "shutdown_summary"
+        ]
+        assert len(summary_calls) == 1
 
     @pytest.mark.unit
     def test_logging_uses_prefix(self, tmp_path):
@@ -1336,12 +1414,9 @@ class TestLocalShutdownCallback:
         assert ex.shutdown(reason="quorum lost") is True
 
     @pytest.mark.unit
-    def test_callback_skipped_when_remote_shutdown_raises(self, tmp_path):
-        # The callback is positioned AFTER _shutdown_remote_servers
-        # inside the try-block, so an exception in remote shutdown
-        # short-circuits the callback. The coordinator's monitor-side
-        # path can still trigger local shutdown via its own lock; the
-        # redundancy callback is a redundant signal in that scenario.
+    def test_callback_still_fires_when_remote_shutdown_raises(self, tmp_path):
+        # Remote drain is a best-effort sink. If it breaks, the executor must
+        # still notify the coordinator to power off the local host.
         callback = MagicMock()
         group = _redundancy_group(name="rack-local", is_local=True)
         ex = RedundancyGroupExecutor(
@@ -1353,7 +1428,4 @@ class TestLocalShutdownCallback:
                 raise RuntimeError("ssh dead")
             mp.setattr(ex, "_shutdown_remote_servers", boom)
             ex.shutdown(reason="quorum lost")
-        # Exception was caught by the executor's try/except; the
-        # callback was NOT invoked because the raise happened before
-        # the callback line in the try-block.
-        callback.assert_not_called()
+        callback.assert_called_once_with("redundancy:rack-local")

--- a/tests/test_shutdown_containers.py
+++ b/tests/test_shutdown_containers.py
@@ -1,7 +1,9 @@
 """Tests for ContainerShutdownMixin (Docker/Podman + compose phase)."""
 
-import pytest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from eneru import (
     Config,
@@ -327,6 +329,18 @@ def test_compose_stacks_skips_missing_file(tmp_path):
 
 
 @pytest.mark.unit
+def test_compose_stacks_skips_blank_path(tmp_path: Path) -> None:
+    """A programmatic blank compose path is ignored before touching the FS."""
+    monitor = _make_container_monitor(
+        tmp_path,
+        compose_files=[ComposeFileConfig(path="")],
+    )
+    with patch("eneru.shutdown.containers.run_command") as mock_run:
+        monitor._shutdown_compose_stacks()
+    mock_run.assert_not_called()
+
+
+@pytest.mark.unit
 def test_compose_stacks_dry_run(tmp_path):
     """Dry-run logs the compose down but doesn't invoke it."""
     cf = tmp_path / "compose.yml"
@@ -375,6 +389,39 @@ def test_compose_stacks_skips_file_that_contains_current_container(tmp_path):
 
     with patch("eneru.shutdown.containers.run_command", side_effect=fake_run):
         monitor._shutdown_compose_stacks()
+
+
+@pytest.mark.unit
+def test_compose_stack_contains_self_false_when_ids_do_not_match(
+    tmp_path: Path,
+) -> None:
+    """A compose project with other containers must still be eligible for down."""
+    monitor = _make_container_monitor(tmp_path)
+    monitor._current_container_ids = lambda: {_SHORT_ID}
+    other = "fedcba987654"
+
+    with patch("eneru.shutdown.containers.run_command",
+               return_value=(0, f"{other}\n", "")):
+        assert monitor._compose_stack_contains_self("/stack.yml") is False
+
+
+@pytest.mark.unit
+def test_compose_stacks_nonzero_exit_logs_failure(tmp_path: Path) -> None:
+    """Compose down failures are logged and treated as best-effort."""
+    cf = tmp_path / "compose.yml"
+    cf.write_text("services: {}\n")
+    monitor = _make_container_monitor(
+        tmp_path,
+        compose_files=[ComposeFileConfig(path=str(cf))],
+    )
+    log = []
+    monitor._log_message = log.append
+
+    with patch("eneru.shutdown.containers.run_command",
+               return_value=(2, "", "bad compose")):
+        monitor._shutdown_compose_stacks()
+
+    assert any("compose down failed: bad compose" in line for line in log)
 
 
 @pytest.mark.unit
@@ -685,6 +732,30 @@ def test_rootless_podman_skips_users_with_unparseable_uid(tmp_path):
 
 
 @pytest.mark.unit
+def test_rootless_podman_skips_blank_and_incomplete_loginctl_rows(
+    tmp_path: Path,
+) -> None:
+    """Blank and UID-only rows from loginctl should not spawn sudo commands."""
+    monitor = _make_container_monitor(
+        tmp_path, runtime="podman", container_runtime="podman",
+        include_user_containers=True,
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[0] == "loginctl":
+            return (0, "\n1000\n1001 alice\n", "")
+        return (0, "", "")
+
+    with patch("eneru.shutdown.containers.run_command", side_effect=fake_run):
+        monitor._shutdown_podman_user_containers()
+
+    sudo_calls = [cmd for cmd in calls if cmd[:2] == ["sudo", "-u"]]
+    assert sudo_calls == [["sudo", "-u", "alice", "podman", "ps", "-q"]]
+
+
+@pytest.mark.unit
 def test_shutdown_containers_routes_to_rootless_when_include_user_containers_true(tmp_path):
     """The main shutdown path delegates to rootless handling only when
     runtime=podman AND include_user_containers=True."""
@@ -722,7 +793,9 @@ def test_shutdown_containers_skips_rootless_for_docker_runtime(tmp_path):
 
 
 @pytest.mark.unit
-def test_current_container_ids_handles_missing_cgroup_files(tmp_path):
+def test_current_container_ids_handles_missing_cgroup_files(
+    tmp_path: Path,
+) -> None:
     """No /proc/self/cgroup (bare metal) → must not raise; hostname-only fallback."""
     monitor = _make_container_monitor(tmp_path)
     # Restore the real method (the shared fixture stubs it for determinism).
@@ -734,7 +807,9 @@ def test_current_container_ids_handles_missing_cgroup_files(tmp_path):
 
 
 @pytest.mark.unit
-def test_current_container_ids_picks_up_hostname_when_it_looks_like_id(tmp_path):
+def test_current_container_ids_picks_up_hostname_when_it_looks_like_id(
+    tmp_path: Path,
+) -> None:
     """Docker sets hostname to the short container ID by default."""
     monitor = _make_container_monitor(tmp_path)
     # Restore the real method (the shared fixture stubs it for determinism).
@@ -743,6 +818,33 @@ def test_current_container_ids_picks_up_hostname_when_it_looks_like_id(tmp_path)
          patch("pathlib.Path.read_text", side_effect=OSError):
         ids = monitor._current_container_ids()
     assert ids == {_SHORT_ID}
+
+
+@pytest.mark.unit
+def test_current_container_ids_merges_cgroup_and_mountinfo_sources(
+    tmp_path: Path,
+) -> None:
+    """Self-detection should collect IDs from both /proc cgroup and mountinfo."""
+    monitor = _make_container_monitor(tmp_path)
+    del monitor._current_container_ids
+    mount_id = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+
+    def fake_read_text(path: Path, encoding: str = "utf-8") -> str:
+        path_text = str(path)
+        if path_text in {"/proc/self/cgroup", "/proc/1/cgroup"}:
+            return f"0::/system.slice/docker-{_FULL_ID}.scope\n"
+        if path_text == "/proc/self/mountinfo":
+            return (
+                f"431 430 0:73 /var/lib/docker/containers/{mount_id}/hosts "
+                "/etc/hosts rw - tmpfs tmpfs rw\n"
+            )
+        raise AssertionError(path_text)
+
+    with patch("eneru.shutdown.containers.socket.gethostname", return_value="host"), \
+         patch("pathlib.Path.read_text", fake_read_text):
+        ids = monitor._current_container_ids()
+
+    assert ids == {_FULL_ID, mount_id}
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_shutdown_vms.py
+++ b/tests/test_shutdown_vms.py
@@ -6,8 +6,10 @@ on timeout) is most reliably covered with focused unit tests against a
 patched ``eneru.shutdown.vms.run_command`` / ``command_exists``.
 """
 
-import pytest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from eneru import (
     Config,
@@ -125,6 +127,59 @@ def test_shutdown_vms_graceful_shutdown_completes_first_poll(tmp_path):
     assert ["virsh", "shutdown", "vm2"] in issued
     # No `destroy` should fire when graceful shutdown completes cleanly.
     assert not any(c[:2] == ["virsh", "destroy"] for c in issued)
+
+
+@pytest.mark.unit
+def test_shutdown_vms_logs_shutdown_stdout(tmp_path: Path) -> None:
+    """virsh shutdown stdout is relayed to the operator log."""
+    monitor = _make_vm_monitor(tmp_path, max_wait=10)
+    log = []
+    monitor._log_message = log.append
+    call_outputs = [
+        (0, "vm1\n", ""),              # initial list
+        (0, "Domain vm1 is being shutdown\n", ""),
+        (0, "", ""),                   # poll: stopped
+    ]
+
+    with patch("eneru.shutdown.vms.command_exists", return_value=True), \
+         patch("eneru.shutdown.vms.run_command", side_effect=call_outputs), \
+         patch("eneru.shutdown.vms.time.sleep"):
+        monitor._shutdown_vms()
+
+    assert any("Domain vm1 is being shutdown" in line for line in log)
+
+
+@pytest.mark.unit
+def test_shutdown_vms_retry_poll_failure_keeps_prior_remaining(
+    tmp_path: Path,
+) -> None:
+    """A failed wait-loop poll must not make stuck VMs look stopped."""
+    monitor = _make_vm_monitor(tmp_path, max_wait=1)
+    log = []
+    monitor._log_message = log.append
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["virsh", "list", "--name"]:
+            calls = getattr(fake_run, "calls", 0)
+            fake_run.calls = calls + 1
+            if calls == 0:
+                return (0, "vm1\n", "")
+            return (1, "", "libvirt down")
+        return (0, "", "")
+
+    with patch("eneru.shutdown.vms.command_exists", return_value=True), \
+         patch("eneru.shutdown.vms.run_command", side_effect=fake_run) as mock_run, \
+         patch("eneru.shutdown.vms.time.monotonic",
+               side_effect=[0.0, 0.0, 0.0, 1.1, 1.1]), \
+         patch("eneru.shutdown.vms.time.sleep"):
+        monitor._shutdown_vms()
+
+    assert any("keeping prior remaining VMs (1)" in line for line in log)
+    destroy_calls = [
+        c.args[0] for c in mock_run.call_args_list
+        if c.args[0][:2] == ["virsh", "destroy"]
+    ]
+    assert destroy_calls == [["virsh", "destroy", "vm1"]]
 
 
 @pytest.mark.unit

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,6 +17,7 @@ from eneru import (
 from eneru.stats import (
     BUCKET_5MIN,
     BUCKET_HOURLY,
+    DELIVERING_RECOVERY_GRACE_SECONDS,
     SAMPLE_FIELDS,
     SCHEMA_VERSION,
 )
@@ -70,6 +71,18 @@ class TestSchema:
     def test_open_failure_clears_connection(self, tmp_path):
         s = StatsStore(tmp_path / "broken.db")
         with patch.object(s, "_init_schema", side_effect=sqlite3.Error("bad schema")):
+            with pytest.raises(sqlite3.Error):
+                s.open()
+        assert s._conn is None
+
+    @pytest.mark.unit
+    def test_open_failure_on_delivery_recovery_clears_connection(self, tmp_path):
+        s = StatsStore(tmp_path / "broken-recovery.db")
+        with patch.object(
+            s,
+            "_recover_delivering_notifications",
+            side_effect=sqlite3.Error("recovery failed"),
+        ):
             with pytest.raises(sqlite3.Error):
                 s.open()
         assert s._conn is None
@@ -454,7 +467,8 @@ class TestSchemaMigration:
                 )
             }
             assert {"id", "ts", "body", "notify_type", "category",
-                    "status", "attempts", "sent_at", "cancel_reason"} <= cols
+                    "status", "attempts", "sent_at", "delivering_at",
+                    "cancel_reason"} <= cols
         finally:
             s.close()
 
@@ -903,6 +917,84 @@ class TestNotificationQueue:
         finally:
             s.close()
 
+    @pytest.mark.unit
+    def test_open_recovers_inflight_delivering_notifications(self, tmp_path):
+        path = tmp_path / "n.db"
+        s = StatsStore(path)
+        s.open()
+        try:
+            row_id = s.enqueue_notification("body", "warning", "lifecycle", ts=10)
+            stale_claim = int(time.time()) - DELIVERING_RECOVERY_GRACE_SECONDS - 1
+            s._conn.execute(
+                "UPDATE notifications SET status='delivering', delivering_at=? "
+                "WHERE id=?",
+                (stale_claim, row_id),
+            )
+            s._conn.commit()
+        finally:
+            s.close()
+
+        s = StatsStore(path)
+        s.open()
+        try:
+            row = s._conn.execute(
+                "SELECT status, sent_at FROM notifications WHERE id=?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            s.close()
+        assert row == ("pending", None)
+
+    @pytest.mark.unit
+    def test_open_does_not_recover_active_delivery_claims(self, tmp_path):
+        path = tmp_path / "n.db"
+        s = StatsStore(path)
+        s.open()
+        try:
+            row_id = s.enqueue_notification("body", "warning", "lifecycle", ts=10)
+            active_claim = int(time.time())
+            s._conn.execute(
+                "UPDATE notifications SET status='delivering', delivering_at=? "
+                "WHERE id=?",
+                (active_claim, row_id),
+            )
+            s._conn.commit()
+        finally:
+            s.close()
+
+        s = StatsStore(path)
+        s.open()
+        try:
+            row = s._conn.execute(
+                "SELECT status, delivering_at FROM notifications WHERE id=?",
+                (row_id,),
+            ).fetchone()
+        finally:
+            s.close()
+        assert row == ("delivering", active_claim)
+
+    @pytest.mark.unit
+    def test_recovery_failure_is_logged_and_propagated(self, tmp_path):
+        s = StatsStore(tmp_path / "n.db")
+        s.open()
+        original = s._conn
+
+        class _BoomConn:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def execute(self, *a, **k):
+                raise sqlite3.OperationalError("database is locked")
+
+        s._conn = _BoomConn()
+        try:
+            with patch.object(s, "_log_error_once") as log_error:
+                with pytest.raises(sqlite3.OperationalError):
+                    s._recover_delivering_notifications()
+            log_error.assert_called_once()
+        finally:
+            s._conn = original
+            s.close()
+
 
 class TestMetaKV:
     """Generic meta key/value store helpers (for last_seen_version etc)."""
@@ -1227,6 +1319,30 @@ class TestFlush:
                 assert len(store._buffer) == 1
         finally:
             store._conn = original
+
+    @pytest.mark.unit
+    def test_flush_failure_preserves_newer_samples_when_buffer_is_full(self, tmp_path):
+        store = StatsStore(tmp_path / "x.db", buffer_maxlen=2)
+        store.open()
+        store.buffer_sample(SAMPLE_UPS_DATA, ts=1)
+        store.buffer_sample(SAMPLE_UPS_DATA, ts=2)
+
+        class _BoomConn:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def executemany(self, *a, **k):
+                store.buffer_sample(SAMPLE_UPS_DATA, ts=3)
+                raise sqlite3.OperationalError("disk I/O error")
+
+        original = store._conn
+        store._conn = _BoomConn()
+        try:
+            assert store.flush() == 0
+            with store._buffer_lock:
+                assert [row[0] for row in store._buffer] == [2, 3]
+        finally:
+            store._conn = original
+            store.close()
 
 
 class TestAggregate:
@@ -1577,6 +1693,12 @@ class TestOpenReadonly:
                 roconn.execute("INSERT INTO samples (ts) VALUES (1)")
         finally:
             roconn.close()
+
+    @pytest.mark.unit
+    def test_returns_none_when_sqlite_open_fails(self, tmp_path):
+        path = tmp_path / "broken.db"
+        path.write_text("not sqlite")
+        assert StatsStore.open_readonly(path) is None
 
 
 # ===========================================================================

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -67,6 +67,14 @@ class TestSchema:
             s.close()
 
     @pytest.mark.unit
+    def test_open_failure_clears_connection(self, tmp_path):
+        s = StatsStore(tmp_path / "broken.db")
+        with patch.object(s, "_init_schema", side_effect=sqlite3.Error("bad schema")):
+            with pytest.raises(sqlite3.Error):
+                s.open()
+        assert s._conn is None
+
+    @pytest.mark.unit
     def test_open_creates_parent_directory(self, tmp_path):
         # Defensive: pip installs need this.
         path = tmp_path / "nested" / "stats" / "test.db"
@@ -128,6 +136,23 @@ class TestSchema:
         # Bounds writer waits when a slow TUI reader holds the lock.
         cur = store._conn.execute("PRAGMA busy_timeout")
         assert cur.fetchone()[0] == 500
+
+    @pytest.mark.unit
+    def test_safe_alter_only_swallows_duplicate_column(self, tmp_path):
+        class _Conn:
+            def __init__(self, exc):
+                self.exc = exc
+
+            def execute(self, *_a, **_kw):
+                raise self.exc
+
+        s = StatsStore(tmp_path / "x.db")
+        s._conn = _Conn(sqlite3.OperationalError("duplicate column name: status"))
+        s._safe_alter("samples", "status TEXT")
+
+        s._conn = _Conn(sqlite3.OperationalError("database is locked"))
+        with pytest.raises(sqlite3.OperationalError):
+            s._safe_alter("samples", "status TEXT")
 
     @pytest.mark.unit
     def test_busy_timeout_pragma_on_readonly_connection(self, store, tmp_path):
@@ -1198,6 +1223,8 @@ class TestFlush:
         try:
             # Must not raise; must return 0.
             assert store.flush() == 0
+            with store._buffer_lock:
+                assert len(store._buffer) == 1
         finally:
             store._conn = original
 

--- a/tests/test_status_readiness.py
+++ b/tests/test_status_readiness.py
@@ -218,6 +218,46 @@ class TestReadinessNativeInstall:
             payload = readiness(source)
         assert payload["ready"] is False
         assert any("local_vm_teardown" in r for r in payload["reasons"])
+
+    @pytest.mark.unit
+    def test_coordinator_scores_full_config_not_last_monitor_only(self):
+        full_config = Config(
+            ups_groups=[
+                UPSGroupConfig(
+                    ups=UPSConfig(name="UPS-A@host"),
+                    is_local=True,
+                    virtual_machines=VMConfig(enabled=True),
+                ),
+                UPSGroupConfig(
+                    ups=UPSConfig(name="UPS-B@host"),
+                    is_local=False,
+                ),
+            ],
+            local_shutdown=LocalShutdownConfig(enabled=False, trigger_on="none"),
+        )
+        monitor_a = MagicMock()
+        monitor_a.config = Config(
+            ups_groups=[full_config.ups_groups[0]],
+            local_shutdown=full_config.local_shutdown,
+        )
+        monitor_a.state.snapshot.return_value = _ok_snapshot()
+        monitor_b = MagicMock()
+        monitor_b.config = Config(
+            ups_groups=[full_config.ups_groups[1]],
+            local_shutdown=full_config.local_shutdown,
+        )
+        monitor_b.state.snapshot.return_value = _ok_snapshot()
+        source = MagicMock()
+        source.config = full_config
+        source._monitors = [monitor_a, monitor_b]
+
+        with patch("eneru.status._runtime_context_label",
+                   return_value="systemd service"), \
+             patch("eneru.status.command_exists", return_value=False):
+            payload = readiness(source)
+
+        assert payload["ready"] is False
+        assert any("local_vm_teardown" in r for r in payload["reasons"])
         vm_cap = next(
             c for c in payload["capabilities"] if c["id"] == "local_vm_teardown"
         )

--- a/tests/test_status_readiness.py
+++ b/tests/test_status_readiness.py
@@ -12,6 +12,7 @@ Required capabilities are derived from config. Achievability depends on:
   HEALTHY (or UNKNOWN — probes treated as advisory)
 """
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,6 +34,7 @@ from eneru.status import (
     live_remote_health,
     query_events,
     query_history,
+    redundancy_group_statuses,
 )
 
 
@@ -63,6 +65,18 @@ def _failed_snapshot():
     snap.connection_state = "FAILED"
     snap.last_update_time = 0
     return snap
+
+
+def _health_snapshot(*, status="OL", trigger_active=False):
+    state = MonitorState()
+    state.latest_status = status
+    state.latest_battery_charge = "100"
+    state.latest_runtime = "3600"
+    state.latest_update_time = time.time()
+    state.connection_state = "OK"
+    state.trigger_active = trigger_active
+    state.trigger_reason = "test trigger" if trigger_active else ""
+    return state.snapshot()
 
 
 def _bare_metal_config():
@@ -347,6 +361,44 @@ class TestReadinessNativeInstall:
         assert achievable is False
         assert "invalid local shutdown command" in reason
         exists.assert_not_called()
+
+
+class TestRedundancyGroupStatus:
+    """API/dashboard redundancy rollups must mirror evaluator quorum policy."""
+
+    @pytest.mark.unit
+    def test_healthy_count_uses_effective_group_health(self):
+        config = Config(
+            ups_groups=[
+                UPSGroupConfig(ups=UPSConfig(name="UPS-A@host")),
+                UPSGroupConfig(ups=UPSConfig(name="UPS-B@host")),
+            ],
+            redundancy_groups=[
+                RedundancyGroupConfig(
+                    name="rack",
+                    ups_sources=["UPS-A@host", "UPS-B@host"],
+                    min_healthy=2,
+                    degraded_counts_as="healthy",
+                    unknown_counts_as="critical",
+                ),
+            ],
+        )
+        monitor_a = MagicMock()
+        monitor_a.config = Config(ups_groups=[config.ups_groups[0]])
+        monitor_a.state.snapshot.return_value = _health_snapshot(status="OB DISCHRG")
+        monitor_b = MagicMock()
+        monitor_b.config = Config(ups_groups=[config.ups_groups[1]])
+        monitor_b.state.snapshot.return_value = _health_snapshot(status="OL")
+        source = MagicMock()
+        source._monitors = [monitor_a, monitor_b]
+        source._redundancy_remote_health_managers = []
+
+        rows = redundancy_group_statuses(source, config)
+
+        assert rows[0]["healthyCount"] == 2
+        assert rows[0]["quorumLost"] is False
+        assert rows[0]["members"][0]["health"] == "degraded"
+        assert rows[0]["members"][0]["effectiveHealth"] == "healthy"
 
 
 class TestReadinessContainerWithLoopback:

--- a/tests/test_status_readiness.py
+++ b/tests/test_status_readiness.py
@@ -216,6 +216,21 @@ class TestReadinessNativeInstall:
         assert any("nut_polling" in r for r in payload["reasons"])
 
     @pytest.mark.unit
+    def test_not_ready_when_source_config_missing_reports_no_config(self):
+        monitor = MagicMock()
+        monitor.config = _bare_metal_config()
+        monitor.state.snapshot.return_value = _ok_snapshot()
+        source = MagicMock()
+        source.config = None
+        source._monitors = [monitor]
+
+        payload = readiness(source)
+
+        assert payload["ready"] is False
+        assert payload["reason"] == "no config"
+        assert payload["ups"][0]["name"] == "UPS@host"
+
+    @pytest.mark.unit
     def test_not_ready_when_local_vm_configured_but_virsh_missing(self):
         config = Config(
             ups_groups=[UPSGroupConfig(
@@ -399,6 +414,35 @@ class TestRedundancyGroupStatus:
         assert rows[0]["quorumLost"] is False
         assert rows[0]["members"][0]["health"] == "degraded"
         assert rows[0]["members"][0]["effectiveHealth"] == "healthy"
+
+    @pytest.mark.unit
+    def test_quorum_lost_honors_live_evaluator_cold_start_hold(self):
+        group = RedundancyGroupConfig(
+            name="rack",
+            ups_sources=["UPS-A@host"],
+            min_healthy=1,
+            unknown_counts_as="critical",
+        )
+        config = Config(
+            ups_groups=[UPSGroupConfig(ups=UPSConfig(name="UPS-A@host"))],
+            redundancy_groups=[group],
+        )
+        monitor = MagicMock()
+        monitor.config = Config(ups_groups=[config.ups_groups[0]])
+        monitor.state.snapshot.return_value = MonitorState().snapshot()
+        evaluator = MagicMock()
+        evaluator._group = group
+        evaluator.cold_start_hold_active.return_value = True
+        source = MagicMock()
+        source._monitors = [monitor]
+        source._redundancy_remote_health_managers = []
+        source._evaluator_threads = [evaluator]
+
+        rows = redundancy_group_statuses(source, config)
+
+        assert rows[0]["healthyCount"] == 0
+        assert rows[0]["quorumLost"] is False
+        assert rows[0]["quorumDeferred"] is True
 
 
 class TestReadinessContainerWithLoopback:


### PR DESCRIPTION
## Summary
- fixes Critical redundancy shutdown audit findings
- fixes High shutdown, readiness, and NUT control audit findings
- Medium and Low/Nit follow-up commits will be pushed to this PR branch as requested

## Verification
- env PYTHONDONTWRITEBYTECODE=1 /tmp/eneru-venv/bin/python -m pytest -m unit -p no:cacheprovider tests/test_redundancy.py tests/test_monitor_core.py tests/test_multi_ups.py tests/test_nut_control.py tests/test_status_readiness.py

Audit-Model: GPT-5.5 xhigh effort

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the remaining RC11 audit findings by hardening shutdown, API auth, stats, and the dashboard. Adds an always‑open auth bootstrap, exposes server‑computed quorum health, and tightens polling, readiness, NUT control, and bulk event deletes.

- **Bug Fixes**
  - Shutdown: local phase errors no longer skip the coordinator poweroff callback; loopback actions bracket regular remotes; loopback host‑poweroff failures mark the run incomplete; shutdown flags are best‑effort (failed write/inspect/clear degrade to an in‑memory guard) and don’t block shutdown or allow duplicates.
  - Polling/readiness: missing `ups.status` treats the poll as failed; readiness evaluates the coordinator’s full config across all monitors.
  - NUT control: no passwords on argv; `upscmd`/`upsrw` run via a PTY and answer prompts securely; preserves NUT error text; rejects username‑only creds and validates CLI arg shapes.
  - API auth/safety: bound request‑body reads with a per‑socket timeout; always‑open `/api/v1/auth/state`; unreadable existing auth DB fails closed (auth stays enabled); auth auto‑activates once a user exists; password resets invalidate sessions.
  - Dashboard: uses server‑computed `healthyCount`/`quorumLost`; banner only warns when shutdown would trigger; exact event‑source filter and stable `(ts, source, id)` sort; CSP‑safe battery meter; bulk delete only removes rows when the server confirms all selected items; login bootstrap uses `/api/v1/auth/state`.
  - Stats/notifications: safer SQLite open/close/flush with requeue on failure and cleared state on failed open; readonly opens return `None` on corrupt DBs; writer thread is joined on stop; deferred stop notifications claim `delivering` until sent and stale claims are recovered; control‑audit write failures are logged.
  - VM/containers: relays `virsh shutdown` stdout; ignores blank compose paths; safer compose project self‑detection.

- **Dependencies**
  - Optional MQTT support: add `paho-mqtt>=2.0.0`.

<sup>Written for commit 94bc575641a9e9b140eb70e2e7963abcddc7f59f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public auth-state endpoint added; dashboard Sign-in timing now driven by its poll
  * Native battery meter and richer redundancy/quorum status displayed

* **Security Improvements**
  * NUT passwords no longer appear on process argv (sent only when prompted)
  * Sessions invalidated on user deletion or password reset; transient DB errors preserve valid sessions
  * Request-body read timeouts enforced

* **Bug Fixes**
  * Hardening for delivery, shutdown, and DB resilience

* **Documentation**
  * Expanded auth, config, observability, changelog, and testing docs

* **Chores**
  * Optional MQTT dependency noted; version bumped to rc11

* **Tests**
  * Expanded unit and e2e coverage across auth, control, redundancy, stats, and shutdown
<!-- end of auto-generated comment: release notes by coderabbit.ai -->