### PR TITLE
test+docs: container SSH host-key trust (#73) and NUT-name autodiscovery E2E (#71)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,7 @@ jobs:
           grep -Eq "^[[:space:]]*run_loopback_case[[:space:]]+sudo[[:space:]]+testuser[[:space:]]+true[[:space:]]+19192[[:space:]]*$" tests/e2e/groups/loopback.sh
           grep -Eq "^[[:space:]]*negative_missing_machine_id[[:space:]]*$" tests/e2e/groups/loopback.sh
           grep -Eq "^[[:space:]]*negative_missing_loopback[[:space:]]*$" tests/e2e/groups/loopback.sh
+          grep -Eq "^[[:space:]]*strict_known_hosts_remote[[:space:]]+19194[[:space:]]*$" tests/e2e/groups/loopback.sh
           grep -q "stop_vms" tests/e2e/groups/loopback.sh
           grep -q "stop_compose" tests/e2e/groups/loopback.sh
           grep -q "stop_containers_rootless" tests/e2e/groups/loopback.sh
@@ -114,6 +115,7 @@ jobs:
           # tiered config / write gating (single-ups) must stay present.
           if [ "${{ matrix.group }}" = "cli" ]; then
             grep -q "Test 51: auth user + apikey CLI lifecycle" tests/e2e/groups/cli.sh
+            grep -q "Test 58: NUT name autodiscovery self-heals single exposed UPS" tests/e2e/groups/cli.sh
           else
             grep -q "Test 52: API authentication login + tiered config + write gating" tests/e2e/groups/single-ups.sh
             grep -q "Test 53: UPS control fail-closed + allowlist enforcement" tests/e2e/groups/single-ups.sh

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Container SSH host-key setup (issue #73).** A container is a hotel room:
+  anything learned interactively inside it disappears when the room is rebuilt.
+  The container docs now tell operators to mount both the private key and a
+  pre-seeded `known_hosts` file from `/srv/eneru/ssh`, then configure
+  `UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts` with
+  `StrictHostKeyChecking=yes` so remote-server trust survives
+  Docker/Podman/Kubernetes recreates without disabling host-key checks. The same
+  pass makes the uid `10001` private-key ownership and mode guidance consistent
+  across the container walkthroughs.
+- **E2E coverage for issue #71 and issue #73.** The CI matrix now includes a
+  real NUT autodiscovery regression that proves a wrong single-UPS name
+  self-heals for the running session, plus a container SSH regression that uses
+  a mounted private key and mounted `known_hosts` with strict host-key checking
+  across container recreation.
 - **`expected_host_identity` auto-populates from any `cat /absolute/path`
   (issue #70).** Previously the container-side identity read was hardcoded to
   `/etc/machine-id`, so marker-file setups had to duplicate the value or mount

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pre-seeded `known_hosts` file from `/srv/eneru/ssh`, then configure
   `UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts` with
   `StrictHostKeyChecking=yes` so remote-server trust survives
-  Docker/Podman/Kubernetes recreates without disabling host-key checks. The same
+  Docker/Podman/Kubernetes recreation without disabling host-key checks. The same
   pass makes the uid `10001` private-key ownership and mode guidance consistent
   across the container walkthroughs.
 - **E2E coverage for issue #71 and issue #73.** The CI matrix now includes a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,17 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [6.1.0-rc1] - 2026-06-09
-
-### Added
-
-- **NUT name autodiscovery (issue #71).** When a poll can't reach the configured
-  UPS, Eneru now runs `upsc -l <host>` to list the UPS names the server actually
-  exposes and logs them. If exactly one UPS exists and the configured name is not
-  it (the classic case of a NUT *login username* placed where the UPS *device
-  name* belongs), Eneru self-heals for the session and tells you to fix
-  `ups.name`. With multiple UPSes it lists the choices instead of guessing. The
-  operator-configured name, display, and on-disk state are never mutated.
+## [6.1.0-rc2] - 2026-06-10
 
 ### Changed
 
@@ -35,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   self-heals for the running session, plus a container SSH regression that uses
   a mounted private key and mounted `known_hosts` with strict host-key checking
   across container recreation.
+
+## [6.1.0-rc1] - 2026-06-09
+
+### Added
+
+- **NUT name autodiscovery (issue #71).** When a poll can't reach the configured
+  UPS, Eneru now runs `upsc -l <host>` to list the UPS names the server actually
+  exposes and logs them. If exactly one UPS exists and the configured name is not
+  it (the classic case of a NUT *login username* placed where the UPS *device
+  name* belongs), Eneru self-heals for the session and tells you to fix
+  `ups.name`. With multiple UPSes it lists the choices instead of guessing. The
+  operator-configured name, display, and on-disk state are never mutated.
+
+### Changed
+
 - **`expected_host_identity` auto-populates from any `cat /absolute/path`
   (issue #70).** Previously the container-side identity read was hardcoded to
   `/etc/machine-id`, so marker-file setups had to duplicate the value or mount

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -472,7 +472,7 @@ mounts:
 | `shutdown_command` | `sudo shutdown -h now` | Final shutdown command |
 | `use_sudo` | `false` | Prefix generated privileged actions and non-sudo final shutdown commands with `sudo -n`. Useful for non-root loopback or remote users with NOPASSWD sudo |
 | `ssh_key_path` | `null` | Optional SSH private-key path, useful for container/Kubernetes volume mounts |
-| `ssh_options` | `[]` | Extra SSH options. Avoid disabling host-key checks in production |
+| `ssh_options` | `[]` | Extra SSH options. For containers, prefer `UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts` over accepting keys inside the container. Avoid disabling host-key checks in production |
 | `pre_shutdown_commands` | `[]` | Pre-shutdown actions or commands. For loopback entries Eneru generates these from the local config — don't duplicate |
 | `pre_shutdown_commands[].mounts` | `[]` | Mounts for `action: unmount_filesystems` on ordinary remote servers. Loopback entries derive mounts from `filesystems.unmount.mounts` |
 | `shutdown_order` | unset | Explicit phase. Same value runs in parallel; higher values run later |

--- a/docs/containers-kubernetes.md
+++ b/docs/containers-kubernetes.md
@@ -56,6 +56,9 @@ ups:
         host: "nas.example.lan"
         user: "ups"
         ssh_key_path: "/var/lib/eneru/ssh/id_ups_shutdown"
+        ssh_options:
+          - "UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts"
+          - "StrictHostKeyChecking=yes"
         shutdown_command: "sudo shutdown -h now"
 
 local_shutdown:
@@ -130,7 +133,9 @@ mkdir -p /srv/eneru/ssh
 ssh-keygen -t ed25519 -N '' \
     -f /srv/eneru/ssh/id_loopback \
     -C "eneru-loopback@$(hostname)"
-chmod 600 /srv/eneru/ssh/id_loopback
+chown 10001:10001 /srv/eneru/ssh/id_loopback /srv/eneru/ssh/id_loopback.pub
+chmod 0400 /srv/eneru/ssh/id_loopback
+chmod 0644 /srv/eneru/ssh/id_loopback.pub
 ```
 
 Then authorize either the default root loopback key, or a dedicated
@@ -152,6 +157,29 @@ chmod 600 /root/.ssh/authorized_keys
 This matches the synthesized defaults: `user: root`,
 `shutdown_command: "shutdown -h now"`, and key path
 `/var/lib/eneru/ssh/id_loopback`.
+
+For ordinary remote targets from the container, put their trusted host
+keys in the same bind-mounted directory instead of accepting them from
+inside a disposable container:
+
+```bash
+# On the Eneru host:
+ssh-keyscan -H nas.example.lan > /srv/eneru/ssh/known_hosts
+chown 10001:10001 /srv/eneru/ssh/known_hosts
+chmod 0644 /srv/eneru/ssh/known_hosts
+ssh-keygen -l -f /srv/eneru/ssh/known_hosts
+```
+
+Verify the printed fingerprint out-of-band, then configure the remote
+entry with `UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts`. The
+remote-only sample at the top of this page shows the full shape.
+With `StrictHostKeyChecking=yes`, the file can stay read-only in the
+container because SSH never appends new keys. Add new remotes by
+updating `/srv/eneru/ssh/known_hosts` on the host after verifying the
+new fingerprint. If you deliberately choose
+`StrictHostKeyChecking=accept-new`, then the mounted `known_hosts` file
+must be writable by uid `10001`; that is more convenient, but it lets
+the daemon trust a first-seen key during an outage path.
 
 ### Option B: dedicated user + sudoers
 

--- a/docs/migrate-to-container.md
+++ b/docs/migrate-to-container.md
@@ -135,6 +135,17 @@ cp /root/.ssh/id_rsa /srv/eneru/ssh/id_rsa
 cp /root/.ssh/id_rsa.pub /srv/eneru/ssh/id_rsa.pub
 chown 10001:10001 /srv/eneru/ssh/id_rsa /srv/eneru/ssh/id_rsa.pub
 chmod 0400 /srv/eneru/ssh/id_rsa
+
+# Preserve the host-key trust store too. If /root/.ssh/known_hosts is
+# missing, build a new one from the remote hosts named in your config.
+if [ -f /root/.ssh/known_hosts ]; then
+  cp /root/.ssh/known_hosts /srv/eneru/ssh/known_hosts
+else
+  ssh-keyscan -H 192.168.x.y > /srv/eneru/ssh/known_hosts
+fi
+chown 10001:10001 /srv/eneru/ssh/known_hosts
+chmod 0644 /srv/eneru/ssh/known_hosts
+ssh-keygen -l -f /srv/eneru/ssh/known_hosts
 ```
 
 Then add `ssh_key_path` to each existing `remote_servers` entry in your
@@ -147,11 +158,24 @@ remote_servers:
     host: 192.168.x.y
     user: nas-admin
     ssh_key_path: /var/lib/eneru/ssh/id_rsa   # ADD THIS
+    ssh_options:
+      - "UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts"
+      - "StrictHostKeyChecking=yes"
     shutdown_command: "shutdown -h now"
 ```
 
 The container-side path `/var/lib/eneru/ssh/id_rsa` resolves to the host
 file via the `-v /srv/eneru/ssh:/var/lib/eneru/ssh:ro` mount in Step 6.
+The `known_hosts` path resolves the same way. With
+`StrictHostKeyChecking=yes`, the file can stay read-only in the
+container because SSH never appends new keys; add new remotes by
+updating `/srv/eneru/ssh/known_hosts` on the host after verifying the
+new fingerprint. The `ssh-keygen -l` output above is the fingerprint
+to compare against the remote server's console or inventory before you
+trust it. If you deliberately choose `StrictHostKeyChecking=accept-new`,
+then the mounted `known_hosts` file must be writable by uid `10001`;
+that is more convenient, but it lets the daemon trust a first-seen key
+during an outage path.
 
 ## Step 3: Stop the native service
 

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -199,6 +199,49 @@ Accept host keys deliberately before relying on shutdown:
 sudo ssh user@remote-server "echo OK"
 ```
 
+For Docker, Podman, or Kubernetes, do not accept the key interactively
+inside a running container. A container is like a hotel room: anything
+you tape to the wall is gone when housekeeping recreates it. Store the
+trusted host keys on the host and bind-mount them with the SSH private
+key:
+
+```bash
+# On the Eneru host:
+install -d -o 10001 -g 10001 -m 0755 /srv/eneru/ssh
+ssh-keyscan -H remote-server > /srv/eneru/ssh/known_hosts
+chown 10001:10001 /srv/eneru/ssh/known_hosts
+chmod 0644 /srv/eneru/ssh/known_hosts
+```
+
+Compare the scanned fingerprint against the target's console or out-of-band
+inventory before trusting it:
+
+```bash
+ssh-keygen -l -f /srv/eneru/ssh/known_hosts
+```
+
+Then point OpenSSH at the mounted file:
+
+```yaml
+remote_servers:
+  - name: "NAS"
+    enabled: true
+    host: "nas.example.lan"
+    user: "ups"
+    ssh_key_path: "/var/lib/eneru/ssh/id_ups_shutdown"
+    ssh_options:
+      - "UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts"
+      - "StrictHostKeyChecking=yes"
+```
+
+With `StrictHostKeyChecking=yes`, the file can stay read-only in the
+container because SSH never appends new keys. To add another remote,
+update `/srv/eneru/ssh/known_hosts` on the host after verifying that
+remote's fingerprint. If you deliberately choose
+`StrictHostKeyChecking=accept-new`, then the mounted `known_hosts` file
+must be writable by uid `10001`; that is more convenient, but it lets
+the daemon trust a first-seen key during an outage path.
+
 Do not leave `StrictHostKeyChecking=no` in production. If a host key changes unexpectedly, SSH should fail closed instead of sending shutdown commands to an untrusted host.
 
 ## Passwordless sudo

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,13 +161,13 @@ The workflow is split into six parallel matrix groups:
 | UPS Multi | Independent UPS groups and local-drain policies |
 | Redundancy | Quorum behavior, advisory triggers, and runtime NUT-visibility regressions |
 | Stats | SQLite, graphs, events, notification coalescing |
-| Loopback | Containerized local-host ownership through root and sudo SSH loopback, including generated local VM/container/sync/unmount actions |
+| Loopback | Containerized local-host ownership through root and sudo SSH loopback, including generated local VM/container/sync/unmount actions and strict container SSH trust |
 
 The scenario files simulate online, on-battery, low-battery, FSD, brownout, overload, hot-grid, and nominal-voltage-mismatch states.
 
 ### E2E test inventory
 
-The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 56 numbered tests, two redundancy runtime regression cases, plus one CLI completion smoke check.
+The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 58 numbered tests, two redundancy runtime regression cases, plus one CLI completion smoke check.
 
 | Test | Group | What it proves |
 |------|-------|----------------|
@@ -229,6 +229,8 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 56 numb
 | 54 | UPS Single | Config hot-reload: SIGHUP applies a threshold change live, the authenticated `/config/reload` endpoint returns a report (anonymous is 401), and a broken config is rejected without dropping the daemon |
 | 55 | UPS Single | Browser dashboard: the embedded API serves the SPA shell and assets with a strict CSP, and rejects path traversal / unknown assets with 404 |
 | 56 | UPS Single | Event management: a wide-range `/api/v1/events` query returns source-qualified rows, an authenticated `DELETE` removes a real event (anonymous is 401), and a history `from > to` is 400 |
+| 57 | Loopback | Containerized remote SSH uses a mounted private key plus mounted `known_hosts` with `StrictHostKeyChecking=yes`; the remote health probe reaches `HEALTHY` (proving the host key was trusted, not just that NUT was reachable) and the daemon stays ready after the container is recreated |
+| 58 | CLI | NUT name autodiscovery (issue #71) lists a single exposed UPS with `upsc -l`, auto-corrects the runtime poll target, and logs the `ups.name` fix hint |
 | E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |
 
 Every commit on the protected workflow has to prove the daemon works against real services. That means real NUT sockets, Dockerized SSH targets, a live SQLite database, rendered TUI output, validated production-shaped configs, and a full shutdown orchestration run. None of it depends on local developer state.

--- a/examples/config-container-remote.yaml
+++ b/examples/config-container-remote.yaml
@@ -13,12 +13,17 @@ ups:
     # Uncomment and adapt to drive remote shutdowns from this Eneru container.
     # The ssh_key_path below points at a file mounted from a Kubernetes Secret
     # or a Docker bind mount so the private key never lives in the image.
+    # Put trusted host keys in the same mounted directory as known_hosts;
+    # accepting them interactively inside a container is lost on recreate.
     # remote_servers:
     #   - name: "nas"
     #     enabled: true
     #     host: "nas.example.lan"
     #     user: "ups"
     #     ssh_key_path: "/var/lib/eneru/ssh/id_eneru"
+    #     ssh_options:
+    #       - "UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts"
+    #       - "StrictHostKeyChecking=yes"
     #     shutdown_command: "sudo shutdown -h now"
 
 local_shutdown:

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.1.0-rc1"
+__version__ = "6.1.0-rc2"

--- a/tests/e2e/groups/cli.sh
+++ b/tests/e2e/groups/cli.sh
@@ -273,5 +273,120 @@ fi
 echo "PASS: auth user + apikey CLI lifecycle"
 )
 
+# ======================================================================
+# Test 58: NUT name autodiscovery self-heals single exposed UPS
+# ======================================================================
+# Issue #71: when ups.name uses a wrong NUT device name but the target
+# server exposes exactly one UPS, Eneru should list names with `upsc -l`,
+# auto-correct only the runtime poll target, and tell the operator to fix
+# config. This uses a separate temporary single-UPS NUT container so
+# the shared E2E compose services remain untouched.
+(
+echo ""
+echo ">>> Running: Test 58: NUT name autodiscovery self-heals single exposed UPS"
+
+docker build -t eneru:e2e-nut-single "$E2E_DIR/nut-dummy"
+docker rm -f eneru-e2e-nut-single >/dev/null 2>&1 || true
+docker run -d --name eneru-e2e-nut-single \
+  -p 127.0.0.1:3494:3493 \
+  --entrypoint /bin/bash \
+  eneru:e2e-nut-single \
+  -c '
+set -e
+cat >/etc/nut/ups.conf <<EOF
+[TestUPS]
+    driver = dummy-ups
+    port = TestUPS.dev
+    desc = "Eneru E2E Test UPS (single autodiscovery)"
+EOF
+chown nut:nut /etc/nut/ups.conf /etc/nut/TestUPS.dev
+chmod 640 /etc/nut/ups.conf
+nohup /usr/lib/nut/dummy-ups -a TestUPS -D >/tmp/e2e-test58-dummy.log 2>&1 &
+sleep 2
+exec /usr/sbin/upsd -D -F
+' >/dev/null
+cleanup_test58() {
+  docker rm -f eneru-e2e-nut-single >/dev/null 2>&1 || true
+}
+trap cleanup_test58 EXIT
+
+nut_single_ready=false
+for _ in $(seq 1 30); do
+  if upsc TestUPS@localhost:3494 2>/dev/null | grep -q "ups.status"; then
+    nut_single_ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "$nut_single_ready" != "true" ]; then
+  echo "FAIL: temporary single-UPS NUT container never became ready"
+  docker logs eneru-e2e-nut-single || true
+  exit 1
+fi
+
+NAMES="$(upsc -l localhost:3494 2>/dev/null | tr -d '\r')"
+if [ "$NAMES" != "TestUPS" ]; then
+  echo "FAIL: expected temporary NUT server to expose exactly TestUPS"
+  printf 'Observed names:\n%s\n' "$NAMES"
+  docker logs eneru-e2e-nut-single || true
+  exit 1
+fi
+echo "PASS: temporary NUT server exposes exactly one UPS name"
+
+cat >/tmp/config-e2e-nut-name-autodiscovery.yaml <<'YAML'
+ups:
+  name: upsmon@localhost:3494
+  display_name: "E2E Wrong NUT Name"
+  check_interval: 1
+  max_stale_data_tolerance: 5
+behavior:
+  dry_run: true
+local_shutdown:
+  enabled: false
+  trigger_on: none
+remote_health:
+  enabled: false
+statistics:
+  db_directory: /tmp/e2e-test58-stats
+logging:
+  file: null
+  state_file: /tmp/e2e-test58-state
+  battery_history_file: /tmp/e2e-test58-history
+  shutdown_flag_file: /tmp/e2e-test58-shutdown-flag
+YAML
+
+set +e
+timeout 55s eneru run --config /tmp/config-e2e-nut-name-autodiscovery.yaml \
+  >/tmp/test58.log 2>&1
+rc=$?
+set -e
+cat /tmp/test58.log
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
+  echo "FAIL: autodiscovery daemon exited unexpectedly with status $rc"
+  exit 1
+fi
+
+if ! grep -q "Auto-correcting this session" /tmp/test58.log; then
+  echo "FAIL: autodiscovery did not log session auto-correction"
+  exit 1
+fi
+if ! grep -q "poll 'TestUPS@localhost:3494'" /tmp/test58.log; then
+  echo "FAIL: autodiscovery did not switch runtime poll target to TestUPS"
+  exit 1
+fi
+if ! grep -q "Please fix ups.name in your config" /tmp/test58.log; then
+  echo "FAIL: autodiscovery did not tell the operator to fix config"
+  exit 1
+fi
+if ! grep -q "value before '@' in ups.name must be the UPS device name" /tmp/test58.log; then
+  echo "FAIL: autodiscovery did not include the username-vs-device-name hint"
+  exit 1
+fi
+
+echo "PASS: NUT name autodiscovery self-healed the single-UPS target"
+cleanup_test58
+trap - EXIT
+)
+
 echo ""
 echo "=== Group 'cli' completed successfully ==="

--- a/tests/e2e/groups/loopback.sh
+++ b/tests/e2e/groups/loopback.sh
@@ -56,6 +56,24 @@ prepare_loopback_key() {
   sudo chmod 0400 /tmp/e2e-loopback-key
 }
 
+prepare_strict_remote_ssh_material() {
+  install -m 0755 -d /tmp/e2e-strict-ssh
+  cp /tmp/e2e-ssh-key /tmp/e2e-strict-ssh/id_remote
+  sudo chown 10001:10001 /tmp/e2e-strict-ssh/id_remote
+  sudo chmod 0400 /tmp/e2e-strict-ssh/id_remote
+  # Scan from inside the same Docker network because the container connects
+  # to the service name, not the host-published localhost port. Override the
+  # entrypoint: the image's ENTRYPOINT is ["/usr/bin/tini","--","eneru"], so
+  # without --entrypoint the args become `eneru ssh-keyscan ...` (an invalid
+  # eneru subcommand that exits non-zero) instead of running the ssh-keyscan
+  # binary shipped by openssh-client.
+  docker run --rm --network "$NETWORK" --entrypoint ssh-keyscan eneru:e2e \
+    -H ssh-target > /tmp/e2e-strict-ssh/known_hosts
+  sudo chown 10001:10001 /tmp/e2e-strict-ssh/known_hosts
+  sudo chmod 0644 /tmp/e2e-strict-ssh/known_hosts
+  ssh-keygen -l -f /tmp/e2e-strict-ssh/known_hosts
+}
+
 write_loopback_config() {
   local path="$1" user="$2" use_sudo="$3" identity="$4"
   cat >"$path" <<YAML
@@ -330,6 +348,86 @@ YAML
   docker rm -f "$name" >/dev/null 2>&1 || true
 }
 
+strict_known_hosts_remote() {
+  local config="/tmp/e2e-strict-known-hosts.yaml"
+  local name="eneru-e2e-strict-known-hosts"
+  local port="$1"
+  cat >"$config" <<'YAML'
+ups:
+  - name: "TestUPS@nut-server"
+    display_name: "Strict SSH Trust E2E UPS"
+    is_local: false
+    remote_servers:
+      - name: strict-ssh-target
+        enabled: true
+        host: ssh-target
+        user: root
+        ssh_key_path: /var/lib/eneru/ssh/id_remote
+        ssh_options:
+          - "UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts"
+          - "StrictHostKeyChecking=yes"
+        shutdown_command: "shutdown -h now"
+local_shutdown:
+  enabled: false
+  trigger_on: none
+remote_health:
+  enabled: true
+  startup_check: true
+  failure_threshold: 1
+logging:
+  file: null
+  state_file: "/var/run/eneru/ups-monitor.state"
+  battery_history_file: "/var/run/eneru/ups-battery-history"
+  shutdown_flag_file: "/var/run/eneru/ups-shutdown-scheduled"
+statistics:
+  db_directory: "/var/lib/eneru"
+YAML
+
+  for attempt in first recreated; do
+    docker rm -f "$name" >/dev/null 2>&1 || true
+    echo "  Starting strict known_hosts container (${attempt})"
+    docker run -d --name "$name" \
+      --network "$NETWORK" \
+      -p "127.0.0.1:${port}:9191" \
+      -v "$config":/etc/ups-monitor/config.yaml:ro \
+      -v /tmp/e2e-strict-ssh:/var/lib/eneru/ssh:ro \
+      eneru:e2e \
+      run --config /etc/ups-monitor/config.yaml \
+      --api --api-bind 0.0.0.0 --api-port 9191 >/dev/null
+
+    if ! poll_http_pattern \
+        "http://127.0.0.1:${port}/ready" \
+        "/tmp/e2e-strict-known-hosts-${attempt}.json" \
+        '"ready"[[:space:]]*:[[:space:]]*true'; then
+      echo "FAIL: strict known_hosts remote was not ready after ${attempt} start"
+      cat "/tmp/e2e-strict-known-hosts-${attempt}.json" || true
+      docker logs "$name" || true
+      exit 1
+    fi
+    echo "  PASS: strict known_hosts remote ready after ${attempt} start"
+
+    # Readiness alone is not enough: /ready can flip true on the successful
+    # NUT poll while the remote SSH probe is still UNKNOWN (it runs in a
+    # background thread and readiness treats UNKNOWN as achievable). Assert
+    # the remote target actually reaches HEALTHY so this test proves the
+    # mounted known_hosts satisfied StrictHostKeyChecking=yes -- with a
+    # missing/wrong key the probe would land in FAILED, never HEALTHY.
+    # collect_status serializes with sort_keys=True, so within each
+    # remoteHealth entry "server" sits immediately before "status".
+    if ! poll_http_pattern \
+        "http://127.0.0.1:${port}/api/v1/ups" \
+        "/tmp/e2e-strict-known-hosts-${attempt}-health.json" \
+        '"server"[[:space:]]*:[[:space:]]*"strict-ssh-target"[[:space:]]*,[[:space:]]*"status"[[:space:]]*:[[:space:]]*"HEALTHY"'; then
+      echo "FAIL: strict known_hosts remote SSH probe never reached HEALTHY after ${attempt} start"
+      cat "/tmp/e2e-strict-known-hosts-${attempt}-health.json" || true
+      docker logs "$name" || true
+      exit 1
+    fi
+    echo "  PASS: strict known_hosts remote SSH target HEALTHY after ${attempt} start"
+    docker rm -f "$name" >/dev/null 2>&1 || true
+  done
+}
+
 echo ">>> Building Eneru OCI image for loopback E2E"
 docker build -t eneru:e2e .
 NETWORK="$(network_name)"
@@ -341,6 +439,8 @@ fi
 echo ">>> Using Docker network: ${NETWORK}"
 prepare_loopback_key
 echo ">>> Prepared loopback private key at /tmp/e2e-loopback-key"
+prepare_strict_remote_ssh_material
+echo ">>> Prepared strict remote SSH key and known_hosts at /tmp/e2e-strict-ssh"
 
 echo ">>> Running: Test 47: E2E Loopback Root"
 run_loopback_case root root false 19191
@@ -350,5 +450,7 @@ echo ">>> Running: Test 49: E2E Loopback missing machine-id readiness"
 negative_missing_machine_id
 echo ">>> Running: Test 50: E2E Loopback missing delegate startup failure"
 negative_missing_loopback
+echo ">>> Running: Test 57: E2E container remote strict known_hosts survives recreate"
+strict_known_hosts_remote 19194
 
-echo "PASS: E2E loopback root/sudo and negative readiness checks passed"
+echo "PASS: E2E loopback root/sudo, strict SSH trust, and negative readiness checks passed"

--- a/tests/e2e/groups/loopback.sh
+++ b/tests/e2e/groups/loopback.sh
@@ -414,10 +414,16 @@ YAML
     # missing/wrong key the probe would land in FAILED, never HEALTHY.
     # collect_status serializes with sort_keys=True, so within each
     # remoteHealth entry "server" sits immediately before "status".
+    # Poll for up to 75s (150 tries x 0.5s): the startup probe normally
+    # marks HEALTHY within seconds, but remote_health re-probes only every
+    # max(60, interval) seconds, so the window must clear one full retry
+    # cycle to survive a missed first probe instead of flaking. A match
+    # returns immediately, so this costs nothing on the happy path.
     if ! poll_http_pattern \
         "http://127.0.0.1:${port}/api/v1/ups" \
         "/tmp/e2e-strict-known-hosts-${attempt}-health.json" \
-        '"server"[[:space:]]*:[[:space:]]*"strict-ssh-target"[[:space:]]*,[[:space:]]*"status"[[:space:]]*:[[:space:]]*"HEALTHY"'; then
+        '"server"[[:space:]]*:[[:space:]]*"strict-ssh-target"[[:space:]]*,[[:space:]]*"status"[[:space:]]*:[[:space:]]*"HEALTHY"' \
+        150; then
       echo "FAIL: strict known_hosts remote SSH probe never reached HEALTHY after ${attempt} start"
       cat "/tmp/e2e-strict-known-hosts-${attempt}-health.json" || true
       docker logs "$name" || true

--- a/tests/e2e/groups/loopback.sh
+++ b/tests/e2e/groups/loopback.sh
@@ -373,6 +373,7 @@ local_shutdown:
 remote_health:
   enabled: true
   startup_check: true
+  interval: 60   # minimum; the 3600 default would outlast the HEALTHY poll below
   failure_threshold: 1
 logging:
   file: null
@@ -415,10 +416,10 @@ YAML
     # collect_status serializes with sort_keys=True, so within each
     # remoteHealth entry "server" sits immediately before "status".
     # Poll for up to 75s (150 tries x 0.5s): the startup probe normally
-    # marks HEALTHY within seconds, but remote_health re-probes only every
-    # max(60, interval) seconds, so the window must clear one full retry
-    # cycle to survive a missed first probe instead of flaking. A match
-    # returns immediately, so this costs nothing on the happy path.
+    # marks HEALTHY within seconds. The config pins remote_health.interval
+    # to 60, so if the first probe is missed the next one fires at ~60s,
+    # inside this window, keeping the test deterministic instead of flaky.
+    # A match returns immediately, so this costs nothing on the happy path.
     if ! poll_http_pattern \
         "http://127.0.0.1:${port}/api/v1/ups" \
         "/tmp/e2e-strict-known-hosts-${attempt}-health.json" \


### PR DESCRIPTION
## Summary

Closes the documentation and test gaps behind two reported bugs:

- **Issue #73 — remote-server SSH keys untrusted in containers.** Accepting a host key interactively inside a container is lost on recreate. The container docs now tell operators to pre-seed a `known_hosts` file on the host, bind-mount it next to the private key, and point OpenSSH at it with `UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts` + `StrictHostKeyChecking=yes`. With strict checking the file can stay read-only in the container; `accept-new` is documented as the writable-mount alternative with its trade-off called out. uid `10001` key ownership/mode guidance is now consistent across the container walkthroughs.
- **Issue #71 — NUT name autodiscovery** (behaviour shipped in #72) now has end-to-end coverage proving a wrong single-UPS name self-heals at runtime.

## Tests added

| Test | Group | What it proves |
|------|-------|----------------|
| 57 | Loopback | Containerized remote SSH uses a mounted private key + mounted `known_hosts` with `StrictHostKeyChecking=yes`; the remote health probe reaches `HEALTHY` (proving the host key was trusted, not just that NUT was reachable) and the daemon stays ready after the container is recreated. |
| 58 | CLI | NUT name autodiscovery lists a single exposed UPS via `upsc -l`, auto-corrects the runtime poll target, and logs the `ups.name` fix hint. |

E2E inventory bumped 56 → 58; CI wiring guards updated for both new cases.

## Notes for reviewers

- Test 57 generates `known_hosts` by running `ssh-keyscan` from inside the compose network (the container resolves `ssh-target` by service name, not a host-published port). The keyscan uses `--entrypoint ssh-keyscan` because the image entrypoint is `tini -- eneru`.
- The `HEALTHY` assertion polls `/api/v1/ups` rather than `/ready`, because remote SSH health is advisory for `/ready` (an `UNKNOWN` probe still counts as ready); `/api/v1/ups` is the source of truth for per-target remote health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a secure container SSH known_hosts workflow and added E2E coverage for strict host‑key trust and NUT single‑UPS autodiscovery. Addresses #73 and #71 and bumps version to 6.1.0-rc2.

- **Documentation**
  - Recommend mounting a pre-seeded `known_hosts` next to the private key and setting `UserKnownHostsFile=/var/lib/eneru/ssh/known_hosts` with `StrictHostKeyChecking=yes`; note `accept-new` trade-offs and perms for uid `10001`.
  - Updated Kubernetes, migration, remote servers, config reference, testing, changelog (new rc2 entry), and example config to use the mounted `known_hosts` approach.

- **E2E Tests**
  - Test 57 (Loopback): containerized remote SSH uses a mounted private key and mounted `known_hosts` with strict checking; remote SSH probe must reach HEALTHY and the daemon stays ready across container recreate. Widened the HEALTHY poll to 75s and pinned `remote_health.interval` to 60s to avoid flakes.
  - Test 58 (CLI): NUT name autodiscovery fixes a wrong single-UPS name at runtime via `upsc -l` and logs the config-fix hint.
  - CI asserts both tests; inventory now 58.

<sup>Written for commit eb2cb141d8e5244fd81f1f8817323864ff0419eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded SSH host-key verification guidance for containerized deployments with secure `known_hosts` setup.
  * Added configuration examples showing how to use mounted `known_hosts` with `StrictHostKeyChecking` for remote servers.
  * Updated migration guides with step-by-step instructions for SSH key setup and host trust store preservation.

* **Tests**
  * Expanded E2E test coverage for containerized remote SSH with strict host-key verification and NUT name autodiscovery self-healing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->