### PR TITLE
fix: Alpine/non-systemd machine-id (#70) and NUT name autodiscovery (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ docker run -d --name eneru \
   --api --api-bind 0.0.0.0 --api-port 9191
 ```
 
-Use `ghcr.io/m4r1k/eneru:testing` for pre-release builds. v5.5+ supports the OCI image for **both** remote-only and local-host deployments. For full local-host ownership from a container (host poweroff, VM teardown, container stop, filesystem unmount), add `--network host`, `-v /etc/machine-id:/etc/machine-id:ro`, and a loopback SSH key. See [Choose your install](https://eneru.readthedocs.io/latest/install-comparison/) for the three deployment profiles and [Migrate to container](https://eneru.readthedocs.io/latest/migrate-to-container/) for the step-by-step.
+Use `ghcr.io/m4r1k/eneru:testing` for pre-release builds. v5.5+ supports the OCI image for **both** remote-only and local-host deployments. For full local-host ownership from a container (host poweroff, VM teardown, container stop, filesystem unmount), add `--network host`, `-v /etc/machine-id:/etc/machine-id:ro`, and a loopback SSH key. Hosts without systemd (Alpine, musl) have no `/etc/machine-id` — use a [marker file](https://eneru.readthedocs.io/latest/containers-kubernetes/#no-systemd-no-machine-id-alpine-consumer-hosts) instead. See [Choose your install](https://eneru.readthedocs.io/latest/install-comparison/) for the three deployment profiles and [Migrate to container](https://eneru.readthedocs.io/latest/migrate-to-container/) for the step-by-step.
 
 **PyPI:**
 ```bash

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [6.1.0-rc1] - 2026-06-09
+
+### Added
+
+- **NUT name autodiscovery (issue #71).** When a poll can't reach the configured
+  UPS, Eneru now runs `upsc -l <host>` to list the UPS names the server actually
+  exposes and logs them. If exactly one UPS exists and the configured name is not
+  it (the classic case of a NUT *login username* placed where the UPS *device
+  name* belongs), Eneru self-heals for the session and tells you to fix
+  `ups.name`. With multiple UPSes it lists the choices instead of guessing. The
+  operator-configured name, display, and on-disk state are never mutated.
+
+### Changed
+
+- **`expected_host_identity` auto-populates from any `cat /absolute/path`
+  (issue #70).** Previously the container-side identity read was hardcoded to
+  `/etc/machine-id`, so marker-file setups had to duplicate the value or mount
+  over `/etc/machine-id`. Now a simple `host_identity_command: "cat /path"` reads
+  the same path locally and fills in the expected value automatically. Non-`cat`
+  commands still require an explicit `expected_host_identity`.
+- **Quieter NUT polling.** `upsc` runs with `NUT_QUIET_INIT_SSL=true` and the
+  benign `Init SSL without certificate database` line is filtered from failure
+  output, so real errors stay visible.
+- **Docs for non-systemd / no-`machine-id` hosts.** New end-to-end marker-file
+  recipe for Alpine and other consumer/non-systemd setups, linked from the
+  install, migration, and troubleshooting pages. deb and rpm remain the published
+  packages; the OCI image stays a first-class citizen.
+
 ## [6.0.0] - 2026-06-04
 
 v6.0 turns Eneru from a shutdown daemon with observability into an operator tool

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -479,8 +479,8 @@ mounts:
 | `parallel` | unset | Legacy mode. `false` runs before the default parallel batch. Mutually exclusive with `shutdown_order` |
 | `shutdown_safety_margin` | `60` | Extra wait budget for parallel server threads |
 | `is_host_loopback` | `false` | **v5.5.** Mark this entry as the host-loopback delegate for the containerized OCI deployment. See [Remote servers](remote-servers.md#v55-host-loopback-delegate-container-only) |
-| `host_identity_command` | `cat /etc/machine-id` | **v5.5.** Safe SSH probe used to verify the loopback target is really this container's host. Only used when `is_host_loopback: true` |
-| `expected_host_identity` | auto-populated from `/etc/machine-id` inside the container | **v5.5.** Expected output of `host_identity_command`. Auto-populated at startup so operators bind-mount `/etc/machine-id` instead of supplying a value |
+| `host_identity_command` | `cat /etc/machine-id` | **v5.5.** Safe SSH probe used to verify the loopback target is really this container's host. Only used when `is_host_loopback: true`. On hosts without `/etc/machine-id` (Alpine, non-systemd), point it at a marker file — see [Containers and Kubernetes](containers-kubernetes.md#no-systemd-no-machine-id-alpine-consumer-hosts) |
+| `expected_host_identity` | auto-populated from the `host_identity_command` path inside the container | **v5.5** (extended in **6.1**). Expected output of `host_identity_command`. When the command is a simple `cat /absolute/path` (the default `/etc/machine-id`, or any marker file), Eneru reads that same path locally and auto-populates this at startup — so you bind-mount the file instead of supplying a value. For non-`cat` commands, set it explicitly |
 
 ### Pre-shutdown action templates
 

--- a/docs/containers-kubernetes.md
+++ b/docs/containers-kubernetes.md
@@ -218,6 +218,49 @@ remote_servers:
     expected_host_identity: "host-rack-3a-2026-05"   # any stable string
 ```
 
+### No systemd / no machine-id (Alpine, consumer hosts)
+
+`/etc/machine-id` is created by systemd (or `dbus`) and is the expected,
+enterprise-tested baseline. Some hosts don't have it — most commonly
+**Alpine Linux** and other non-systemd / musl setups. There, the default
+`cat /etc/machine-id` probe has nothing to read, and the loopback fails
+closed. The fix is a **stable marker file** you create once and bind-mount
+at the **same path** on both sides.
+
+1. On the host, generate a stable identity (run once; it persists):
+
+   ```sh
+   cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/eneru-machine-id
+   ```
+
+2. Bind-mount that file read-only into the container **at the same path**,
+   and point the probe at it:
+
+   ```sh
+   docker run ... \
+     -v /etc/eneru-machine-id:/etc/eneru-machine-id:ro \
+     ...
+   ```
+
+   ```yaml
+   remote_servers:
+     - is_host_loopback: true
+       host_identity_command: "cat /etc/eneru-machine-id"
+   ```
+
+That's all. Because `host_identity_command` is a simple `cat /absolute/path`,
+Eneru reads the **same path locally** inside the container and auto-populates
+`expected_host_identity` for you — no need to copy the value into YAML. The
+SSH probe reads the host's copy, the local read sees the bind-mounted copy,
+the two match, and the guard passes. (If you use a non-`cat` command Eneru
+cannot infer the expected output, so set `expected_host_identity` explicitly,
+as in the marker-file example above.)
+
+> The same `:ro` rule applies as for `/etc/machine-id`: never add `:Z`/`:z`
+> to a host file other services also read. A file you created solely for
+> Eneru (like `/etc/eneru-machine-id`) is safe to relabel, but plain `:ro`
+> is all you need.
+
 ## Network mode decision table
 
 | Container network mode | Loopback `host:` value | Notes |

--- a/docs/install-comparison.md
+++ b/docs/install-comparison.md
@@ -95,6 +95,8 @@ container):
   the container generates its own random machine-id, the identity
   probe fails on the first health check, the loopback is marked
   FAILED, and `/ready` returns 503. **Fails closed by construction.**
+  No `/etc/machine-id` (Alpine, non-systemd)? Use a marker file —
+  [No systemd / no machine-id](containers-kubernetes.md#no-systemd-no-machine-id-alpine-consumer-hosts).
 - `-v /srv/eneru/ssh:/var/lib/eneru/ssh:ro` — SSH private key for the
   loopback. Defaults to `/var/lib/eneru/ssh/id_loopback` inside the
   container; the host's `authorized_keys` for the matching user holds

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -13,7 +13,9 @@ config and stats history carry forward.
 - A working NUT server (`upsc <UPS@host>` must answer).
 - `/etc/machine-id` populated on the host. Most systemd distros put
   one there at first boot; if `cat /etc/machine-id` returns empty,
-  run `sudo systemd-machine-id-setup`.
+  run `sudo systemd-machine-id-setup`. No systemd (Alpine, musl)? There
+  is no `/etc/machine-id` — use a marker file instead, see
+  [No systemd / no machine-id](containers-kubernetes.md#no-systemd-no-machine-id-alpine-consumer-hosts).
 - Root access on the host long enough to authorize the loopback SSH key
   and create the writable directories below.
 

--- a/docs/migrate-to-container.md
+++ b/docs/migrate-to-container.md
@@ -39,7 +39,10 @@ Before swapping in the container, on the **host** that will run it:
    ```bash
    cat /etc/machine-id
    ```
-   If empty, run `systemd-machine-id-setup`.
+   If empty, run `systemd-machine-id-setup`. On hosts without systemd
+   (Alpine, other musl/non-systemd setups) there is no `/etc/machine-id`;
+   use a marker file instead — see
+   [No systemd / no machine-id](containers-kubernetes.md#no-systemd-no-machine-id-alpine-consumer-hosts).
 
 4. Notification URLs, NUT credentials, and everything else from your
    YAML carry over unchanged. They live in the config file you'll

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -329,6 +329,7 @@ fall into one of these:
 | Symptom in `last_error` | Cause | Fix |
 |---|---|---|
 | `host identity mismatch: probe returned 'X' but expected 'Y'` | `/etc/machine-id` not bind-mounted from host | Add `-v /etc/machine-id:/etc/machine-id:ro` to the `docker run` command (plain `:ro` only — never `:Z` or `:z`; the relabel persists on disk and breaks dbus-broker on the next host reboot). |
+| `host identity unknown: container-side … was not readable at startup` | Host has no `/etc/machine-id` (Alpine / non-systemd), so there is nothing to read or mount | Create a stable marker file and point `host_identity_command` at it. See [No systemd / no machine-id](containers-kubernetes.md#no-systemd-no-machine-id-alpine-consumer-hosts). |
 | `authorized_keys command=` | Forced-command SSH key rewrites Eneru's identity probe and generated shutdown actions | Remove `command="..."` from the loopback key. Use the root default or `use_sudo: true` with sudoers. |
 | `Permission denied (publickey,password)` | Loopback SSH key not authorized on the host | The container's `/var/lib/eneru/ssh/id_loopback` public half must be in the host user's `authorized_keys`. See [Containers and Kubernetes](containers-kubernetes.md) for the walkthrough. |
 | `connection refused` | No `sshd` on `127.0.0.1`, OR container isn't on `network_mode: host` | Either start `sshd` on the host, or switch to `--network host`. For bridge networking, override the loopback `host` to the host's bridge IP (`172.17.0.1` on Linux default Docker bridge). |

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -961,7 +961,7 @@ class UPSGroupMonitor(
             return False
 
     def _run_upsc(self, args: List[str], *, full_poll: bool) -> Tuple[int, str, str]:
-        cmd = ["upsc", self._poll_target] + list(args)
+        cmd = ["upsc", self._poll_target, *args]
         started = time.monotonic()
         # NUT's NSS-backed libupsclient can emit "Init SSL without certificate
         # database" on stderr even for plain read-only polling. Suppress that

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -175,6 +175,15 @@ class UPSGroupMonitor(
         self._slow_nut_poll_streak = 0
         self._slow_nut_poll_notified = False
 
+        # Effective target passed to ``upsc`` (``upsname@host:port``). Normally
+        # identical to ``config.ups.name``, but the autodiscovery diagnostic may
+        # self-heal it to the real UPS name when the configured one is wrong
+        # (issue #71). Only ``_run_upsc`` reads this; every display/log/state
+        # path keeps using ``config.ups.name`` so operator-facing identity and
+        # on-disk state never fragment.
+        self._poll_target = self.config.ups.name
+        self._ups_name_autocorrected = False
+
     def _start_stats(self):
         """Open the per-UPS stats DB (if not already open) and start the
         background writer.
@@ -952,7 +961,7 @@ class UPSGroupMonitor(
             return False
 
     def _run_upsc(self, args: List[str], *, full_poll: bool) -> Tuple[int, str, str]:
-        cmd = ["upsc", self.config.ups.name] + list(args)
+        cmd = ["upsc", self._poll_target] + list(args)
         started = time.monotonic()
         # NUT's NSS-backed libupsclient can emit "Init SSL without certificate
         # database" on stderr even for plain read-only polling. Suppress that
@@ -977,6 +986,110 @@ class UPSGroupMonitor(
         if parts:
             return " | ".join(parts)
         return (stderr or stdout or "upsc exited without output").strip()
+
+    @staticmethod
+    def _parse_nut_host(target: str) -> str:
+        """Extract the ``host[:port]`` part of an ``upsname@host:port`` target.
+
+        A NUT UPS name cannot contain ``@``, so the first ``@`` separates the
+        UPS name from the host spec. Returns ``localhost`` when no host is
+        given (bare ``upsname``), matching NUT's own default.
+        """
+        if "@" in (target or ""):
+            host = target.split("@", 1)[1].strip()
+            return host or "localhost"
+        return "localhost"
+
+    @staticmethod
+    def _parse_nut_name(target: str) -> str:
+        """Extract the UPS-name part (before ``@``) of a poll target."""
+        return (target or "").split("@", 1)[0].strip()
+
+    def _discover_ups_names(self, host: str) -> List[str]:
+        """List the UPS names a NUT server actually exposes via ``upsc -l``.
+
+        Called directly (not through ``_run_upsc``, which would prepend the
+        configured UPS name). Returns the discovered names, or an empty list if
+        the server is unreachable / returns nothing. SSL-init noise is silenced
+        and connection/SSL banner lines are filtered out so only bare UPS names
+        (no whitespace, no ``:``) survive.
+        """
+        exit_code, stdout, _ = run_command(
+            ["upsc", "-l", host],
+            timeout=10,
+            env_overrides={"NUT_QUIET_INIT_SSL": "true"},
+        )
+        if exit_code != 0:
+            return []
+        names = []
+        for line in (stdout or "").splitlines():
+            token = line.strip()
+            # Real UPS names are ups.conf section names: no whitespace, no
+            # colon. This drops banners like "Connected to NUT server X in SSL"
+            # and "Certificate verification is disabled".
+            if not token or " " in token or "\t" in token or ":" in token:
+                continue
+            if token not in names:
+                names.append(token)
+        return names
+
+    def _run_ups_name_diagnostic(self, error_msg: str) -> None:
+        """On a hard NUT connection failure, help the operator (issue #71).
+
+        The benign ``Init SSL without certificate database`` line used to mask
+        the real cause, which is most often a wrong ``ups.name`` — e.g. a NUT
+        login *username* placed where the UPS *device name* belongs. We probe
+        the server with ``upsc -l`` to list the real names and:
+          * self-heal the poll target when exactly one UPS exists and the
+            configured name is not it (unambiguous), or
+          * tell the operator which names are available otherwise.
+        """
+        host = self._parse_nut_host(self._poll_target)
+        configured_name = self._parse_nut_name(self._poll_target)
+        names = self._discover_ups_names(host)
+
+        if not names:
+            self._log_message(
+                f"🔎  Could not list UPS names on {host} (server unreachable, "
+                f"access-restricted, or network issue), so the configured name "
+                f"'{configured_name}' could not be verified. Check that NUT "
+                f"(upsd) is running and reachable there."
+            )
+            return
+
+        # Educational note for the classic username-vs-UPS-name mix-up.
+        name_hint = (
+            "Note: the value before '@' in ups.name must be the UPS device "
+            "name from the server's ups.conf, not a NUT login username. If you "
+            "meant it as a control credential, set nut_control.username instead."
+        )
+
+        if configured_name in names:
+            self._log_message(
+                f"🔎  UPS '{configured_name}' exists on {host} "
+                f"(available: {', '.join(names)}), so this failure is likely "
+                f"access control (ERR ACCESS-DENIED) or transient, not the "
+                f"UPS name. Last error: {error_msg}"
+            )
+            return
+
+        if len(names) == 1 and not self._ups_name_autocorrected:
+            discovered = names[0]
+            self._poll_target = f"{discovered}@{host}"
+            self._ups_name_autocorrected = True
+            self._log_message(
+                f"⚠️  UPS '{configured_name}' was not found on {host}; the only "
+                f"UPS there is '{discovered}'. Auto-correcting this session to "
+                f"poll '{self._poll_target}'. Please fix ups.name in your "
+                f"config so this is not needed on restart. {name_hint}"
+            )
+            return
+
+        self._log_message(
+            f"⚠️  UPS '{configured_name}' was not found on {host}. Available "
+            f"UPS names: {', '.join(names)}. Set ups.name to one of these "
+            f"(as '<name>@{host}'). {name_hint}"
+        )
 
     def _record_upsc_latency(self, elapsed: float, cmd: List[str], *, full_poll: bool):
         now = time.time()
@@ -1994,6 +2107,11 @@ class UPSGroupMonitor(
                             f"(Attempt {self.state.connection_error_count}/"
                             f"{tolerance}). Output: {error_msg}"
                         )
+                    # Diagnose once per failure episode (the counter resets to 0
+                    # on the next successful poll): list the server's real UPS
+                    # names and self-heal an obviously-wrong ups.name (issue #71).
+                    if self.state.connection_error_count == 1:
+                        self._run_ups_name_diagnostic(error_msg)
                     self.state.stale_data_count = 0
                     # Off-battery: first hard error feeds the grace period as
                     # before. On-battery (H3): require max_stale_data_tolerance

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -915,7 +915,7 @@ class UPSGroupMonitor(
         exit_code, stdout, stderr = self._run_upsc([], full_poll=True)
 
         if exit_code != 0:
-            return False, {}, stderr
+            return False, {}, self._format_upsc_error(stdout, stderr)
 
         if "Data stale" in stdout or "Data stale" in stderr:
             return False, {}, "Data stale"
@@ -954,10 +954,29 @@ class UPSGroupMonitor(
     def _run_upsc(self, args: List[str], *, full_poll: bool) -> Tuple[int, str, str]:
         cmd = ["upsc", self.config.ups.name] + list(args)
         started = time.monotonic()
-        result = run_command(cmd)
+        # NUT's NSS-backed libupsclient can emit "Init SSL without certificate
+        # database" on stderr even for plain read-only polling. Suppress that
+        # upstream noise so real connection/UPS-name errors stay visible.
+        result = run_command(cmd, env_overrides={"NUT_QUIET_INIT_SSL": "true"})
         elapsed = time.monotonic() - started
         self._record_upsc_latency(elapsed, cmd, full_poll=full_poll)
         return result
+
+    def _format_upsc_error(self, stdout: str, stderr: str) -> str:
+        """Return an operator-facing error from a failed ``upsc`` call."""
+        parts = []
+        for stream in (stderr, stdout):
+            for line in (stream or "").splitlines():
+                text = line.strip()
+                if not text:
+                    continue
+                if text == "Init SSL without certificate database":
+                    continue
+                if text not in parts:
+                    parts.append(text)
+        if parts:
+            return " | ".join(parts)
+        return (stderr or stdout or "upsc exited without output").strip()
 
     def _record_upsc_latency(self, elapsed: float, cmd: List[str], *, full_poll: bool):
         now = time.time()

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -985,7 +985,9 @@ class UPSGroupMonitor(
                     parts.append(text)
         if parts:
             return " | ".join(parts)
-        return (stderr or stdout or "upsc exited without output").strip()
+        # All output was blank or filtered noise (e.g. only the SSL-init line):
+        # do not resurface what we just stripped.
+        return "upsc exited without output"
 
     @staticmethod
     def _parse_nut_host(target: str) -> str:
@@ -1024,9 +1026,11 @@ class UPSGroupMonitor(
         names = []
         for line in (stdout or "").splitlines():
             token = line.strip()
-            # Real UPS names are ups.conf section names: no whitespace, no
-            # colon. This drops banners like "Connected to NUT server X in SSL"
-            # and "Certificate verification is disabled".
+            # `upsc -l` prints bare UPS names (ups.conf section names) one per
+            # line on stdout; SSL/connection banners go to stderr and are
+            # already discarded above. This filter is defensive against any
+            # unexpected stdout decoration: real names never contain whitespace
+            # or a colon, so dropping such lines cannot lose a valid name.
             if not token or " " in token or "\t" in token or ":" in token:
                 continue
             if token not in names:
@@ -1080,8 +1084,9 @@ class UPSGroupMonitor(
             self._log_message(
                 f"⚠️  UPS '{configured_name}' was not found on {host}; the only "
                 f"UPS there is '{discovered}'. Auto-correcting this session to "
-                f"poll '{self._poll_target}'. Please fix ups.name in your "
-                f"config so this is not needed on restart. {name_hint}"
+                f"poll '{self._poll_target}'. Please fix ups.name in your config "
+                f"so this is not needed on restart (NUT control commands keep "
+                f"using the configured name until then). {name_hint}"
             )
             return
 
@@ -2110,7 +2115,12 @@ class UPSGroupMonitor(
                     # Diagnose once per failure episode (the counter resets to 0
                     # on the next successful poll): list the server's real UPS
                     # names and self-heal an obviously-wrong ups.name (issue #71).
-                    if self.state.connection_error_count == 1:
+                    # Skip while On Battery: the discovery subprocess (up to 10s)
+                    # must never sit in front of an FSB emergency shutdown, and a
+                    # wrong ups.name could not have produced an "OB" status in the
+                    # first place, so there is nothing to discover on that path.
+                    if (self.state.connection_error_count == 1
+                            and "OB" not in self.state.previous_status):
                         self._run_ups_name_diagnostic(error_msg)
                     self.state.stale_data_count = 0
                     # Off-battery: first hard error feeds the grace period as

--- a/src/eneru/remote_health.py
+++ b/src/eneru/remote_health.py
@@ -256,19 +256,6 @@ def _read_identity_from_path(path: Path) -> Optional[str]:
         return None
 
 
-def _read_container_machine_id() -> Optional[str]:
-    """Read the container-side /etc/machine-id, or None if unavailable.
-
-    Used to auto-populate ``RemoteServerConfig.expected_host_identity`` on
-    loopback entries. When the operator bind-mounts the host's machine-id
-    at the same path, this value matches what the host's SSH probe will
-    return — the identity guard passes. When the bind-mount is missing,
-    this returns the container's own (random) machine-id and the guard
-    fails closed on the first probe.
-    """
-    return _read_identity_from_path(Path("/etc/machine-id"))
-
-
 def _read_expected_identity_for_command(command: str) -> Optional[str]:
     """Auto-populate expected identity for simple local ``cat /path`` probes.
 

--- a/src/eneru/remote_health.py
+++ b/src/eneru/remote_health.py
@@ -5,6 +5,7 @@ and never execute configured pre-shutdown or final shutdown commands.
 """
 
 import json
+import shlex
 import time
 import threading
 from dataclasses import dataclass, asdict
@@ -203,24 +204,56 @@ def run_loopback_identity_probe(
         ), latency_ms
     expected = (server.expected_host_identity or "").strip()
     if not expected:
+        source = _describe_identity_source(server.host_identity_command)
         return False, (
-            "host identity unknown: container-side /etc/machine-id was not "
+            f"host identity unknown: container-side {source} was not "
             "readable at startup and no explicit expected_host_identity was "
-            "configured. Bind-mount the host's /etc/machine-id read-only "
-            "(-v /etc/machine-id:/etc/machine-id:ro for Docker; hostPath "
-            "volume for Kubernetes). If /etc/machine-id is empty on the "
-            "host, initialize it with systemd-machine-id-setup."
+            "configured. Bind-mount the host identity file read-only at the "
+            "same container path or set expected_host_identity explicitly. "
+            "If using the default /etc/machine-id path and it is empty on "
+            "the host, initialize it with systemd-machine-id-setup."
         ), latency_ms
     if actual != expected:
+        source = _describe_identity_source(server.host_identity_command)
         return False, (
             f"host identity mismatch: probe returned {actual!r} but expected "
-            f"{expected!r}. Most likely cause: /etc/machine-id is NOT "
-            "bind-mounted from the host into the container, so Eneru sees a "
-            "different machine-id locally than what the loopback SSH target "
-            "reports. Fix: bind-mount /etc/machine-id from the host "
-            "(-v /etc/machine-id:/etc/machine-id:ro for Docker)."
+            f"{expected!r}. Most likely cause: {source} is NOT bind-mounted "
+            "from the host into the container, so Eneru sees a different "
+            "identity locally than what the loopback SSH target reports. "
+            "Fix: bind-mount the same host identity file read-only into the "
+            "container or set expected_host_identity explicitly."
         ), latency_ms
     return True, "", latency_ms
+
+
+def _identity_path_from_cat_command(command: str) -> Optional[Path]:
+    """Return the local path for simple ``cat /path`` identity probes."""
+    try:
+        parts = shlex.split(command or "")
+    except ValueError:
+        return None
+    if len(parts) != 2:
+        return None
+    if Path(parts[0]).name != "cat":
+        return None
+    path = Path(parts[1])
+    if not path.is_absolute():
+        return None
+    return path
+
+
+def _describe_identity_source(command: str) -> str:
+    path = _identity_path_from_cat_command(command)
+    if path is not None:
+        return str(path)
+    return "the configured host_identity_command output"
+
+
+def _read_identity_from_path(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
 
 
 def _read_container_machine_id() -> Optional[str]:
@@ -233,10 +266,23 @@ def _read_container_machine_id() -> Optional[str]:
     this returns the container's own (random) machine-id and the guard
     fails closed on the first probe.
     """
-    try:
-        return Path("/etc/machine-id").read_text(encoding="utf-8").strip() or None
-    except OSError:
+    return _read_identity_from_path(Path("/etc/machine-id"))
+
+
+def _read_expected_identity_for_command(command: str) -> Optional[str]:
+    """Auto-populate expected identity for simple local ``cat /path`` probes.
+
+    The loopback identity check compares what SSH reports from the host with
+    what the container can read locally. For the default ``cat /etc/machine-id``
+    and for Alpine-style marker files mounted at the same path, reading the
+    same local path gives the expected value without asking the operator to
+    duplicate it in YAML. Non-``cat /path`` commands still require an explicit
+    ``expected_host_identity`` because Eneru cannot safely infer their output.
+    """
+    path = _identity_path_from_cat_command(command)
+    if path is None:
         return None
+    return _read_identity_from_path(path)
 
 
 class RemoteHealthManager:
@@ -288,7 +334,9 @@ class RemoteHealthManager:
         # clear bind-mount hint.
         for server in self.servers:
             if server.is_host_loopback is True and not server.expected_host_identity:
-                server.expected_host_identity = _read_container_machine_id()
+                server.expected_host_identity = _read_expected_identity_for_command(
+                    server.host_identity_command
+                )
         self._statuses: Dict[str, RemoteHealthStatus] = {
             self._key(server): RemoteHealthStatus(
                 group=group_label,
@@ -383,12 +431,14 @@ class RemoteHealthManager:
 
         probe = self._validated_probe_command
         if server.is_host_loopback is True and not (server.expected_host_identity or "").strip():
+            source = _describe_identity_source(server.host_identity_command)
             success, error, latency_ms = False, (
-                "host identity unknown: container-side /etc/machine-id was not "
+                f"host identity unknown: container-side {source} was not "
                 "readable at startup and no explicit expected_host_identity was "
-                "configured. Bind-mount the host's /etc/machine-id read-only. "
-                "If /etc/machine-id is empty on the host, initialize it with "
-                "systemd-machine-id-setup."
+                "configured. Bind-mount the host identity file read-only at the "
+                "same container path or set expected_host_identity explicitly. "
+                "If using the default /etc/machine-id path and it is empty on "
+                "the host, initialize it with systemd-machine-id-setup."
             ), 0
         elif probe is None:
             success, error, latency_ms = False, "unsafe probe command rejected", 0

--- a/src/eneru/utils.py
+++ b/src/eneru/utils.py
@@ -3,7 +3,7 @@
 import math
 import subprocess
 import os
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def is_numeric(value: Any) -> bool:
@@ -32,7 +32,8 @@ def is_numeric(value: Any) -> bool:
 def run_command(
     cmd: List[str],
     timeout: int = 30,
-    capture_output: bool = True
+    capture_output: bool = True,
+    env_overrides: Optional[Dict[str, str]] = None,
 ) -> Tuple[int, str, str]:
     """Run a shell command and return (exit_code, stdout, stderr)."""
     # A None timeout means "wait forever" to subprocess.run. No caller wants
@@ -47,7 +48,7 @@ def run_command(
             capture_output=capture_output,
             text=True,
             timeout=timeout,
-            env={**os.environ, 'LC_NUMERIC': 'C'}
+            env={**os.environ, 'LC_NUMERIC': 'C', **(env_overrides or {})}
         )
         # subprocess.run returns stdout/stderr=None when capture_output
         # is False; normalize to empty strings so callers can always

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.0.0"
+__version__ = "6.1.0-rc1"

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -3253,23 +3253,42 @@ class TestNutNameAutodiscovery:
         assert monitor._parse_nut_name("UPS") == "UPS"
 
     @pytest.mark.unit
-    def test_discover_filters_ssl_and_banner_lines(self, tmp_path):
-        """Only bare ups.conf section names survive; banners are dropped."""
+    def test_discover_returns_names_with_banners_on_stderr(self, tmp_path):
+        """Real NUT prints names on stdout; SSL/connection banners go to
+        stderr, which is discarded."""
         monitor = make_monitor(tmp_path)
-        stdout = (
+        stderr = (
+            "Init SSL without certificate database\n"
             "Connected to NUT server 192.168.178.11 in SSL\n"
             "Certificate verification is disabled\n"
-            "UPS\n"
         )
         with patch("eneru.monitor.run_command",
-                   return_value=(0, stdout, "")) as run:
+                   return_value=(0, "UPS\nUPS2\n", stderr)) as run:
             names = monitor._discover_ups_names("192.168.178.11")
-        assert names == ["UPS"]
+        assert names == ["UPS", "UPS2"]
         run.assert_called_once_with(
             ["upsc", "-l", "192.168.178.11"],
             timeout=10,
             env_overrides={"NUT_QUIET_INIT_SSL": "true"},
         )
+
+    @pytest.mark.unit
+    def test_discover_filter_is_defensive_against_stdout_decoration(self, tmp_path):
+        """Defense-in-depth: blank, whitespace, and colon lines on stdout are
+        dropped, and duplicate names are de-duplicated."""
+        monitor = make_monitor(tmp_path)
+        stdout = (
+            "\n"                        # blank -> dropped
+            "ups-a\n"
+            "Connected to X in SSL\n"   # internal space -> dropped
+            "two\twords\n"             # internal tab -> dropped
+            "key: value\n"             # colon -> dropped
+            "ups-a\n"                   # duplicate -> de-duplicated
+            "ups-b\n"
+        )
+        with patch("eneru.monitor.run_command", return_value=(0, stdout, "")):
+            names = monitor._discover_ups_names("h")
+        assert names == ["ups-a", "ups-b"]
 
     @pytest.mark.unit
     def test_discover_returns_empty_on_failure(self, tmp_path):
@@ -3376,6 +3395,47 @@ class TestNutNameAutodiscovery:
         with patch.object(monitor, "_run_ups_name_diagnostic") as diag:
             _run_one_iteration(monitor, (False, {}, "Network error"))
         diag.assert_not_called()
+
+    @pytest.mark.unit
+    def test_diagnostic_skipped_on_fsb_path_while_on_battery(self, tmp_path):
+        """The up-to-10s discovery probe must never sit in front of an FSB:
+        on battery with tolerance=1, the shutdown fires and discovery is
+        skipped entirely."""
+        monitor = make_monitor(tmp_path)
+        monitor._in_redundancy_group = False
+        monitor.config.ups.max_stale_data_tolerance = 1
+        monitor.state.previous_status = "OB DISCHRG"
+        monitor.state.connection_state = "OK"
+        monitor.state.connection_error_count = 0
+        with patch.object(monitor, "_run_ups_name_diagnostic") as diag, \
+             patch.object(monitor, "_execute_shutdown_sequence") as exec_seq:
+            _run_one_iteration(monitor, (False, {}, "Network error"))
+        diag.assert_not_called()
+        exec_seq.assert_called_once()
+
+
+class TestFormatUpscError:
+    """`_format_upsc_error` joins real error lines from both streams, drops the
+    benign SSL-init noise, de-duplicates, and never resurfaces filtered noise."""
+
+    @pytest.mark.unit
+    def test_filters_blank_dedups_and_joins_both_streams(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        out = monitor._format_upsc_error(
+            stdout="Error: Unknown UPS\n\nError: Unknown UPS\n",   # blank + dup
+            stderr="Init SSL without certificate database\n"
+                   "Error: Driver not connected\n",
+        )
+        # stderr is scanned first; the SSL line is dropped; the duplicate
+        # stdout line is collapsed.
+        assert out == "Error: Driver not connected | Error: Unknown UPS"
+
+    @pytest.mark.unit
+    def test_only_ssl_noise_falls_back_without_resurfacing_it(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        out = monitor._format_upsc_error(
+            stdout="", stderr="Init SSL without certificate database\n")
+        assert out == "upsc exited without output"
 
 
 class TestRecordRemoteHealthEvent:

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -3232,6 +3232,152 @@ class TestGetAllUpsDataFailurePaths:
         assert err == "Missing ups.status"
 
 
+class TestNutNameAutodiscovery:
+    """Issue #71: on a hard NUT connection failure, list the server's real UPS
+    names (``upsc -l``), warn clearly, and self-heal an obviously-wrong
+    ``ups.name`` (e.g. a NUT username placed where the UPS name belongs)."""
+
+    @pytest.mark.unit
+    def test_parse_nut_host(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        assert monitor._parse_nut_host("upsmon@10.13.0.8:3493") == "10.13.0.8:3493"
+        assert monitor._parse_nut_host("UPS@server") == "server"
+        assert monitor._parse_nut_host("UPS") == "localhost"
+        assert monitor._parse_nut_host("UPS@") == "localhost"
+        assert monitor._parse_nut_host("") == "localhost"
+
+    @pytest.mark.unit
+    def test_parse_nut_name(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        assert monitor._parse_nut_name("upsmon@10.13.0.8:3493") == "upsmon"
+        assert monitor._parse_nut_name("UPS") == "UPS"
+
+    @pytest.mark.unit
+    def test_discover_filters_ssl_and_banner_lines(self, tmp_path):
+        """Only bare ups.conf section names survive; banners are dropped."""
+        monitor = make_monitor(tmp_path)
+        stdout = (
+            "Connected to NUT server 192.168.178.11 in SSL\n"
+            "Certificate verification is disabled\n"
+            "UPS\n"
+        )
+        with patch("eneru.monitor.run_command",
+                   return_value=(0, stdout, "")) as run:
+            names = monitor._discover_ups_names("192.168.178.11")
+        assert names == ["UPS"]
+        run.assert_called_once_with(
+            ["upsc", "-l", "192.168.178.11"],
+            timeout=10,
+            env_overrides={"NUT_QUIET_INIT_SSL": "true"},
+        )
+
+    @pytest.mark.unit
+    def test_discover_returns_empty_on_failure(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        with patch("eneru.monitor.run_command",
+                   return_value=(1, "", "Connection failure")):
+            assert monitor._discover_ups_names("10.0.0.9") == []
+
+    @pytest.mark.unit
+    def test_self_heals_single_ups(self, tmp_path):
+        """Wrong name + exactly one real UPS -> auto-correct the poll target."""
+        monitor = make_monitor(tmp_path)
+        monitor._poll_target = "upsmon@10.13.0.8:3493"
+        with patch("eneru.monitor.run_command",
+                   return_value=(0, "UPS\n", "")):
+            monitor._run_ups_name_diagnostic("Init SSL without certificate database")
+        assert monitor._poll_target == "UPS@10.13.0.8:3493"
+        assert monitor._ups_name_autocorrected is True
+        # config.ups.name (display/state identity) is untouched.
+        assert monitor.config.ups.name == "TestUPS@localhost"
+        logged = " ".join(str(c) for c in monitor.logger.log.call_args_list)
+        assert "Auto-correcting" in logged
+
+    @pytest.mark.unit
+    def test_self_heal_runs_only_once(self, tmp_path):
+        """A second failure episode must not flip the target again."""
+        monitor = make_monitor(tmp_path)
+        monitor._poll_target = "upsmon@10.13.0.8:3493"
+        with patch("eneru.monitor.run_command", return_value=(0, "UPS\n", "")):
+            monitor._run_ups_name_diagnostic("err")
+            healed = monitor._poll_target
+            # Even if a different single UPS appears later, do not re-correct.
+            with patch("eneru.monitor.run_command",
+                       return_value=(0, "OTHER\n", "")):
+                monitor._run_ups_name_diagnostic("err")
+        assert monitor._poll_target == healed == "UPS@10.13.0.8:3493"
+
+    @pytest.mark.unit
+    def test_multiple_names_no_heal_lists_them(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        monitor._poll_target = "upsmon@10.13.0.8:3493"
+        with patch("eneru.monitor.run_command",
+                   return_value=(0, "ups-a\nups-b\n", "")):
+            monitor._run_ups_name_diagnostic("err")
+        assert monitor._poll_target == "upsmon@10.13.0.8:3493"  # unchanged
+        assert monitor._ups_name_autocorrected is False
+        logged = " ".join(str(c) for c in monitor.logger.log.call_args_list)
+        assert "ups-a" in logged and "ups-b" in logged
+
+    @pytest.mark.unit
+    def test_configured_name_present_no_heal(self, tmp_path):
+        """Name exists but poll still fails -> point at auth, not the name."""
+        monitor = make_monitor(tmp_path)
+        monitor._poll_target = "UPS@10.13.0.8:3493"
+        with patch("eneru.monitor.run_command",
+                   return_value=(0, "UPS\n", "")):
+            monitor._run_ups_name_diagnostic("ERR ACCESS-DENIED")
+        assert monitor._poll_target == "UPS@10.13.0.8:3493"  # unchanged
+        assert monitor._ups_name_autocorrected is False
+        logged = " ".join(str(c) for c in monitor.logger.log.call_args_list)
+        assert "exists" in logged
+
+    @pytest.mark.unit
+    def test_discovery_failure_warns_unverified(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        monitor._poll_target = "upsmon@10.13.0.8:3493"
+        with patch("eneru.monitor.run_command",
+                   return_value=(1, "", "Connection failure")):
+            monitor._run_ups_name_diagnostic("err")
+        assert monitor._poll_target == "upsmon@10.13.0.8:3493"  # unchanged
+        logged = " ".join(str(c) for c in monitor.logger.log.call_args_list)
+        assert "Could not list" in logged
+
+    @pytest.mark.unit
+    def test_run_upsc_uses_healed_poll_target(self, tmp_path):
+        """After a self-heal, polling uses the corrected name."""
+        monitor = make_monitor(tmp_path)
+        monitor._poll_target = "UPS@10.13.0.8:3493"
+        with patch("eneru.monitor.run_command",
+                   return_value=(0, "ups.status: OL\n", "")) as run:
+            monitor._run_upsc([], full_poll=True)
+        run.assert_called_once_with(
+            ["upsc", "UPS@10.13.0.8:3493"],
+            env_overrides={"NUT_QUIET_INIT_SSL": "true"},
+        )
+
+    @pytest.mark.unit
+    def test_diagnostic_fires_once_on_first_hard_error(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        monitor.state.previous_status = "OL CHRG"
+        monitor.state.connection_state = "OK"
+        monitor.state.connection_error_count = 0
+        with patch.object(monitor, "_run_ups_name_diagnostic") as diag:
+            _run_one_iteration(monitor, (False, {}, "Network error"))
+        diag.assert_called_once()
+
+    @pytest.mark.unit
+    def test_diagnostic_skipped_mid_episode(self, tmp_path):
+        """It runs only when connection_error_count reaches 1 (episode start)."""
+        monitor = make_monitor(tmp_path)
+        monitor.state.previous_status = "OL CHRG"
+        monitor.state.connection_state = "GRACE_PERIOD"
+        monitor.state.connection_error_count = 5
+        with patch.object(monitor, "_run_ups_name_diagnostic") as diag:
+            _run_one_iteration(monitor, (False, {}, "Network error"))
+        diag.assert_not_called()
+
+
 class TestRecordRemoteHealthEvent:
     """`_record_remote_health_event` mirrors RemoteHealthManager events
     into the per-UPS stats DB (best-effort)."""

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -3182,6 +3182,34 @@ class TestGetAllUpsDataFailurePaths:
         assert err == "no such ups"
 
     @pytest.mark.unit
+    def test_nonzero_exit_filters_nut_ssl_init_noise(self, tmp_path):
+        """Issue #71: the NSS SSL-init line is not the actual NUT failure."""
+        monitor = make_monitor(tmp_path)
+        with patch.object(
+            monitor, "_run_upsc",
+            return_value=(
+                1,
+                "Error: Unknown UPS\n",
+                "Init SSL without certificate database\n",
+            ),
+        ):
+            success, data, err = monitor._get_all_ups_data()
+        assert success is False
+        assert data == {}
+        assert err == "Error: Unknown UPS"
+
+    @pytest.mark.unit
+    def test_run_upsc_suppresses_nut_ssl_init_noise(self, tmp_path):
+        monitor = make_monitor(tmp_path)
+        with patch("eneru.monitor.run_command",
+                   return_value=(0, "ups.status: OL\n", "")) as run:
+            monitor._run_upsc([], full_poll=True)
+        run.assert_called_once_with(
+            ["upsc", "TestUPS@localhost"],
+            env_overrides={"NUT_QUIET_INIT_SSL": "true"},
+        )
+
+    @pytest.mark.unit
     def test_stale_data_marker_returns_failure(self, tmp_path):
         monitor = make_monitor(tmp_path)
         with patch.object(monitor, "_run_upsc",

--- a/tests/test_remote_health.py
+++ b/tests/test_remote_health.py
@@ -621,7 +621,7 @@ def test_loopback_auto_populates_expected_identity_from_etc_machine_id(tmp_path)
     config.remote_health.enabled = True
     server = _make_loopback_server(expected_host_identity=None)
 
-    with patch("eneru.remote_health._read_container_machine_id",
+    with patch("eneru.remote_health._read_identity_from_path",
                return_value="aabbcc-host-id"):
         RemoteHealthManager(
             config=config,
@@ -632,6 +632,58 @@ def test_loopback_auto_populates_expected_identity_from_etc_machine_id(tmp_path)
             log_fn=lambda msg: None,
         )
     assert server.expected_host_identity == "aabbcc-host-id"
+
+
+@pytest.mark.unit
+def test_loopback_auto_populates_expected_identity_from_custom_cat_path(tmp_path):
+    """Issue #70: custom ``host_identity_command: cat /path`` should use
+    the same container-side path for the expected identity."""
+    config = Config()
+    config.remote_health.enabled = True
+    marker = tmp_path / "eneru-machine-id"
+    marker.write_text("alpine-host-id\n", encoding="utf-8")
+    server = _make_loopback_server(
+        host_identity_command=f"cat {marker}",
+        expected_host_identity=None,
+    )
+
+    RemoteHealthManager(
+        config=config,
+        group_label="Rack",
+        servers=[server],
+        sidecar_path=tmp_path / "state.remote-health.json",
+        stop_event=threading.Event(),
+        log_fn=lambda msg: None,
+    )
+
+    assert server.expected_host_identity == "alpine-host-id"
+
+
+@pytest.mark.unit
+def test_loopback_non_cat_identity_command_requires_explicit_expected(tmp_path):
+    """Non-``cat /path`` commands cannot be safely inferred locally."""
+    config = Config()
+    config.remote_health.enabled = True
+    server = _make_loopback_server(
+        host_identity_command="hostname",
+        expected_host_identity=None,
+    )
+
+    manager = RemoteHealthManager(
+        config=config,
+        group_label="Rack",
+        servers=[server],
+        sidecar_path=tmp_path / "state.remote-health.json",
+        stop_event=threading.Event(),
+        log_fn=lambda msg: None,
+    )
+
+    assert server.expected_host_identity is None
+    with patch("eneru.remote_health.run_remote_probe",
+               return_value=(True, "", 8)):
+        rows = manager.check_once()
+    assert rows[0]["status"] == REMOTE_HEALTH_DEGRADED
+    assert "expected_host_identity" in rows[0]["last_error"]
 
 
 @pytest.mark.unit
@@ -737,7 +789,7 @@ def test_empty_machine_id_fails_with_setup_hint(tmp_path):
     config.remote_health.enabled = True
     config.remote_health.failure_threshold = 1
     server = _make_loopback_server(expected_host_identity=None)
-    with patch("eneru.remote_health._read_container_machine_id", return_value=None):
+    with patch("eneru.remote_health._read_identity_from_path", return_value=None):
         manager = RemoteHealthManager(
             config=config,
             group_label="Rack",

--- a/tests/test_remote_health.py
+++ b/tests/test_remote_health.py
@@ -693,7 +693,7 @@ def test_loopback_explicit_expected_identity_not_overwritten(tmp_path):
     config.remote_health.enabled = True
     server = _make_loopback_server(expected_host_identity="operator-set-id")
 
-    with patch("eneru.remote_health._read_container_machine_id",
+    with patch("eneru.remote_health._read_expected_identity_for_command",
                return_value="DIFFERENT"):
         RemoteHealthManager(
             config=config,
@@ -1013,34 +1013,56 @@ def test_identity_probe_mismatch_reports_bind_mount_hint(tmp_path):
 
 
 @pytest.mark.unit
-def test_read_container_machine_id_returns_value_when_readable(monkeypatch):
-    """When /etc/machine-id is readable, _read_container_machine_id
-    returns its stripped contents (remote_health.py lines 222-223)."""
+def test_read_identity_from_path_returns_value_when_readable(tmp_path):
+    """A readable identity file yields its stripped contents."""
     from eneru import remote_health as rh
-    fake_value = "machine-id-from-bind-mount\n"
-
-    class _FakePath:
-        def __init__(self, p): self.p = p
-        def read_text(self, encoding="utf-8"):
-            return fake_value
-
-    monkeypatch.setattr(rh, "Path", _FakePath)
-    assert rh._read_container_machine_id() == "machine-id-from-bind-mount"
+    marker = tmp_path / "marker"
+    marker.write_text("machine-id-from-bind-mount\n", encoding="utf-8")
+    assert rh._read_identity_from_path(marker) == "machine-id-from-bind-mount"
 
 
 @pytest.mark.unit
-def test_read_container_machine_id_returns_none_on_oserror(monkeypatch):
-    """OSError reading /etc/machine-id yields None
-    (remote_health.py lines 224-225)."""
+def test_read_identity_from_path_returns_none_on_oserror(tmp_path):
+    """A missing/unreadable identity file yields None (OSError swallowed)."""
     from eneru import remote_health as rh
+    assert rh._read_identity_from_path(tmp_path / "does-not-exist") is None
 
-    class _FakePath:
-        def __init__(self, p): self.p = p
-        def read_text(self, encoding="utf-8"):
-            raise OSError("file not found")
 
-    monkeypatch.setattr(rh, "Path", _FakePath)
-    assert rh._read_container_machine_id() is None
+@pytest.mark.unit
+def test_read_identity_from_path_returns_none_when_empty(tmp_path):
+    """An empty file yields None (blank machine-id is not a valid identity)."""
+    from eneru import remote_health as rh
+    marker = tmp_path / "empty"
+    marker.write_text("", encoding="utf-8")
+    assert rh._read_identity_from_path(marker) is None
+
+
+@pytest.mark.unit
+def test_identity_path_from_cat_command_accepts_simple_cat():
+    """`cat /abs/path` (with or without a full path to cat) is recognized."""
+    from eneru import remote_health as rh
+    from pathlib import Path
+    assert rh._identity_path_from_cat_command(
+        "cat /etc/machine-id") == Path("/etc/machine-id")
+    assert rh._identity_path_from_cat_command(
+        "/bin/cat /etc/eneru-machine-id") == Path("/etc/eneru-machine-id")
+
+
+@pytest.mark.unit
+def test_identity_path_from_cat_command_rejects_non_cat_and_relative():
+    """Anything that isn't exactly `cat <absolute-path>` is rejected."""
+    from eneru import remote_health as rh
+    assert rh._identity_path_from_cat_command("hostname") is None          # 1 token
+    assert rh._identity_path_from_cat_command("cat a b") is None           # != 2 tokens
+    assert rh._identity_path_from_cat_command("echo /etc/machine-id") is None  # not cat
+    assert rh._identity_path_from_cat_command("cat relative/path") is None     # relative
+
+
+@pytest.mark.unit
+def test_identity_path_from_cat_command_handles_bad_quoting():
+    """A command that fails shell-tokenization yields None, not an exception."""
+    from eneru import remote_health as rh
+    assert rh._identity_path_from_cat_command('cat "unterminated') is None
 
 
 @pytest.mark.unit

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -102,6 +102,18 @@ class TestRunCommand:
         assert "C" in stdout
 
     @pytest.mark.unit
+    def test_command_with_env_overrides(self):
+        """Callers can add process-local environment without mutating os.environ."""
+        exit_code, stdout, stderr = run_command(
+            ["sh", "-c", "echo $NUT_QUIET_INIT_SSL:$LC_NUMERIC"],
+            env_overrides={"NUT_QUIET_INIT_SSL": "true"},
+        )
+
+        assert exit_code == 0
+        assert "true:C" in stdout
+        assert stderr == ""
+
+    @pytest.mark.unit
     def test_default_timeout(self):
         """Test that default timeout is applied (command should complete quickly)."""
         # A quick command should work with default timeout


### PR DESCRIPTION
Resolves #70 and #71 — both reported from running Eneru in a container on a non-systemd host (Alpine).

## #70 — Alpine / non-systemd hosts have no `/etc/machine-id`

The v5.5 loopback host-identity guard compares an SSH-probed host identity against a locally-read one. The local read was hardcoded to `/etc/machine-id`, so marker-file setups had to mount over `/etc/machine-id` or duplicate `expected_host_identity` by hand.

- **Code** (`5dc32f6`): `expected_host_identity` now auto-populates from the same local path whenever `host_identity_command` is a safe `cat /absolute/path`. Non-`cat` commands still require an explicit value (fails closed).
- **Docs**: new canonical **"No systemd / no machine-id (Alpine, consumer hosts)"** marker-file recipe in the containers guide, linked from the install, migration, and troubleshooting pages; `expected_host_identity` reference updated. deb + rpm remain the published packages, the OCI image stays first-class, and systemd + machine-id remain the expected baseline.

## #71 — "Init SSL without certificate database" masked the real failure

That line is benign NUT/NSS noise printed even for plain reads. The real cause is almost always a wrong `ups.name` — a NUT *login username* placed where the UPS *device name* belongs (`upsc upsmon@host` fails: no UPS is named `upsmon`).

- **Output** (`c2783ca`): run `upsc` with `NUT_QUIET_INIT_SSL=true` and filter the SSL line so real errors stay visible.
- **Autodiscovery** (`598118c`): on the first hard error of a failure episode, probe `upsc -l <host>` and either **self-heal** (exactly one UPS exists and the configured name isn't it → switch the effective poll target for the session and warn), or **list** the available names / report the server is unreachable — with a note about username-vs-UPS-name and `nut_control.username`. The correction lives in a dedicated `_poll_target` read only by `_run_upsc`, so `config.ups.name` and every display/log/state path derived from it are never mutated.

## Release

Version bumped to `6.1.0-rc1` (PEP 440 `6.1.0rc1`); changelog updated.

## Testing

`pytest -m unit` — **2355 passed** (12 new autodiscovery tests). `mkdocs build --strict` passes. Docker/E2E and packaging run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #70 and #71. Enables loopback identity on Alpine/non-systemd hosts via a stable marker file and makes NUT polling clearer with UPS name autodiscovery and safe, session-only self-heal.

- **New Features**
  - Autodiscover UPS names on the first hard poll error: runs `upsc -l <host>`, self-heals a wrong `ups.name` for the session when exactly one UPS exists (polling only; control commands keep the configured name), otherwise lists available names; skips this probe while On Battery.

- **Bug Fixes**
  - Auto-populate `expected_host_identity` from the path in `host_identity_command` when it is `cat /absolute/path` (supports `/etc/machine-id` or a marker file; no YAML duplication). Error messages now reference the actual identity source path, not just `/etc/machine-id`.
  - Run `upsc` with `NUT_QUIET_INIT_SSL=true`, filter the benign SSL init line, and format errors from both streams; if only SSL noise appears, return a generic message so real failures are clear. Docs updated for non-systemd hosts; bump version to `6.1.0-rc1`.

<sup>Written for commit e0d91d645dd5ae9283fcc271982e4fc4927cef58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NUT name autodiscovery to automatically detect correct UPS names
  * Automatic population of host identity from configured host identity commands
  * Quieter NUT polling output option via environment variable

* **Documentation**
  * Expanded Docker/Podman quick-start guidance with host loopback setup
  * Added instructions for non-systemd/Alpine environments using marker files
  * Enhanced troubleshooting section with host identity resolution
  * Updated container and migration documentation

* **Chores**
  * Version bumped to 6.1.0-rc1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->