### PR TITLE
fix(v6.1.2): self-test — credentialed discovery, softer permission, passive observation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -135,6 +135,15 @@ jobs:
             grep -q "Test 56: Event management" tests/e2e/groups/single-ups-auth.sh
           fi
 
+      - name: Verify v6.1.2 self-test E2E coverage is wired
+        if: matrix.group == 'single-ups-auth'
+        run: |
+          # v6.1.2 wiring guard: passive self-test observation + softened
+          # permission (self_test without nut_control; effective auth via DB
+          # user) must stay present, and the scenario file it depends on.
+          grep -q "Test 57: self-test passive observation" tests/e2e/groups/single-ups-auth.sh
+          grep -q "^ups.test.result:" tests/e2e/scenarios/self-test-passed.dev
+
       - name: Collect logs on failure
         if: failure()
         run: |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [6.1.2] - 2026-07-01
+
+Self-test fixes driven by real UniFi UPS testing, on top of 6.1.1. No shutdown
+behavior changes.
+
+### Fixed
+
+- **Self-test discovery ignored NUT credentials.** `upscmd -l` ran anonymously,
+  so on an upsd that only lists instant commands to a logged-in client (notably
+  UniFi's NUT) discovery came back empty and a supported test looked unsupported
+  ("does not expose 'test.battery.start'"). Discovery now forwards the
+  `nut_control` credentials to `upscmd -l`, with the password kept off argv.
+  Anonymous listing is unchanged when no credentials are set.
+- **Self-test validation ignored auth-DB users.** Enabling `self_test` demanded
+  `api.auth.enabled: true` even when auth was already active because a user
+  existed in the auth DB. Validation — and the `nut_control` → auth rule — now
+  honor the same effective-auth state the API enforces at runtime.
+
+### Changed
+
+- **Self-test no longer needs the full nut_control setup.** Enabling `self_test`
+  is now its own narrow permission granting exactly `self_test.command`; you no
+  longer also have to set `nut_control.enabled` and list the command in
+  `nut_control.allowed_commands`. API authentication is still required, and the
+  general control surface (arbitrary commands, variable writes) is untouched.
+  Credentials for `upscmd` still come from `nut_control` when your upsd requires
+  a login.
+
+### Added
+
+- **Passive self-test observation.** Eneru reads `ups.test.result` /
+  `ups.test.date` on every poll and records a `source: device` result whenever a
+  new pass/fail appears, whether or not scheduled self-tests are enabled. A UPS
+  that tests on its own cadence, or one you test by hand, now surfaces in the
+  dashboard, API, Prometheus, and the battery-health score with no configuration.
+  This path is covered end-to-end; issuing a test still is not, as the dummy NUT
+  driver has no INSTCMD.
+- **Daemon version + runtime in the dashboard footer.** The footer shows the
+  running Eneru version and where it runs (baremetal / container / Kubernetes)
+  ahead of the update time. Both are top-level fields in `GET /api/v1/ups`:
+  `version` (new) and `runtimeContext` (mirrors the existing `runtime.context`).
+
+---
+
 ## [6.1.1] - 2026-06-30
 
 Dashboard UX polish and bug fixes on top of 6.1.0. No config, API, or shutdown

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,7 +190,7 @@ Validation catches YAML errors, invalid enum values, local-resource ownership mi
 | `mqtt` | Global | Optional outbound MQTT status publishing |
 | `nut_control` | Global, overridable per group | UPS control via NUT (write surface; requires API auth) |
 | `battery_health` | Global, overridable per UPS | Battery health score + replacement prediction (v6.1) |
-| `self_test` | Global, overridable per UPS | Scheduled UPS battery self-test (v6.1; write surface) |
+| `self_test` | Global, overridable per UPS | UPS battery self-test — observe device-run results (no config) and optionally issue on a schedule (v6.1; issuing is a write surface) |
 | `reports` | Global | Periodic summary reports via the notification channel (v6.1) |
 | `energy` | Global | kWh and optional cost tracking (v6.1) |
 | `notifications` | Global | Apprise URLs, retry, coalescing, and event suppression |
@@ -341,7 +341,7 @@ The API is opt-in and binds to localhost by default when enabled. With `api.auth
 | `mqtt.broker` | `""` | Broker URL: `mqtt://host:port` for plaintext or `mqtts://host:port` for TLS via the system trust store (default port 8883 for `mqtts`). |
 | `mqtt.topic_prefix` | `eneru` | Topic prefix; messages publish to `<topic_prefix>/status` (QoS 0, retain false) |
 | `mqtt.publish_interval` | `10` | Republish at this interval even when the status fingerprint is unchanged |
-| `nut_control.enabled` | `false` | Enable UPS control (upscmd/upsrw). Requires `api.auth.enabled` or startup fails (write surface). See [UPS control](nut-control.md) |
+| `nut_control.enabled` | `false` | Enable UPS control (upscmd/upsrw). Requires API auth — `api.auth.enabled` **or** a user in the auth DB — or startup fails (write surface). See [UPS control](nut-control.md) |
 | `nut_control.username` | `""` | NUT `upsd.users` account with INSTCMD/SET actions |
 | `nut_control.password` | `""` | Password for that NUT account |
 | `nut_control.allowed_commands` | `[]` | Allowlisted instant commands (e.g. `test.battery.start`, `beeper.toggle`). Calibration/FSD omitted by default |

--- a/docs/self-test.md
+++ b/docs/self-test.md
@@ -1,44 +1,62 @@
 # Self-test
 
-Eneru can issue a UPS **battery self-test** — on a schedule, from the CLI, or
-from the dashboard — and record the result so it feeds the
-[battery-health score](battery-health.md). It uses the same NUT `upscmd` path as
-[UPS control](nut-control.md), so the same safety rules apply.
+Eneru handles UPS **battery self-tests** two ways:
 
-## Safety model
+1. **Observe** the result of a test the UPS ran on its own — on the device's own
+   schedule or triggered by hand — and record it (no configuration required).
+2. **Issue** a test itself — on a schedule, from the CLI, or from the dashboard.
 
-A self-test is a **write surface**. Enabling the scheduled test requires **all**
-of the following, or the daemon refuses to start — a scheduled test must never be
-a back door around the v6.0 control allowlist:
+Both feed the [battery-health score](battery-health.md). Issuing uses the same
+NUT `upscmd` path as [UPS control](nut-control.md).
 
-- `nut_control.enabled: true` with valid `upsd.users` credentials,
-- `api.auth.enabled: true` (auth-off always means read-only), and
-- `self_test.command` listed in `nut_control.allowed_commands`.
+## Observing device-run tests (no config)
 
-The same allowlist check runs on the scheduled path, the API path, and the
-`--direct` CLI path — none is exempt. If `upscmd -l` does not actually expose the
-configured command, the feature self-disables for that UPS with a logged warning.
+On every poll Eneru reads `ups.test.result` / `ups.test.date` and, when a new
+settled result appears (pass or fail), records it as a `source: device` row.
+This happens whether or not scheduled self-tests are enabled — many UPSes run a
+test on their own cadence (`ups.test.interval`), and some operators only ever
+test by hand. The latest result shows up in the dashboard, the API `selfTest`
+block, the Prometheus series, and the battery-health score with no setup.
+
+## Issuing tests: safety model
+
+Issuing a test is a **write surface**, so it always requires **API
+authentication** — an explicit `api.auth.enabled: true`, or simply a user in the
+auth DB (`eneru user create`), which activates auth with no restart. Auth-off
+always means read-only.
+
+Enabling `self_test` is its own narrow permission: it grants exactly the one
+command in `self_test.command`. You do **not** also need `nut_control.enabled`
+or that command on `nut_control.allowed_commands` — the general control surface
+(arbitrary `/command`, variable writes) stays gated separately. Credentials for
+`upscmd` still come from `nut_control.username`/`password` when your upsd
+requires a login to run instant commands.
+
+If `upscmd -l` does not expose the configured command, the feature self-disables
+for that UPS with a logged warning. Note that some upsd setups (notably UniFi's
+NUT) only return the command list to a **logged-in** client — Eneru forwards the
+`nut_control` credentials to `upscmd -l` so discovery works there.
 
 ## Configuration
 
 ```yaml
 api:
   auth:
-    enabled: true
-
-nut_control:
-  enabled: true
-  username: "eneru"
-  password: "secret"
-  allowed_commands:
-    - test.battery.start          # must include self_test.command
+    enabled: true            # or just: eneru user create <name>
 
 self_test:
   enabled: true
-  schedule: monthly               # daily | weekly | monthly | "every <N>d|h|m"
-  time: "03:00"                   # wall-clock for calendar schedules
-  command: test.battery.start     # adapts to what upscmd -l exposes
-  result_poll_after: 60           # seconds to wait before reading the result
+  schedule: monthly          # daily | weekly | monthly | "every <N>d|h|m"
+  time: "03:00"              # wall-clock for calendar schedules
+  command: test.battery.start # adapts to what upscmd -l exposes
+  result_poll_after: 60      # seconds to wait before reading the result
+
+# Only needed if your upsd requires a login for upscmd (list/issue). The
+# self_test command above is auto-permitted; you do NOT need nut_control.enabled
+# or an allowed_commands entry just for self-test.
+nut_control:
+  username: "eneru"
+  password: "secret"
 ```
 
 `schedule` accepts `daily`, `weekly`, `monthly`, or an interval such as
@@ -79,11 +97,14 @@ it when no daemon is running. `--ups` defaults to the only configured UPS.
 
 ## API and dashboard
 
-- `POST /api/v1/ups/{name}/self-test` — auth-gated, audited, allowlist-checked.
-- The latest result appears in the `selfTest` block of `GET /api/v1/ups`. (The
-  `GET /api/v1/ups/{name}/battery-health` endpoint returns the health score and
-  replacement projection; the self-test result lives in the status `selfTest`
-  block.)
+- `POST /api/v1/ups/{name}/self-test` — auth-gated and audited. Permitted when
+  `self_test` is enabled (grants exactly `self_test.command`) or the general
+  `nut_control` surface allows the command.
+- The latest result appears in the `selfTest` block of `GET /api/v1/ups`,
+  including its `source` (`device` for an observed test, `scheduler`/`api`/`cli`
+  for one Eneru issued). (The `GET /api/v1/ups/{name}/battery-health` endpoint
+  returns the health score and replacement projection; the self-test result
+  lives in the status `selfTest` block.)
 - The dashboard **Control** tab has a per-UPS *Run self-test* button; the
   **Battery** tab shows the latest result.
 - **Prometheus** → `eneru_ups_self_test_result{result="passed|failed|..."}`
@@ -91,8 +112,11 @@ it when no daemon is running. `--ups` defaults to the only configured UPS.
 
 ## Testing it for real
 
-The NUT **dummy driver has no INSTCMD**, so self-test has no end-to-end CI
-coverage (the logic is unit-tested). On real hardware, confirm `upscmd -l` lists
-your test command first — e.g. the Ubiquiti TOWER_1000VA exposes
-`test.battery.start` — then run `eneru self-test run` and check
+The NUT **dummy driver has no INSTCMD**, so *issuing* a test has no end-to-end CI
+coverage (the issue logic is unit-tested). The **observe** path *is* covered
+end-to-end: the E2E suite serves a dummy UPS reporting `ups.test.result` and
+asserts Eneru records a `source: device` row surfaced via the API. On real
+hardware, confirm `upscmd -l` lists your test command first — e.g. the Ubiquiti
+TOWER_1000VA exposes `test.battery.start` (pass `nut_control` credentials if your
+upsd requires a login to list) — then run `eneru self-test run` and check
 `eneru self-test status`.

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -216,11 +216,18 @@ battery_health:
     min_history_days: 14
 
 # ==============================================================================
-# SELF-TEST (v6.1) — scheduled UPS battery self-test
+# SELF-TEST (v6.1) — UPS battery self-test
 # ==============================================================================
-# A WRITE surface like nut_control: enabling it requires nut_control.enabled AND
-# api.auth.enabled AND that `command` is in nut_control.allowed_commands, so a
-# scheduled test can never bypass the control allowlist. See docs/self-test.md.
+# Two things (see docs/self-test.md):
+#  * OBSERVE — with NO config, Eneru reads ups.test.result / ups.test.date every
+#    poll and records a `source: device` result (a test the UPS ran on its own or
+#    that you triggered by hand). Surfaced in the dashboard/API/Prometheus.
+#  * ISSUE (below) — a WRITE surface. It requires API authentication (either
+#    api.auth.enabled OR a user in the auth DB). Enabling self_test is its OWN
+#    narrow permission that grants exactly `command` — you do NOT also need
+#    nut_control.enabled or that command in nut_control.allowed_commands. If your
+#    upsd requires a login for upscmd, set nut_control.username/password (the
+#    command list and issue calls use them).
 self_test:
   enabled: false
   # daily | weekly | monthly, or "every <N>d/h/m" (e.g. "every 30d").
@@ -228,7 +235,7 @@ self_test:
   # Wall-clock time for calendar schedules (HH:MM, daemon local time).
   time: "03:00"
   # The instant command to issue. Adapts to whatever `upscmd -l` exposes; many
-  # UPSes only support `test.battery.start`. Must be on the control allowlist.
+  # UPSes only support `test.battery.start`. Enabling self_test auto-permits it.
   command: test.battery.start
   # Seconds to wait after issuing before polling ups.test.result.
   result_poll_after: 60

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 from eneru import nut_control as nutctl
 from eneru import self_test as selftest
-from eneru.auth import AuthStore
+from eneru.auth import AuthStore, auth_is_active
 from eneru.status import (
     HISTORY_METRICS,
     collect_status,
@@ -185,29 +185,13 @@ API_ENDPOINTS = (
 
 
 def _auth_is_active(config: Any) -> bool:
-    """Whether API authentication is effectively enforced.
+    """Whether API authentication is effectively enforced for ``config``.
 
-    An explicit ``api.auth.enabled`` (true *or* false) always wins. When it is
-    left unset, auth is active iff the auth DB already has at least one user — so
-    "create a user, then sign in" works **with no restart**, while a fresh
-    install with no users stays open (v5.3 read-only behavior). The DB is never
-    created as a side effect of this check. Once the DB file exists, a
-    broken/unreadable DB fails closed to "active": reads that require auth stay
-    gated and writes require credentials rather than silently reopening.
+    Thin wrapper over :func:`eneru.auth.auth_is_active` (the shared source of
+    truth, also used by config validation): an explicit ``api.auth.enabled``
+    always wins; when unset, auth is active iff the auth DB already has a user.
     """
-    auth_cfg = getattr(getattr(config, "api", None), "auth", None)
-    if auth_cfg is None:
-        return False
-    if getattr(auth_cfg, "enabled_explicitly_set", False):
-        return bool(auth_cfg.enabled)
-    if auth_cfg.enabled:
-        return True
-    try:
-        if not os.path.exists(auth_cfg.db_path):
-            return False
-        return AuthStore(auth_cfg.db_path).user_count() > 0
-    except Exception:
-        return True
+    return auth_is_active(getattr(getattr(config, "api", None), "auth", None))
 
 
 class EneruAPIServer:
@@ -914,26 +898,36 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         return 404, "application/json", self._not_found("Endpoint not found")
 
     def _run_self_test(self, ups_name: str) -> Tuple[int, str, Any]:
-        """Issue a UPS self-test (auth-gated, audited). Goes through the same
-        nut_control allowlist as the manual command path -- the self-test
-        command must be allowlisted."""
+        """Issue a UPS self-test (auth-gated, audited).
+
+        Authentication (enforced by ``_authorize(write=True)``) is the real
+        privilege gate. Permission to issue the command comes from
+        ``self_test.self_test_control``: enabling ``self_test`` grants exactly
+        ``self_test.command`` (v6.1.2), OR the general control surface allows it
+        (``nut_control.enabled`` + allowlist). The general ``/command`` and
+        variable endpoints still require ``nut_control.enabled`` independently."""
         principal = self._authorize(write=True)
-        self._require_nut_control()
         real = self._resolve_ups_name(ups_name)
         if real is None:
             return 404, "application/json", self._not_found("UPS not found")
         nc = self._effective_nut_control(real)
-        command = self._effective_self_test(real).command
-        if not nutctl.command_allowed(command, nc.allowed_commands):
+        st_cfg = self._effective_self_test(real)
+        command = st_cfg.command
+        if not command:
+            raise APIBadRequest("self_test.command is not configured")
+        permitted, nc = selftest.self_test_control(nc, st_cfg, command)
+        if not permitted:
             self._audit(principal, "self-test", f"{real}:{command}", "denied")
             raise APIForbidden(
-                f"self_test.command {command!r} is not in allowed_commands")
+                "self-test is not permitted: enable self_test, or enable "
+                "nut_control and add the command to allowed_commands")
         # Preflight against `upscmd -l` like the scheduled/direct paths, so the
         # API honors the same "self-disable if unsupported" contract the docs
         # promise rather than letting NUT reject it after the fact.
         try:
             exposed = selftest.discover_self_test_command(
-                real, command, timeout=nc.timeout)
+                real, command, username=nc.username, password=nc.password,
+                timeout=nc.timeout)
         except selftest.SelfTestUnavailable as exc:
             self._audit(principal, "self-test", f"{real}:{command}", "failed")
             return 502, "application/json", self._error("NUT_ERROR", str(exc))
@@ -1158,7 +1152,8 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         if real is None:
             return 404, "application/json", self._not_found("UPS not found")
         nc = self._effective_nut_control(real)
-        ok, commands, err = nutctl.list_commands(real, timeout=nc.timeout)
+        ok, commands, err = nutctl.list_commands(
+            real, username=nc.username, password=nc.password, timeout=nc.timeout)
         if not ok:
             return 502, "application/json", self._error("NUT_ERROR", err)
         allowed = set(nc.allowed_commands)
@@ -1311,6 +1306,12 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         auth_enabled = self._auth_active()
         nut_enabled = bool(getattr(getattr(self.api_config, "nut_control", None),
                                    "enabled", False))
+        # v6.1.2: self-test is reachable when self_test is enabled (its own narrow
+        # permission) OR the general control surface is on — global or per-UPS.
+        self_test_enabled = bool(
+            getattr(getattr(self.api_config, "self_test", None), "enabled", False)
+            or any(getattr(getattr(g, "self_test", None), "enabled", False)
+                   for g in getattr(self.api_config, "ups_groups", [])))
 
         def _visible(path: str) -> bool:
             if path == "/metrics":
@@ -1325,9 +1326,10 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
                     path.startswith("/api/v1/ups/{name}/variables"):
                 return nut_enabled
             if path == "/api/v1/ups/{name}/self-test":
-                # POST self-test needs auth (write) AND nut_control, exactly like
-                # the manual control path.
-                return auth_enabled and nut_enabled
+                # POST self-test needs auth (write) AND permission — either
+                # self_test enabled (its own narrow grant) or the general
+                # nut_control surface.
+                return auth_enabled and (self_test_enabled or nut_enabled)
             return True
 
         return [dict(e) for e in API_ENDPOINTS if _visible(e["path"])]

--- a/src/eneru/auth.py
+++ b/src/eneru/auth.py
@@ -32,7 +32,7 @@ import sqlite3
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 SCHEMA_VERSION = 1
@@ -375,6 +375,39 @@ class AuthStore:
             )
         return {"id": row["id"], "label": row["label"], "role": row["role"],
                 "kind": "api_key"}
+
+
+def auth_is_active(auth_cfg: Any) -> bool:
+    """Whether API authentication is effectively enforced for ``auth_cfg``.
+
+    ELI5: the config file is one light switch, the account book is another.
+    Auth is "on" if the operator flicked the switch (``api.auth.enabled``,
+    true *or* false, always wins) OR — when they never touched the switch —
+    the account book already has at least one name in it. So "create a user,
+    then just sign in" works with no restart and no config edit.
+
+    Shared by the API request path AND config validation so both agree on the
+    same effective state (a user in the DB is enough; the raw ``enabled`` flag
+    is not the only source of truth). The DB is never created as a side effect
+    of the check; once the DB file exists, a broken/unreadable DB fails closed
+    to "active" so writes keep demanding credentials rather than silently
+    reopening.
+    """
+    if auth_cfg is None:
+        return False
+    if getattr(auth_cfg, "enabled_explicitly_set", False):
+        return bool(auth_cfg.enabled)
+    if getattr(auth_cfg, "enabled", False):
+        return True
+    db_path = getattr(auth_cfg, "db_path", None)
+    if not db_path:
+        return False
+    try:
+        if not os.path.exists(db_path):
+            return False
+        return AuthStore(db_path).user_count() > 0
+    except Exception:
+        return True
 
 
 def _validate_username(username: str) -> str:

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -1984,20 +1984,24 @@ def _self_test_run_api(
 def _self_test_run_direct(
         config: Config, group: UPSGroupConfig, name: str) -> None:
     from eneru import self_test as selftest
-    from eneru.nut_control import command_allowed, command_lock
+    from eneru.nut_control import command_lock
     nc = _effective_nut_control(config, group)
-    if not nc.enabled:
-        print("nut_control is not enabled. --direct issues a real command via "
-              "NUT and needs nut_control credentials + allowlist in the config.")
-        sys.exit(2)
+    st_cfg = getattr(group, "self_test", None) or config.self_test
     command = _resolve_self_test_command(config, group)
-    if not command_allowed(command, nc.allowed_commands):
-        print(f"self_test.command {command!r} is not in "
-              "nut_control.allowed_commands; refusing (the direct path is not "
-              "exempt from the control allowlist).")
+    # self_test is its own narrow permission (v6.1.2): enabling it grants exactly
+    # this command, else the general control surface must allow it. Returns the
+    # effective nut_control (command guaranteed allowlisted; creds inherited).
+    permitted, nc = selftest.self_test_control(nc, st_cfg, command)
+    if not permitted:
+        print("Self-test is not permitted by the config: enable self_test, or "
+              "enable nut_control and add the command to allowed_commands. "
+              "--direct issues a real command via NUT and needs nut_control "
+              "credentials in the config.")
         sys.exit(2)
     try:
-        cmd = selftest.discover_self_test_command(name, command, timeout=nc.timeout)
+        cmd = selftest.discover_self_test_command(
+            name, command, username=nc.username, password=nc.password,
+            timeout=nc.timeout)
     except selftest.SelfTestUnavailable as exc:
         print(f"Could not query the UPS ({exc}); try again.")
         sys.exit(1)

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -2582,12 +2582,16 @@ class ConfigLoader:
         # Fail-closed: UPS control is a write surface, so it must never be
         # reachable without authentication. "Auth disabled" means read-only,
         # full stop — refuse to start rather than expose unauthenticated control.
-        if config.nut_control.enabled and not config.api.auth.enabled:
+        # Honor the EFFECTIVE auth state (explicit api.auth.enabled OR a user
+        # already in the auth DB), matching how the API decides enforcement at
+        # runtime — so "create a user, then enable control" doesn't false-error.
+        from eneru.auth import auth_is_active as _auth_is_active
+        if config.nut_control.enabled and not _auth_is_active(config.api.auth):
             messages.append(
-                "ERROR: nut_control.enabled requires api.auth.enabled — UPS "
+                "ERROR: nut_control.enabled requires API authentication — UPS "
                 "control endpoints are write operations and must be "
-                "authenticated. Enable api.auth and create a user with "
-                "'eneru user create' first."
+                "authenticated. Set api.auth.enabled: true or create a user "
+                "with 'eneru user create' first."
             )
 
         messages.extend(cls._validate_v61(config))
@@ -2605,7 +2609,6 @@ class ConfigLoader:
         # Imported lazily to avoid any import-cycle risk at config import time.
         from eneru.self_test import parse_schedule as _parse_schedule
         from eneru.scheduler import parse_hhmm as _parse_hhmm
-        from eneru import nut_control as _nutctl
         from eneru.scheduler import parse_weekday as _parse_weekday
 
         st_glob = config.self_test
@@ -2665,39 +2668,46 @@ class ConfigLoader:
                 f"ERROR: reports.format must be one of "
                 f"{', '.join(_REPORT_FORMATS)}, got {reports.format!r}")
 
-        # Self-test is a scheduled write surface. Validate the EFFECTIVE config
-        # per UPS (per-UPS override else global) against the EFFECTIVE
-        # nut_control, so a per-UPS-narrowed allowlist or a global command that
-        # isn't in a group's own allowlist is caught — a scheduled test can never
-        # be a back door around the v6.0 control allowlist.
+        # Self-test is a scheduled write surface. Authentication is the real
+        # privilege gate (a self-test issues a NUT control command), so enabling
+        # self_test requires EFFECTIVE auth — an explicit api.auth.enabled OR a
+        # user already in the auth DB, matching how the API decides enforcement
+        # at runtime. From v6.1.2, enabling self_test is its OWN narrow
+        # permission: it grants exactly self_test.command without also needing
+        # nut_control.enabled or that command on nut_control.allowed_commands
+        # (the general control surface is unchanged; see self_test.self_test_control).
+        # Credentials for upscmd still come from nut_control.username/password
+        # when the UPS requires auth for INSTCMD — that can't be validated here.
+        from eneru.auth import auth_is_active as _auth_is_active
+        auth_active = _auth_is_active(config.api.auth)
         for group in config.ups_groups:
             st = getattr(group, "self_test", None) or config.self_test
             if not st.enabled:
                 continue
             name = group.ups.name
-            nc = group.nut_control or config.nut_control
-            if not nc.enabled:
+            if not auth_active:
                 messages.append(
-                    f"ERROR: self_test for UPS '{name}' requires "
-                    "nut_control.enabled (per-UPS or global) — self-tests issue "
-                    "a UPS command via NUT control.")
-            if not config.api.auth.enabled:
-                messages.append(
-                    f"ERROR: self_test for UPS '{name}' requires "
-                    "api.auth.enabled — a scheduled self-test is privileged.")
+                    f"ERROR: self_test for UPS '{name}' requires API "
+                    "authentication — set api.auth.enabled: true or create a "
+                    "user with 'eneru user create'. A scheduled self-test is "
+                    "privileged.")
             cmd = (st.command or "").strip() if st.command else ""
             if not cmd:
                 messages.append(
                     f"ERROR: self_test for UPS '{name}' is enabled but has no "
-                    "command — set self_test.command (per-UPS or global) to a "
-                    "command on nut_control.allowed_commands "
-                    "(e.g. 'test.battery.start').")
-            elif not _nutctl.command_allowed(cmd, nc.allowed_commands):
+                    "command — set self_test.command (per-UPS or global) to the "
+                    "instant command your UPS exposes (e.g. 'test.battery.start').")
+            elif not cmd.startswith("test."):
+                # Enabling self_test auto-permits exactly this command WITHOUT the
+                # nut_control allowlist, so a non-test command here (e.g.
+                # shutdown.return, load.off) is a real control grant. Warn — don't
+                # block — so a deliberate vendor test command that isn't named
+                # test.* still works, but an accidental footgun is visible.
                 messages.append(
-                    f"ERROR: self_test.command '{st.command}' for UPS '{name}' "
-                    "is not in nut_control.allowed_commands — a scheduled test "
-                    "must not bypass the control allowlist. Add it to "
-                    "nut_control.allowed_commands.")
+                    f"WARNING: self_test.command '{cmd}' for UPS '{name}' is not "
+                    "a battery-test command (no 'test.' prefix). Enabling "
+                    "self_test grants exactly this command via NUT, bypassing the "
+                    "nut_control allowlist — confirm this is intentional.")
 
         # Battery-health numeric fields must be numbers (a quoted/typo'd YAML
         # value would otherwise blow up the runtime int()/float() coercions).

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -2104,13 +2104,14 @@ class UPSGroupMonitor(
 
         # If connection_state == "FAILED": already notified, nothing to do
 
-    def _run_periodic_tasks(self) -> None:
+    def _run_periodic_tasks(self, ups_data: Optional[Dict[str, str]] = None) -> None:
         """End-of-iteration per-UPS periodic tasks (v6.1).
 
         Time-gated and fully failure-isolated: any exception here is logged
         and swallowed so a scheduler/health hiccup can never interrupt the
         poll loop or the shutdown path. The battery-health interval is read
-        live from config (SAFE hot-reload). Self-test is wired in B6.
+        live from config (SAFE hot-reload). ``ups_data`` is the latest
+        successful poll, used by the passive self-test observer.
         """
         try:
             bh = self._resolve_battery_health_config()
@@ -2127,6 +2128,12 @@ class UPSGroupMonitor(
             self._run_self_test_task()
         except Exception as exc:
             self._log_message(f"⚠️  self-test task failed: {exc}")
+        # Passive observation: record a self-test the UPS ran on its own
+        # (device schedule or a manual test), independent of self_test.enabled.
+        try:
+            self._check_observed_self_test(ups_data)
+        except Exception as exc:
+            self._log_message(f"⚠️  self-test observer failed: {exc}")
         # Reports are daemon-wide (one digest). In multi-UPS mode the
         # coordinator owns them; a per-group monitor must not send N copies.
         try:
@@ -2167,6 +2174,44 @@ class UPSGroupMonitor(
                     and getattr(group, "nut_control", None)):
                 return group.nut_control
         return glob
+
+    def _check_observed_self_test(self, ups_data: Optional[Dict[str, str]]) -> None:
+        """Record a self-test the UPS ran on its own (device schedule or manual).
+
+        ELI5: your UPS keeps its own logbook — "last test: passed, 2026-06-02".
+        Eneru reads that logbook on every poll and copies a NEW settled entry
+        into its own records exactly once. A fingerprint in the meta table stops
+        it re-copying the same entry, and it stands down while an Eneru-issued
+        test is mid-flight (that path owns its own row). This runs regardless of
+        whether scheduled self-tests are enabled — some UPSes test on their own
+        cadence, and some operators only ever test by hand.
+        """
+        store = getattr(self, "_stats_store", None)
+        if store is None or not getattr(store, "is_open", False):
+            return
+        raw = (ups_data or {}).get("ups.test.result")
+        if not raw:
+            return  # this UPS doesn't report a test result
+        enum = selftest.normalize_result(raw)
+        # Only persist a SETTLED, meaningful result. running/unknown churn while a
+        # test is in flight or was never run; unsupported is one-time noise.
+        if enum not in ("passed", "failed"):
+            return
+        date = (ups_data or {}).get("ups.test.date") or ""
+        key = f"{date}|{raw}"
+        # Fingerprint of the last result Eneru already accounted for — via this
+        # observer OR its own scheduled finalise (which stamps the same key).
+        if store.get_meta("self_test_observed_key") == key:
+            return
+        # Never race the scheduled path: it owns the row for a test it issued.
+        if self._self_test_pending_id is not None:
+            return
+        # command="" — Eneru issued nothing; this is the device's own test.
+        store.record_self_test(
+            "", "device", result_raw=raw, result_enum=enum,
+            result_date=(date or None))
+        store.set_meta("self_test_observed_key", key)
+        self._log_message(f"🔋 Observed UPS self-test: {enum} ({raw!r})")
 
     def _run_self_test_task(self) -> None:
         """Issue / poll the scheduled UPS self-test (v6.1).
@@ -2214,6 +2259,10 @@ class UPSGroupMonitor(
                 enum = selftest.record_self_test_result(
                     store, self._self_test_pending_id, raw, date)
                 self._log_message(f"🔋 Self-test result: {enum} ({raw!r})")
+                # Stamp the observer fingerprint so the passive path doesn't
+                # re-record the same result Eneru just finalised.
+                store.set_meta(
+                    "self_test_observed_key", f"{date or ''}|{raw or ''}")
                 self._self_test_pending_id = None
                 self._self_test_poll_due_mono = None
                 store.set_meta("self_test_pending_id", "")  # cleared
@@ -2224,11 +2273,12 @@ class UPSGroupMonitor(
         if not cfg.enabled:
             return
         nc = self._resolve_nut_control_config()
-        # Defense-in-depth: never issue a control command unless nut_control is
-        # enabled (validation requires this for the global case; this also
-        # covers a per-UPS self_test override paired with control disabled).
-        if not nc.enabled:
-            return
+        # self_test is its own narrow permission (v6.1.2): enabling it grants
+        # exactly cfg.command even when nut_control is otherwise off. Auth is the
+        # real privilege gate and is enforced at config-validation time, so it
+        # is not re-checked here. The effective nut_control (cfg.command
+        # guaranteed on its allowlist; credentials/timeout inherited) is built
+        # at issue time below.
 
         # 2) Due? (calendar/interval via the shared scheduler helpers)
         try:
@@ -2272,7 +2322,8 @@ class UPSGroupMonitor(
         # 30-day) cadence; a genuine "not exposed" still consumes the cycle.
         try:
             cmd = selftest.discover_self_test_command(
-                self._poll_target, cfg.command, timeout=nc.timeout)
+                self._poll_target, cfg.command, username=nc.username,
+                password=nc.password, timeout=nc.timeout)
         except selftest.SelfTestUnavailable as exc:
             self._log_message(
                 f"⚠️  self-test discovery failed ({exc}); retrying next cycle")
@@ -2287,9 +2338,12 @@ class UPSGroupMonitor(
         # Serialize against the API control path (same per-UPS lock identity) so
         # a scheduled self-test can't race an operator-issued command/self-test
         # on the same device.
+        # Build the effective control the issue path uses: self_test.enabled
+        # auto-allows exactly `cmd` (the general allowlist is untouched).
+        _permitted, eff_nc = selftest.self_test_control(nc, cfg, cmd)
         with nutctl.command_lock(self._poll_target):
             result = selftest.issue_self_test(
-                self._poll_target, cmd, nc, store, source="scheduler")
+                self._poll_target, cmd, eff_nc, store, source="scheduler")
         if result["ok"]:
             # Stamp the cadence ONLY once the issue succeeds: a failed issue
             # (NUT error, transient lock contention) must retry next cycle, not
@@ -2598,6 +2652,6 @@ class UPSGroupMonitor(
             # v6.1: time-gated per-UPS periodic tasks (battery-health update,
             # self-test). Failure-isolated so a scheduler hiccup can never
             # touch the poll/shutdown path.
-            self._run_periodic_tasks()
+            self._run_periodic_tasks(ups_data)
 
             self._stop_event.wait(self.config.ups.check_interval)

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -2207,9 +2207,11 @@ class UPSGroupMonitor(
         if self._self_test_pending_id is not None:
             return
         # command="" — Eneru issued nothing; this is the device's own test.
-        store.record_self_test(
+        test_id = store.record_self_test(
             "", "device", result_raw=raw, result_enum=enum,
             result_date=(date or None))
+        if test_id is None:
+            return  # write failed — don't fingerprint, so it retries next poll
         store.set_meta("self_test_observed_key", key)
         self._log_message(f"🔋 Observed UPS self-test: {enum} ({raw!r})")
 

--- a/src/eneru/nut_control.py
+++ b/src/eneru/nut_control.py
@@ -85,6 +85,18 @@ def _validated_auth_command_argv(cmd: List[str]) -> Tuple[Optional[List[str]], s
     binary = cmd[0]
     args = cmd[1:]
     if binary == "upscmd":
+        # Authenticated LIST: `upscmd -u user -l ups`. Some upsd setups (e.g.
+        # UniFi's NUT) only return the instant-command list to a logged-in
+        # client, so listing must be able to carry credentials just like an
+        # INSTCMD. `-l` is a fixed literal we control (never validated as data).
+        if len(args) == 4 and args[0] == "-u" and args[2] == "-l":
+            username, error = _safe_auth_data_arg(args[1])
+            if error:
+                return None, error
+            ups_name, error = _safe_auth_data_arg(args[3])
+            if error:
+                return None, error
+            return ["upscmd", "-u", username, "-l", ups_name], ""
         if len(args) == 2:
             ups_name, error = _safe_auth_data_arg(args[0])
             if error:
@@ -160,6 +172,15 @@ def _popen_validated_auth_command(
         if len(safe_cmd) == 3:
             return subprocess.Popen(
                 ["upscmd", safe_cmd[1], safe_cmd[2]],
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                close_fds=True,
+            )
+        if safe_cmd[3] == "-l":
+            # Authenticated list: upscmd -u user -l ups (keep -l a literal).
+            return subprocess.Popen(
+                ["upscmd", "-u", safe_cmd[2], "-l", safe_cmd[4]],
                 stdin=slave_fd,
                 stdout=slave_fd,
                 stderr=slave_fd,
@@ -285,12 +306,22 @@ def _run_auth_command(
                     pass
 
 
-def list_commands(ups_name: str, *, timeout: int = 10) -> Tuple[bool, List[str], str]:
+def list_commands(ups_name: str, *, username: str = "", password: str = "",
+                  timeout: int = 10) -> Tuple[bool, List[str], str]:
     """Return the instant commands a UPS supports (``upscmd -l``).
 
-    Listing needs no credentials. Returns ``(ok, commands, error)``.
+    Returns ``(ok, commands, error)``. Pass ``username``/``password`` when the
+    upsd requires a logged-in client to list commands — some setups (notably
+    UniFi's NUT) return an EMPTY list to an anonymous ``upscmd -l``, which would
+    otherwise look like "the UPS doesn't expose the command". When both are
+    given the credentialed PTY path is used (password never on argv); otherwise
+    it falls back to an anonymous listing (unchanged v6.0 behavior).
     """
-    code, out, err = run_command(["upscmd", "-l", ups_name], timeout=timeout)
+    if username and password:
+        code, out, err = _run_auth_command(
+            ["upscmd", "-u", username, "-l", ups_name], password, timeout=timeout)
+    else:
+        code, out, err = run_command(["upscmd", "-l", ups_name], timeout=timeout)
     if code != 0:
         return False, [], (err.strip() or out.strip() or f"upscmd exited {code}")
     return True, _parse_command_list(out), ""

--- a/src/eneru/self_test.py
+++ b/src/eneru/self_test.py
@@ -11,7 +11,8 @@ exercised end-to-end (the maintainer validates it against real hardware).
 Everything here keeps I/O behind ``nut_control`` so tests mock it.
 """
 
-from typing import Dict, Optional
+from dataclasses import replace
+from typing import Dict, Optional, Tuple
 
 from eneru import nut_control as nutctl
 from eneru.scheduler import Schedule
@@ -24,6 +25,7 @@ __all__ = [
     "normalize_result",
     "parse_schedule",
     "record_self_test_result",
+    "self_test_control",
 ]
 
 
@@ -62,6 +64,7 @@ def normalize_result(raw: Optional[str]) -> str:
 
 
 def discover_self_test_command(ups_name: str, command: str, *,
+                               username: str = "", password: str = "",
                                timeout: int = 10) -> Optional[str]:
     """Return ``command`` if ``upscmd -l`` actually exposes it, else ``None``.
 
@@ -69,11 +72,58 @@ def discover_self_test_command(ups_name: str, command: str, *,
     UPS). A *transient* ``upscmd -l`` failure raises ``SelfTestUnavailable`` so
     the caller can retry instead of mistaking a dropped connection for an
     unsupported command (which on a 30-day cadence would skip a whole cycle).
+
+    Credentials are forwarded to ``upscmd -l`` because some upsd setups only
+    return the command list to a logged-in client — without them the list comes
+    back empty and a supported command looks unsupported.
     """
-    ok, commands, err = nutctl.list_commands(ups_name, timeout=timeout)
+    ok, commands, err = nutctl.list_commands(
+        ups_name, username=username, password=password, timeout=timeout)
     if not ok:
         raise SelfTestUnavailable(err or "upscmd -l failed")
     return command if command in commands else None
+
+
+def _with_command_allowed(nut_control, command: str):
+    """A copy of ``nut_control`` with ``command`` guaranteed on its allowlist."""
+    allowed = list(getattr(nut_control, "allowed_commands", None) or [])
+    if command and command not in allowed:
+        allowed.append(command)
+        return replace(nut_control, allowed_commands=allowed)
+    return nut_control
+
+
+def self_test_control(nut_control, self_test_cfg,
+                      command: str) -> Tuple[bool, object]:
+    """Decide whether ``command`` may be issued as a self-test, and under what
+    effective ``nut_control``. Returns ``(permitted, effective_nut_control)``.
+
+    ELI5: a self-test used to need a full key ring — flip nut_control on AND put
+    the test command on its allowlist AND turn auth on. That was three keys for
+    one door. From v6.1.2, turning ``self_test`` on is its own key that opens
+    exactly ONE door: the single command you configured in ``self_test.command``.
+    Every other control door (arbitrary commands, variable writes) still needs
+    the old key ring. Authentication is still mandatory — that lock never comes
+    off — but it is enforced by the caller / config validation, not here.
+
+    Precedence:
+      * ``self_test.enabled`` → permitted; the returned ``nut_control`` has
+        ``command`` guaranteed on its allowlist (so :func:`issue_self_test`'s
+        shared allowlist check still passes) while inheriting the configured
+        credentials / timeout unchanged.
+      * else if the GENERAL control surface already allows it
+        (``nut_control.enabled`` AND ``command`` on the allowlist) → permitted,
+        ``nut_control`` returned unchanged (v6.0/v6.1 behavior).
+      * else → not permitted.
+    """
+    if bool(getattr(self_test_cfg, "enabled", False)):
+        return True, _with_command_allowed(nut_control, command)
+    if (bool(getattr(nut_control, "enabled", False))
+            and nutctl.command_allowed(command,
+                                       getattr(nut_control, "allowed_commands",
+                                               None))):
+        return True, nut_control
+    return False, nut_control
 
 
 def issue_self_test(ups_name: str, command: str, nut_control, store, *,

--- a/src/eneru/status.py
+++ b/src/eneru/status.py
@@ -18,6 +18,7 @@ from eneru.remote_health import (
 from eneru.redundancy import effective_redundancy_health
 from eneru.stats import StatsStore
 from eneru.utils import command_exists
+from eneru.version import __version__
 
 
 HISTORY_METRICS = {
@@ -259,8 +260,14 @@ def collect_status(source: Any) -> Dict[str, Any]:
     """Collect all live UPS statuses from a source object."""
     monitors = iter_monitors(source)
     config = getattr(source, "config", None)
+    # Detect once and surface at the top level (alongside `version`) so consumers
+    # can read the running build AND where it runs — baremetal / container /
+    # Kubernetes — without digging into the nested `runtime` object below.
+    runtime_label = _runtime_context_label()
     payload: Dict[str, Any] = {
         "generatedAt": time.time(),
+        "version": __version__,
+        "runtimeContext": runtime_label,
         "ups": [monitor_status(m) for m in monitors],
         "redundancyGroups": redundancy_group_statuses(source, config),
     }
@@ -270,7 +277,7 @@ def collect_status(source: Any) -> Dict[str, Any]:
         health_rows = live_remote_health(source, config)
         loopback_row = _loopback_health_row(health_rows)
         payload["runtime"] = {
-            "context": _runtime_context_label(),
+            "context": runtime_label,
             "loopbackDelegate": _loopback_runtime_summary(config, loopback_row),
         }
     return payload

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.1.1"
+__version__ = "6.1.2"

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -2834,9 +2834,19 @@ function initTabs() {
 
 // ----- polling -----
 
+// Daemon build + runtime context, learned from the /api/v1/ups payload and shown
+// in the footer ahead of the "Updated · <time>" so the running version and where
+// it runs (baremetal / container / Kubernetes) are always visible.
+let daemonVersion = null;
+let daemonRuntime = null;
+
 function setStatus(msg) {
-  document.getElementById("status-line").textContent =
-    msg + " · " + new Date().toLocaleTimeString();
+  const bits = [];
+  if (daemonVersion) bits.push("Eneru v" + daemonVersion);
+  if (daemonRuntime) bits.push(daemonRuntime);
+  bits.push(msg);
+  bits.push(new Date().toLocaleTimeString());
+  document.getElementById("status-line").textContent = bits.join(" · ");
 }
 
 async function refresh() {
@@ -2867,6 +2877,13 @@ async function refresh() {
   if (rh.ok) remoteHealthSnapshot = (rh.data && rh.data.servers) || [];
 
   const ups = await api("/api/v1/ups");
+  if (ups.ok && ups.data) {
+    if (ups.data.version) daemonVersion = ups.data.version;
+    // Prefer the top-level runtimeContext; fall back to the nested runtime block.
+    const rc = ups.data.runtimeContext
+      || (ups.data.runtime && ups.data.runtime.context);
+    if (rc) daemonRuntime = rc;
+  }
   if (ups.ok) {
     // Poll-driven redraws must not yank the operator back to the top of a tab
     // they have scrolled (battery health, energy cards, overview, …). Explicit

--- a/tests/e2e/groups/single-ups-auth.sh
+++ b/tests/e2e/groups/single-ups-auth.sh
@@ -503,5 +503,113 @@ wait "$DAEMON_PID" 2>/dev/null || true
 trap - EXIT
 echo "PASS: event wide-range query, auth-gated delete, and history validation verified"
 )
+
+# ======================================================================
+# Test 57: self-test — passive observation + softened permission (v6.1.2)
+# ======================================================================
+# Two v6.1.2 behaviours the pre-6.1.2 suite never exercised:
+#   (A) enabling self_test no longer requires nut_control.enabled, and
+#       effective auth may come from a USER IN THE AUTH DB (not only the
+#       api.auth.enabled flag) -- so `eneru validate` accepts that shape;
+#   (B) Eneru passively records the UPS's OWN self-test result
+#       (ups.test.result / ups.test.date) as a source=device row, surfaced
+#       in the /api/v1/ups selfTest block, regardless of self_test being on.
+# The dummy-ups driver has no INSTCMD, so ISSUING a test cannot be E2E'd;
+# (A)+(B) are the reachable — and previously-missing — self-test coverage.
+echo ">>> Running: Test 57: self-test passive observation + softened permission"
+(
+set -euo pipefail
+
+ST_AUTH_DB="$(mktemp -d)/auth.db"
+printf 's3cret-pw' | eneru user create operator --password-stdin --auth-db "$ST_AUTH_DB" \
+  || { echo "FAIL: could not create auth user"; exit 1; }
+
+# --- (A) validate: self_test on + nut_control OFF + auth via DB user -> OK ---
+cat > /tmp/config-e2e-selftest-soft.yaml <<YAML
+ups:
+  name: "TestUPS@localhost:3493"
+behavior:
+  dry_run: true
+statistics:
+  enabled: true
+  db_directory: "$(mktemp -d)"
+api:
+  enabled: true
+  bind: "127.0.0.1"
+  port: 9100
+  auth:
+    db_path: "$ST_AUTH_DB"
+    require_for_reads: false
+self_test:
+  enabled: true
+  command: test.battery.start
+notifications:
+  enabled: false
+local_shutdown:
+  enabled: false
+YAML
+
+if ! eneru validate --config /tmp/config-e2e-selftest-soft.yaml >/tmp/test57-val.log 2>&1; then
+  echo "FAIL: self_test + auth-via-DB-user + nut_control off should validate"
+  cat /tmp/test57-val.log; exit 1
+fi
+echo "PASS: self_test validates without nut_control.enabled (auth via DB user)"
+
+# --- (A negative) self_test on but NO auth at all -> validation error ---
+cat > /tmp/config-e2e-selftest-noauth.yaml <<YAML
+ups:
+  name: "TestUPS@localhost:3493"
+api:
+  auth:
+    db_path: "$(mktemp -d)/empty-auth.db"
+self_test:
+  enabled: true
+  command: test.battery.start
+YAML
+if eneru validate --config /tmp/config-e2e-selftest-noauth.yaml >/tmp/test57-noauth.log 2>&1; then
+  echo "FAIL: self_test without any auth must be rejected at validation"
+  cat /tmp/test57-noauth.log; exit 1
+fi
+grep -q "requires API authentication" /tmp/test57-noauth.log \
+  || { echo "FAIL: expected 'requires API authentication' error"; cat /tmp/test57-noauth.log; exit 1; }
+echo "PASS: self_test without auth is rejected at validation"
+
+# --- (B) passive observation: the UPS reports its own last self-test ---
+apply_scenario self-test-passed
+timeout 30s eneru run --config /tmp/config-e2e-selftest-soft.yaml > /tmp/test57-daemon.log 2>&1 &
+DAEMON_PID=$!
+trap 'kill "$DAEMON_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 30); do
+  curl -fsS http://127.0.0.1:9100/health >/dev/null 2>&1 && break
+  sleep 0.5
+done
+
+# Poll the anonymous /api/v1/ups read until the observer has recorded the
+# device result into the selfTest block (record commits immediately).
+RESULT=""; SOURCE=""; DATE=""
+for _ in $(seq 1 40); do
+  if curl -fsS http://127.0.0.1:9100/api/v1/ups > /tmp/test57-ups.json 2>/dev/null; then
+    RESULT=$(python3 -c "import json;d=json.load(open('/tmp/test57-ups.json'));st=(d.get('ups') or [{}])[0].get('selfTest') or {};print(st.get('result') or '-')")
+    if [ "$RESULT" = "passed" ]; then
+      SOURCE=$(python3 -c "import json;d=json.load(open('/tmp/test57-ups.json'));st=(d.get('ups') or [{}])[0].get('selfTest') or {};print(st.get('source') or '-')")
+      DATE=$(python3 -c "import json;d=json.load(open('/tmp/test57-ups.json'));st=(d.get('ups') or [{}])[0].get('selfTest') or {};print(st.get('date') or '-')")
+      break
+    fi
+  fi
+  sleep 0.5
+done
+
+[ "$RESULT" = "passed" ]     || { echo "FAIL: selfTest.result was '$RESULT', expected passed"; cat /tmp/test57-daemon.log; exit 1; }
+[ "$SOURCE" = "device" ]     || { echo "FAIL: selfTest.source was '$SOURCE', expected device"; cat /tmp/test57-daemon.log; exit 1; }
+[ "$DATE" = "2026-06-02" ]   || { echo "FAIL: selfTest.date was '$DATE', expected 2026-06-02"; cat /tmp/test57-daemon.log; exit 1; }
+grep -q "Observed UPS self-test: passed" /tmp/test57-daemon.log \
+  || { echo "FAIL: daemon did not log the passive observation"; cat /tmp/test57-daemon.log; exit 1; }
+
+kill "$DAEMON_PID" 2>/dev/null || true
+wait "$DAEMON_PID" 2>/dev/null || true
+trap - EXIT
+echo "PASS: passive self-test observation surfaced via API (source=device)"
+)
 echo ""
 echo "=== Group 'single-ups-auth' completed successfully ==="

--- a/tests/e2e/groups/single-ups-auth.sh
+++ b/tests/e2e/groups/single-ups-auth.sh
@@ -146,7 +146,7 @@ YAML
 if eneru validate --config /tmp/config-e2e-control-noauth.yaml >/tmp/test53-val.log 2>&1; then
   echo "FAIL: nut_control without auth was accepted"; cat /tmp/test53-val.log; exit 1
 fi
-grep -q "nut_control.enabled requires api.auth.enabled" /tmp/test53-val.log \
+grep -q "nut_control.enabled requires API authentication" /tmp/test53-val.log \
   || { echo "FAIL: missing fail-closed message"; cat /tmp/test53-val.log; exit 1; }
 echo "PASS: nut_control without auth is rejected at startup"
 

--- a/tests/e2e/scenarios/self-test-passed.dev
+++ b/tests/e2e/scenarios/self-test-passed.dev
@@ -1,0 +1,28 @@
+# Scenario: Online + the UPS reports its OWN last self-test result.
+# Used by the v6.1.2 passive self-test observation E2E: Eneru must read
+# ups.test.result / ups.test.date during normal polling and record a
+# `source=device` self_tests row (no INSTCMD issued), regardless of whether
+# scheduled self-tests are enabled. The dummy-ups driver has no INSTCMD, so
+# this is the only way to exercise self-test state end-to-end.
+ups.status: OL CHRG
+ups.load: 25
+
+battery.charge: 100
+battery.runtime: 1800
+battery.voltage: 54.0
+
+input.voltage: 230.5
+input.voltage.nominal: 230
+input.frequency: 50.0
+input.transfer.low: 170
+input.transfer.high: 280
+
+output.voltage: 230.0
+
+# The UPS's own self-test bookkeeping (device schedule / manual test).
+ups.test.result: done and passed
+ups.test.date: 2026-06-02
+ups.test.interval: 2592000
+
+device.mfr: Eneru
+device.model: E2E Test UPS

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,6 +66,12 @@ def test_collect_status_is_read_only_shape(monitor):
     assert payload["ups"][0]["groupId"] == "TestUPS-localhost"
     assert payload["ups"][0]["powerQuality"]["inputVoltage"] == "229.4"
     assert payload["ups"][0]["powerQuality"]["voltageState"] == "NORMAL"
+    # v6.1.2: the daemon version + runtime context are surfaced at the top level
+    # (dashboard footer), the latter mirroring the nested runtime.context.
+    from eneru.version import __version__
+    assert payload["version"] == __version__
+    assert payload["runtimeContext"] == payload["runtime"]["context"]
+    assert isinstance(payload["runtimeContext"], str) and payload["runtimeContext"]
 
 
 @pytest.mark.unit

--- a/tests/test_api_control.py
+++ b/tests/test_api_control.py
@@ -76,8 +76,10 @@ def test_control_requires_auth(minimal_config):
 @pytest.mark.unit
 def test_list_commands_intersects_allowlist(minimal_config, monkeypatch):
     _enable(minimal_config)
-    monkeypatch.setattr(apimod.nutctl, "list_commands",
-                        lambda ups, timeout=10: (True, ["beeper.toggle", "load.off"], ""))
+    monkeypatch.setattr(
+        apimod.nutctl, "list_commands",
+        lambda ups, username="", password="", timeout=10:
+            (True, ["beeper.toggle", "load.off"], ""))
     h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/commands")
     status, _, payload = (lambda hh: (hh.headers.__setitem__(
         "Authorization", f"Bearer {_token(hh)}"), hh._route())[1])(h)
@@ -112,8 +114,9 @@ def test_list_variables_filtered(minimal_config, monkeypatch):
 @pytest.mark.unit
 def test_list_commands_nut_error_502(minimal_config, monkeypatch):
     _enable(minimal_config)
-    monkeypatch.setattr(apimod.nutctl, "list_commands",
-                        lambda ups, timeout=10: (False, [], "driver down"))
+    monkeypatch.setattr(
+        apimod.nutctl, "list_commands",
+        lambda ups, username="", password="", timeout=10: (False, [], "driver down"))
     h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/commands")
     h.headers["Authorization"] = f"Bearer {_token(h)}"
     assert h._route()[0] == 502
@@ -400,6 +403,88 @@ def test_run_self_test_denied_not_allowlisted(minimal_config, monkeypatch):
     minimal_config.self_test.command = "test.battery.start"   # not allowlisted
     monkeypatch.setattr(apimod.selftest, "issue_self_test",
                         lambda *a, **k: pytest.fail("must not issue denied cmd"))
+    logs = []
+    h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/self-test",
+                         method_body=b"{}", logs=logs)
+    h.api_source = _src_with_store("UPS@h")
+    h.headers["Authorization"] = f"Bearer {_token(h)}"
+    with pytest.raises(APIForbidden):
+        h._route_post()
+    assert any("denied" in line for line in logs)
+
+
+@pytest.mark.unit
+def test_run_self_test_permitted_by_self_test_flag_without_nut_control(
+        minimal_config, monkeypatch):
+    # v6.1.2: self_test enabled is its own permission — the API issues the
+    # configured command even with nut_control OFF and no allowlist, and hands
+    # issue_self_test an effective nut_control with the command auto-allowlisted.
+    minimal_config.api.auth.enabled = True
+    minimal_config.self_test.enabled = True
+    minimal_config.self_test.command = "test.battery.start"
+    minimal_config.nut_control.enabled = False
+    minimal_config.nut_control.allowed_commands = []
+    captured = {}
+    monkeypatch.setattr(apimod.selftest, "discover_self_test_command",
+                        lambda ups, cmd, **k: cmd)
+
+    def _issue(ups, cmd, nc, store, source="api"):
+        captured["allowed"] = list(nc.allowed_commands)
+        captured["source"] = source
+        return {"ok": True, "test_id": 9, "error": ""}
+    monkeypatch.setattr(apimod.selftest, "issue_self_test", _issue)
+    h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/self-test",
+                         method_body=b"{}")
+    h.api_source = _src_with_store("UPS@h", store=_open_store_stub())
+    h.headers["Authorization"] = f"Bearer {_token(h)}"
+    status, _, payload = h._route_post()
+    assert status == 200 and payload["testId"] == 9
+    assert "test.battery.start" in captured["allowed"]   # auto-allowed
+    assert captured["source"] == "api"
+
+
+@pytest.mark.unit
+def test_general_command_still_forbidden_when_only_self_test_enabled(
+        minimal_config, monkeypatch):
+    # Adversarial (v6.1.2): the self_test softening must NOT widen the general
+    # control surface. With self_test ON but nut_control OFF, POST /command is
+    # still 403 — even for the very command self_test would auto-permit.
+    minimal_config.api.auth.enabled = True
+    minimal_config.self_test.enabled = True
+    minimal_config.self_test.command = "test.battery.start"
+    minimal_config.nut_control.enabled = False
+    monkeypatch.setattr(apimod.nutctl, "run_instant_command",
+                        lambda *a, **k: pytest.fail("must not reach NUT"))
+    h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/command",
+                         method_body=b'{"command":"test.battery.start"}')
+    h.api_source = _src_with_store("UPS@h")
+    h.headers["Authorization"] = f"Bearer {_token(h)}"
+    with pytest.raises(APIForbidden):
+        h._route_post()
+
+
+@pytest.mark.unit
+def test_run_self_test_empty_command_is_400(minimal_config):
+    minimal_config.api.auth.enabled = True
+    minimal_config.self_test.enabled = True
+    minimal_config.self_test.command = ""      # misconfigured
+    h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/self-test",
+                         method_body=b"{}")
+    h.api_source = _src_with_store("UPS@h")
+    h.headers["Authorization"] = f"Bearer {_token(h)}"
+    with pytest.raises(APIBadRequest):
+        h._route_post()
+
+
+@pytest.mark.unit
+def test_run_self_test_denied_when_neither_permission(minimal_config, monkeypatch):
+    # self_test disabled AND nut_control disabled -> forbidden.
+    minimal_config.api.auth.enabled = True
+    minimal_config.self_test.enabled = False
+    minimal_config.self_test.command = "test.battery.start"
+    minimal_config.nut_control.enabled = False
+    monkeypatch.setattr(apimod.selftest, "issue_self_test",
+                        lambda *a, **k: pytest.fail("must not issue"))
     logs = []
     h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/self-test",
                          method_body=b"{}", logs=logs)

--- a/tests/test_api_v61.py
+++ b/tests/test_api_v61.py
@@ -49,6 +49,18 @@ class TestSelfTestApiResolution:
             "ups:\n  name: U@h\n")
         paths = {e["path"] for e in h._available_endpoints()}
         assert "/api/v1/ups/{name}/self-test" in paths
+
+    @pytest.mark.unit
+    def test_self_test_endpoint_visible_when_self_test_enabled_without_nut_control(self):
+        # v6.1.2: self_test enabled advertises the endpoint even with nut_control
+        # off — enabling self_test is its own permission.
+        h = object.__new__(EneruAPIHandler)
+        h.api_config = _parse_cfg(
+            "api:\n  auth:\n    enabled: true\n"
+            "self_test:\n  enabled: true\n  command: test.battery.start\n"
+            "ups:\n  name: U@h\n")
+        paths = {e["path"] for e in h._available_endpoints()}
+        assert "/api/v1/ups/{name}/self-test" in paths
 from eneru.monitor import UPSGroupMonitor
 from eneru.state import MonitorState
 from eneru.stats import StatsStore

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -329,3 +329,30 @@ def test_auth_is_active_db_users_activate_when_unset(tmp_path):
 def test_auth_is_active_missing_db_is_inactive(tmp_path):
     cfg = _AuthCfg(enabled=False, db_path=str(tmp_path / "nope.db"))
     assert auth.auth_is_active(cfg) is False
+
+
+@pytest.mark.unit
+def test_auth_is_active_enabled_without_explicit_flag_is_active():
+    # enabled=True but enabled_explicitly_set=False (a value assembled in code)
+    # still activates without touching the DB.
+    assert auth.auth_is_active(_AuthCfg(enabled=True)) is True
+
+
+@pytest.mark.unit
+def test_auth_is_active_no_db_path_is_inactive():
+    # Unset flag + no db_path -> inactive (never touches the filesystem).
+    assert auth.auth_is_active(_AuthCfg(enabled=False, db_path="")) is False
+
+
+@pytest.mark.unit
+def test_auth_is_active_broken_db_fails_closed(tmp_path, monkeypatch):
+    # An existing but unreadable/corrupt auth DB must fail CLOSED to "active" so
+    # writes keep demanding credentials rather than silently reopening.
+    db = tmp_path / "auth.db"
+    db.write_text("not a database")
+
+    def boom(self):
+        raise sqlite3.DatabaseError("file is not a database")
+    monkeypatch.setattr(auth.AuthStore, "user_count", boom)
+    cfg = _AuthCfg(enabled=False, db_path=str(db), enabled_explicitly_set=False)
+    assert auth.auth_is_active(cfg) is True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -286,3 +286,46 @@ def test_require_bcrypt_missing_raises(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     with pytest.raises(AuthError):
         auth.require_bcrypt()
+
+
+# ----- auth_is_active (effective auth state, v6.1.2) -----
+
+from dataclasses import dataclass, field  # noqa: E402
+
+
+@dataclass
+class _AuthCfg:
+    enabled: bool = False
+    db_path: str = "/nonexistent/auth.db"
+    enabled_explicitly_set: bool = field(default=False)
+
+
+@pytest.mark.unit
+def test_auth_is_active_none_is_inactive():
+    assert auth.auth_is_active(None) is False
+
+
+@pytest.mark.unit
+def test_auth_is_active_explicit_flag_wins(tmp_path):
+    # Explicit True/False always wins, even against DB contents.
+    db = tmp_path / "auth.db"
+    AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
+    off = _AuthCfg(enabled=False, db_path=str(db), enabled_explicitly_set=True)
+    on = _AuthCfg(enabled=True, db_path=str(db), enabled_explicitly_set=True)
+    assert auth.auth_is_active(off) is False    # explicit off beats DB users
+    assert auth.auth_is_active(on) is True
+
+
+@pytest.mark.unit
+def test_auth_is_active_db_users_activate_when_unset(tmp_path):
+    db = tmp_path / "auth.db"
+    cfg = _AuthCfg(enabled=False, db_path=str(db), enabled_explicitly_set=False)
+    assert auth.auth_is_active(cfg) is False     # no DB yet -> inactive
+    AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
+    assert auth.auth_is_active(cfg) is True       # a user -> active, no restart
+
+
+@pytest.mark.unit
+def test_auth_is_active_missing_db_is_inactive(tmp_path):
+    cfg = _AuthCfg(enabled=False, db_path=str(tmp_path / "nope.db"))
+    assert auth.auth_is_active(cfg) is False

--- a/tests/test_config_v61.py
+++ b/tests/test_config_v61.py
@@ -159,30 +159,94 @@ class TestUnknownKeys:
 
 class TestCrossFieldValidation:
     @pytest.mark.unit
-    def test_self_test_requires_nut_control_and_auth(self):
-        _, errs = _validate("ups:\n  name: U@h\nself_test:\n  enabled: true\n")
-        assert any("requires nut_control.enabled" in e for e in errs)
-        assert any("requires api.auth.enabled" in e for e in errs)
+    def test_self_test_requires_only_auth(self, tmp_path):
+        # v6.1.2: self_test enabled with no auth -> ONE error (auth). It no longer
+        # requires nut_control.enabled — enabling self_test grants its command.
+        missing = tmp_path / "nope.db"
+        _, errs = _validate(
+            "ups:\n  name: U@h\n"
+            f"api:\n  auth:\n    db_path: '{missing}'\n"
+            "self_test:\n  enabled: true\n")
+        assert any("requires API authentication" in e for e in errs)
+        assert not any("nut_control" in e for e in errs)
 
     @pytest.mark.unit
-    def test_self_test_command_must_be_allowlisted(self):
+    def test_self_test_permits_command_without_nut_control(self):
+        # v6.1.2: self_test enabled + auth on, but nut_control DISABLED and the
+        # command NOT on any allowlist -> NO errors (self_test is its own
+        # permission for exactly its command).
         _, errs = _validate(
             "ups:\n  name: U@h\napi:\n  auth:\n    enabled: true\n"
-            "nut_control:\n  enabled: true\n  allowed_commands: [beeper.toggle]\n"
             "self_test:\n  enabled: true\n  command: test.battery.start\n")
-        assert any("not in nut_control.allowed_commands" in e for e in errs)
+        assert errs == []
 
     @pytest.mark.unit
-    def test_per_ups_self_test_override_is_validated(self):
-        # Global self_test disabled, but a per-UPS override enables it with a
-        # non-allowlisted command and no auth -> must be caught.
+    def test_self_test_non_test_command_warns_but_validates(self, tmp_path):
+        # A non-test self_test.command is a real control grant (v6.1.2), so it
+        # WARNS — but does not block: a deliberate vendor command still works.
+        from eneru.auth import AuthStore
+        db = tmp_path / "auth.db"
+        AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
+        raw = yaml.safe_load(
+            "ups:\n  name: U@h\n"
+            f"api:\n  auth:\n    db_path: '{db}'\n"
+            "self_test:\n  enabled: true\n  command: shutdown.return\n")
+        msgs = ConfigLoader.validate_config(ConfigLoader._parse_config(raw), raw)
+        assert not any(m.startswith("ERROR") for m in msgs)      # still valid
+        assert any(m.startswith("WARNING") and "shutdown.return" in m
+                   and "bypassing the nut_control allowlist" in m for m in msgs)
+
+    @pytest.mark.unit
+    def test_self_test_test_command_does_not_warn(self, tmp_path):
+        from eneru.auth import AuthStore
+        db = tmp_path / "auth.db"
+        AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
+        raw = yaml.safe_load(
+            "ups:\n  name: U@h\n"
+            f"api:\n  auth:\n    db_path: '{db}'\n"
+            "self_test:\n  enabled: true\n  command: test.battery.start\n")
+        msgs = ConfigLoader.validate_config(ConfigLoader._parse_config(raw), raw)
+        assert not any("bypassing the nut_control allowlist" in m for m in msgs)
+
+    @pytest.mark.unit
+    def test_self_test_auth_via_db_user(self, tmp_path):
+        # request #2: api.auth.enabled is NOT set, but a user exists in the auth
+        # DB -> effective auth is active, so self_test validation passes.
+        from eneru.auth import AuthStore
+        db = tmp_path / "auth.db"
+        AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
         _, errs = _validate(
+            "ups:\n  name: U@h\n"
+            f"api:\n  auth:\n    db_path: '{db}'\n"
+            "self_test:\n  enabled: true\n  command: test.battery.start\n")
+        assert errs == []
+
+    @pytest.mark.unit
+    def test_self_test_auth_explicitly_disabled_still_errors(self, tmp_path):
+        # An explicit api.auth.enabled: false wins even if the DB has a user.
+        from eneru.auth import AuthStore
+        db = tmp_path / "auth.db"
+        AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
+        _, errs = _validate(
+            "ups:\n  name: U@h\n"
+            f"api:\n  auth:\n    enabled: false\n    db_path: '{db}'\n"
+            "self_test:\n  enabled: true\n")
+        assert any("requires API authentication" in e for e in errs)
+
+    @pytest.mark.unit
+    def test_per_ups_self_test_override_requires_auth(self, tmp_path):
+        # Global self_test disabled, but a per-UPS override enables it with no
+        # auth -> the auth error is raised for that UPS (nut_control no longer
+        # required, and the command is auto-permitted).
+        missing = tmp_path / "nope.db"
+        _, errs = _validate(
+            f"api:\n  auth:\n    db_path: '{missing}'\n"
             "self_test:\n  enabled: false\n"
             "ups:\n  - name: U1@h\n    self_test:\n      enabled: true\n"
             "      command: shutdown.return\n")
-        assert any("U1@h" in e and "nut_control.enabled" in e for e in errs)
-        assert any("U1@h" in e and "api.auth.enabled" in e for e in errs)
-        assert any("shutdown.return" in e and "U1@h" in e for e in errs)
+        assert any("U1@h" in e and "requires API authentication" in e
+                   for e in errs)
+        assert not any("nut_control" in e for e in errs)
 
     @pytest.mark.unit
     def test_per_ups_self_test_override_valid(self):
@@ -194,20 +258,33 @@ class TestCrossFieldValidation:
         assert errs == []
 
     @pytest.mark.unit
-    def test_global_self_test_vs_per_ups_narrowed_allowlist(self):
-        # Global self_test enabled with the default command, but one UPS narrows
-        # its OWN nut_control allowlist to exclude it -> caught for that UPS
-        # (validated against the resolved per-UPS config, not just the global).
+    def test_per_ups_narrowed_allowlist_no_longer_blocks_self_test(self):
+        # v6.1.2: a per-UPS allowlist that excludes the self_test command no
+        # longer blocks it — self_test auto-permits exactly its own command.
         _, errs = _validate(
             "api:\n  auth:\n    enabled: true\n"
             "nut_control:\n  enabled: true\n  allowed_commands: [test.battery.start]\n"
             "self_test:\n  enabled: true\n  command: test.battery.start\n"
             "ups:\n  - name: U1@h\n"
-            "  - name: U2@h\n    nut_control:\n      enabled: true\n"
+            "  - name: U2@h\n    nut_control:\n"
             "      allowed_commands: [beeper.toggle]\n")
-        assert any("U2@h" in e and "not in nut_control.allowed_commands" in e
-                   for e in errs)
-        assert not any("U1@h" in e for e in errs)   # U1 inherits the global allowlist
+        assert errs == []
+
+    @pytest.mark.unit
+    def test_nut_control_requires_auth_effective_via_db_user(self, tmp_path):
+        # The global nut_control->auth rule also honors effective auth: a user in
+        # the DB satisfies it even without api.auth.enabled.
+        from eneru.auth import AuthStore
+        db = tmp_path / "auth.db"
+        base = ("ups:\n  name: U@h\n"
+                "nut_control:\n  enabled: true\n"
+                "  allowed_commands: [beeper.toggle]\n")
+        missing = tmp_path / "nope.db"
+        _, errs = _validate(base + f"api:\n  auth:\n    db_path: '{missing}'\n")
+        assert any("requires API authentication" in e for e in errs)
+        AuthStore(db).create_user("admin", "correct horse")  # noqa: S106
+        _, errs2 = _validate(base + f"api:\n  auth:\n    db_path: '{db}'\n")
+        assert not any("requires API authentication" in e for e in errs2)
 
     @pytest.mark.unit
     @pytest.mark.parametrize("field,val", [

--- a/tests/test_monitor_periodic.py
+++ b/tests/test_monitor_periodic.py
@@ -215,14 +215,49 @@ class TestRunSelfTestTask:
         assert mon.logs == []
 
     @pytest.mark.unit
-    def test_nut_control_disabled_is_defense_in_depth(self, store):
-        # self_test enabled but nut_control disabled -> never issue (the per-UPS
-        # override case validation can't catch).
-        cfg = _cfg("self_test:\n  enabled: true\n  command: test.battery.start\n"
+    def test_issues_without_nut_control_enabled(self, store, monkeypatch):
+        # v6.1.2: self_test is its own permission — enabling it grants exactly
+        # its command even when nut_control is disabled. When DUE, it issues, and
+        # the effective nut_control handed to issue_self_test has the command
+        # auto-allowlisted.
+        cfg = _cfg("api:\n  auth:\n    enabled: true\n"
+                   "self_test:\n  enabled: true\n  command: test.battery.start\n"
                    "ups:\n  name: U@h\n")
         mon = _make_monitor(cfg, store)
+        store.set_meta("self_test_last_run", "0")     # due now
+        captured = {}
+        monkeypatch.setattr(selftest, "discover_self_test_command",
+                            lambda *a, **k: "test.battery.start")
+
+        def _issue(ups, cmd, nc, s, source="scheduler"):
+            captured["allowed"] = list(nc.allowed_commands)
+            return {"ok": True, "test_id": 5, "error": ""}
+        monkeypatch.setattr(selftest, "issue_self_test", _issue)
         mon._run_self_test_task()
-        assert store.latest_self_test() is None
+        assert mon._self_test_pending_id == 5
+        assert "test.battery.start" in captured["allowed"]
+
+    @pytest.mark.unit
+    def test_discovery_receives_nut_control_credentials(self, store, monkeypatch):
+        # Regression: discovery must forward credentials so `upscmd -l` works on
+        # an upsd that only lists commands to a logged-in client.
+        cfg = _cfg("api:\n  auth:\n    enabled: true\n"
+                   "nut_control:\n  enabled: true\n  username: mon\n  password: mon\n"
+                   "  allowed_commands: [test.battery.start]\n"
+                   "self_test:\n  enabled: true\n  command: test.battery.start\n"
+                   "ups:\n  name: U@h\n")
+        mon = _make_monitor(cfg, store)
+        store.set_meta("self_test_last_run", "0")     # due now
+        seen = {}
+
+        def _discover(ups, command, *, username="", password="", timeout=10):
+            seen.update(username=username, password=password)
+            return command
+        monkeypatch.setattr(selftest, "discover_self_test_command", _discover)
+        monkeypatch.setattr(selftest, "issue_self_test",
+                            lambda *a, **k: {"ok": True, "test_id": 1, "error": ""})
+        mon._run_self_test_task()
+        assert seen == {"username": "mon", "password": "mon"}
 
     @pytest.mark.unit
     def test_first_sight_seeds_baseline(self, store):
@@ -431,3 +466,117 @@ class TestRunSelfTestTask:
         mon = _make_monitor(_cfg(_ENABLED), store)
         mon._run_self_test_task()
         assert store.get_meta("self_test_pending_id") == ""   # corrupt value scrubbed
+
+
+# --------------------------------------------------------------------------
+# _check_observed_self_test (v6.1.2 passive observation)
+# --------------------------------------------------------------------------
+
+class TestObservedSelfTest:
+    @pytest.mark.unit
+    def test_records_device_result(self, store):
+        # A UPS that ran its own test (device schedule / manual) is recorded even
+        # with self_test disabled — regardless of whether Eneru schedules tests.
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"})
+        latest = store.latest_self_test()
+        assert latest["result_enum"] == "passed"
+        assert latest["result_date"] == "2026-06-02"
+        assert latest["source"] == "device"
+        assert latest["command"] == ""       # Eneru issued nothing
+        assert any("Observed UPS self-test: passed" in m for m in mon.logs)
+
+    @pytest.mark.unit
+    def test_dedups_same_result(self, store):
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        data = {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"}
+        mon._check_observed_self_test(data)
+        first = store.latest_self_test()["id"]
+        mon._check_observed_self_test(data)               # unchanged -> no new row
+        assert store.latest_self_test()["id"] == first
+
+    @pytest.mark.unit
+    def test_new_test_records_again(self, store):
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"})
+        first = store.latest_self_test()["id"]
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-07-02"})
+        latest = store.latest_self_test()
+        assert latest["id"] != first
+        assert latest["result_date"] == "2026-07-02"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("raw", ["in progress", "No test initiated",
+                                     "not supported"])
+    def test_skips_non_terminal_results(self, store, raw):
+        # running/unknown/unsupported are churny or one-time noise — only settled
+        # pass/fail is persisted passively.
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        mon._check_observed_self_test({"ups.test.result": raw})
+        assert store.latest_self_test() is None
+
+    @pytest.mark.unit
+    def test_skips_when_no_result_or_failed_poll(self, store):
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        mon._check_observed_self_test({"battery.charge": "100"})   # UPS reports no test
+        mon._check_observed_self_test(None)                        # failed poll
+        mon._check_observed_self_test({})                          # empty
+        assert store.latest_self_test() is None
+
+    @pytest.mark.unit
+    def test_stands_down_while_eneru_test_pending(self, store):
+        # The scheduled path owns the row for a test it issued; the observer must
+        # not double-record the same result.
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        mon._self_test_pending_id = 42
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"})
+        assert store.latest_self_test() is None
+
+    @pytest.mark.unit
+    def test_records_without_date(self, store):
+        # Some UPSes report a result but no ups.test.date.
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        mon._check_observed_self_test({"ups.test.result": "Battery test failed"})
+        latest = store.latest_self_test()
+        assert latest["result_enum"] == "failed"
+        assert latest["result_date"] is None
+
+    @pytest.mark.unit
+    def test_no_store_is_safe(self):
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), None)
+        mon._check_observed_self_test({"ups.test.result": "done and passed"})  # no raise
+
+    @pytest.mark.unit
+    def test_observer_failure_isolated(self, store):
+        cfg = _cfg("ups:\n  name: U@h\n")
+        mon = _make_monitor(cfg, store)
+        mon._update_battery_health_periodic = lambda *a: None
+
+        def boom(_data):
+            raise RuntimeError("obs-boom")
+        mon._check_observed_self_test = boom
+        mon._run_periodic_tasks({"ups.test.result": "done and passed"})
+        assert any("self-test observer failed" in m for m in mon.logs)
+
+    @pytest.mark.unit
+    def test_scheduled_finalize_stamps_observed_key(self, store, monkeypatch):
+        # After Eneru finalises its OWN test, the observer must not re-record the
+        # same result: the finalise stamps the observer fingerprint.
+        mon = _make_monitor(_cfg(_ENABLED), store)
+        mon._self_test_pending_id = 3
+        mon._self_test_poll_due_mono = time.monotonic() - 1
+        mon._get_ups_var = lambda var: {"ups.test.result": "done and passed",
+                                        "ups.test.date": "2026-06-02"}.get(var)
+        monkeypatch.setattr(selftest, "record_self_test_result",
+                            lambda s, tid, raw, date: "passed")
+        mon._run_self_test_task()
+        assert store.get_meta("self_test_observed_key") == "2026-06-02|done and passed"
+        # A subsequent observation of that same result is a no-op.
+        before = store.latest_self_test()
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"})
+        assert store.latest_self_test() == before

--- a/tests/test_monitor_periodic.py
+++ b/tests/test_monitor_periodic.py
@@ -242,7 +242,8 @@ class TestRunSelfTestTask:
         # Regression: discovery must forward credentials so `upscmd -l` works on
         # an upsd that only lists commands to a logged-in client.
         cfg = _cfg("api:\n  auth:\n    enabled: true\n"
-                   "nut_control:\n  enabled: true\n  username: mon\n  password: mon\n"
+                   "nut_control:\n  enabled: true\n"
+                   "  username: mon-user\n  password: mon-pass\n"
                    "  allowed_commands: [test.battery.start]\n"
                    "self_test:\n  enabled: true\n  command: test.battery.start\n"
                    "ups:\n  name: U@h\n")
@@ -257,7 +258,7 @@ class TestRunSelfTestTask:
         monkeypatch.setattr(selftest, "issue_self_test",
                             lambda *a, **k: {"ok": True, "test_id": 1, "error": ""})
         mon._run_self_test_task()
-        assert seen == {"username": "mon", "password": "mon"}
+        assert seen == {"username": "mon-user", "password": "mon-pass"}
 
     @pytest.mark.unit
     def test_first_sight_seeds_baseline(self, store):
@@ -544,6 +545,23 @@ class TestObservedSelfTest:
         latest = store.latest_self_test()
         assert latest["result_enum"] == "failed"
         assert latest["result_date"] is None
+
+    @pytest.mark.unit
+    def test_record_failure_does_not_fingerprint(self, store, monkeypatch):
+        # If the row write fails (record_self_test -> None), the observed key
+        # must NOT be stamped, so the next poll retries instead of silently
+        # dropping a device result forever.
+        mon = _make_monitor(_cfg("ups:\n  name: U@h\n"), store)
+        monkeypatch.setattr(store, "record_self_test", lambda *a, **k: None)
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"})
+        assert store.get_meta("self_test_observed_key") in (None, "")
+        # Recovery: once the write succeeds, it records + fingerprints.
+        monkeypatch.undo()
+        mon._check_observed_self_test(
+            {"ups.test.result": "done and passed", "ups.test.date": "2026-06-02"})
+        assert store.latest_self_test()["result_enum"] == "passed"
+        assert store.get_meta("self_test_observed_key") == "2026-06-02|done and passed"
 
     @pytest.mark.unit
     def test_no_store_is_safe(self):

--- a/tests/test_nut_control.py
+++ b/tests/test_nut_control.py
@@ -89,11 +89,11 @@ def test_list_commands_credentialed_uses_auth_path(monkeypatch):
     monkeypatch.setattr(nc, "run_command",
                         lambda *a, **k: pytest.fail("must not use anon path"))
     ok, commands, _ = nc.list_commands(
-        "UPS@h", username="mon", password="mon", timeout=6)  # noqa: S106
+        "UPS@h", username="mon-user", password="mon-pass", timeout=6)  # noqa: S106
     assert ok and commands == ["test.battery.start"]
-    assert captured["cmd"] == ["upscmd", "-u", "mon", "-l", "UPS@h"]
-    assert "mon" == captured["password"]
-    assert "mon" not in captured["cmd"][3:]      # password never in argv
+    assert captured["cmd"] == ["upscmd", "-u", "mon-user", "-l", "UPS@h"]
+    assert captured["password"] == "mon-pass"
+    assert "mon-pass" not in captured["cmd"]      # password never in argv
     assert captured["timeout"] == 6
 
 

--- a/tests/test_nut_control.py
+++ b/tests/test_nut_control.py
@@ -117,6 +117,27 @@ def test_validated_auth_command_list_rejects_bad_data_positions():
 
 
 @pytest.mark.unit
+def test_popen_credentialed_list_builds_literal_argv(monkeypatch):
+    # The authenticated-list spawn site must keep `-l` a literal and place the
+    # validated username/ups in fixed positions (CodeQL invariant). Stub Popen
+    # so nothing actually execs.
+    captured = {}
+
+    class _FakeProc:
+        pass
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(nc.subprocess, "Popen", fake_popen)
+    proc = nc._popen_validated_auth_command(
+        ["upscmd", "-u", "mon", "-l", "UPS@h"], slave_fd=5)
+    assert isinstance(proc, _FakeProc)
+    assert captured["argv"] == ["upscmd", "-u", "mon", "-l", "UPS@h"]
+
+
+@pytest.mark.unit
 def test_run_instant_command_does_not_put_password_in_argv(monkeypatch):
     captured = {}
 

--- a/tests/test_nut_control.py
+++ b/tests/test_nut_control.py
@@ -59,6 +59,64 @@ def test_list_commands_failure(monkeypatch):
 
 
 @pytest.mark.unit
+def test_list_commands_anonymous_when_no_creds(monkeypatch):
+    # With no credentials, listing stays on the plain (anonymous) runner.
+    captured = {}
+    monkeypatch.setattr(nc, "run_command",
+                        lambda cmd, timeout=10: captured.update(cmd=cmd)
+                        or (0, "  test.battery.start - x\n", ""))
+    monkeypatch.setattr(nc, "_run_auth_command",
+                        lambda *a, **k: pytest.fail("must not use auth path"))
+    ok, commands, _ = nc.list_commands("UPS@h")
+    assert ok and commands == ["test.battery.start"]
+    assert captured["cmd"] == ["upscmd", "-l", "UPS@h"]
+
+
+@pytest.mark.unit
+def test_list_commands_credentialed_uses_auth_path(monkeypatch):
+    # Regression: some upsd only list commands to a logged-in client. With creds,
+    # listing goes through the PTY auth path (password never on argv) with the
+    # `upscmd -u user -l ups` shape.
+    captured = {}
+
+    def fake_auth(cmd, password, timeout=10):
+        captured["cmd"] = cmd
+        captured["password"] = password
+        captured["timeout"] = timeout
+        return 0, "  test.battery.start - Start a battery test\n", ""
+
+    monkeypatch.setattr(nc, "_run_auth_command", fake_auth)
+    monkeypatch.setattr(nc, "run_command",
+                        lambda *a, **k: pytest.fail("must not use anon path"))
+    ok, commands, _ = nc.list_commands(
+        "UPS@h", username="mon", password="mon", timeout=6)  # noqa: S106
+    assert ok and commands == ["test.battery.start"]
+    assert captured["cmd"] == ["upscmd", "-u", "mon", "-l", "UPS@h"]
+    assert "mon" == captured["password"]
+    assert "mon" not in captured["cmd"][3:]      # password never in argv
+    assert captured["timeout"] == 6
+
+
+@pytest.mark.unit
+def test_validated_auth_command_accepts_credentialed_list():
+    safe_cmd, err = nc._validated_auth_command_argv(
+        ["upscmd", "-u", "mon", "-l", "UPS@h"])
+    assert err == ""
+    assert safe_cmd == ["upscmd", "-u", "mon", "-l", "UPS@h"]
+    # has_username must be true so the runner enforces the username/password pair.
+    assert nc._auth_command_has_username(safe_cmd) is True
+
+
+@pytest.mark.unit
+def test_validated_auth_command_list_rejects_bad_data_positions():
+    # username and ups are the only data positions; both are validated.
+    assert nc._validated_auth_command_argv(
+        ["upscmd", "-u", "", "-l", "UPS@h"])[0] is None
+    assert nc._validated_auth_command_argv(
+        ["upscmd", "-u", "mon", "-l", "UPS;id"])[0] is None
+
+
+@pytest.mark.unit
 def test_run_instant_command_does_not_put_password_in_argv(monkeypatch):
     captured = {}
 

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -43,12 +43,16 @@ def test_load_and_validate_non_mapping(tmp_path):
 
 @pytest.mark.unit
 def test_load_and_validate_validation_error(tmp_path):
-    # fail-closed: nut_control without auth
+    # fail-closed: nut_control without auth. db_path points at a nonexistent file
+    # so effective-auth is deterministically inactive (no stray users).
+    missing = tmp_path / "nope.db"
     p = _write(tmp_path / "c.yaml",
-               "ups:\n  name: U@h\nnut_control:\n  enabled: true\n")
+               "ups:\n  name: U@h\nnut_control:\n  enabled: true\n"
+               f"api:\n  auth:\n    db_path: '{missing}'\n")
     cfg, errors = reloadmod.load_and_validate(p)
     assert cfg is None
-    assert any("nut_control.enabled requires api.auth.enabled" in e for e in errors)
+    assert any("nut_control.enabled requires API authentication" in e
+               for e in errors)
 
 
 @pytest.mark.unit

--- a/tests/test_self_test.py
+++ b/tests/test_self_test.py
@@ -98,10 +98,10 @@ class TestDiscover:
 
         monkeypatch.setattr(self_test.nutctl, "list_commands", fake_list)
         self_test.discover_self_test_command(
-            "U@h", "test.battery.start", username="mon", password="mon",  # noqa: S106
-            timeout=7)
-        assert captured == {"ups": "U@h", "username": "mon", "password": "mon",
-                            "timeout": 7}
+            "U@h", "test.battery.start",
+            username="mon-user", password="mon-pass", timeout=7)  # noqa: S106
+        assert captured == {"ups": "U@h", "username": "mon-user",
+                            "password": "mon-pass", "timeout": 7}
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_self_test.py
+++ b/tests/test_self_test.py
@@ -57,16 +57,19 @@ class TestNormalize:
 class TestDiscover:
     @pytest.mark.unit
     def test_returns_command_when_exposed(self, monkeypatch):
-        monkeypatch.setattr(self_test.nutctl, "list_commands",
-                            lambda ups, timeout=10: (True, ["test.battery.start",
-                                                            "beeper.toggle"], ""))
+        monkeypatch.setattr(
+            self_test.nutctl, "list_commands",
+            lambda ups, username="", password="", timeout=10:
+                (True, ["test.battery.start", "beeper.toggle"], ""))
         assert self_test.discover_self_test_command(
             "U@h", "test.battery.start") == "test.battery.start"
 
     @pytest.mark.unit
     def test_none_when_not_exposed(self, monkeypatch):
-        monkeypatch.setattr(self_test.nutctl, "list_commands",
-                            lambda ups, timeout=10: (True, ["beeper.toggle"], ""))
+        monkeypatch.setattr(
+            self_test.nutctl, "list_commands",
+            lambda ups, username="", password="", timeout=10:
+                (True, ["beeper.toggle"], ""))
         assert self_test.discover_self_test_command(
             "U@h", "test.battery.start") is None
 
@@ -75,10 +78,77 @@ class TestDiscover:
         # A transient upscmd -l failure must be distinguishable from "command
         # genuinely not exposed" (None), so callers can retry instead of skipping
         # a whole 30-day cadence.
-        monkeypatch.setattr(self_test.nutctl, "list_commands",
-                            lambda ups, timeout=10: (False, [], "upscmd error"))
+        monkeypatch.setattr(
+            self_test.nutctl, "list_commands",
+            lambda ups, username="", password="", timeout=10:
+                (False, [], "upscmd error"))
         with pytest.raises(self_test.SelfTestUnavailable):
             self_test.discover_self_test_command("U@h", "test.battery.start")
+
+    @pytest.mark.unit
+    def test_forwards_credentials_to_list(self, monkeypatch):
+        # Regression: some upsd only list commands to a logged-in client, so
+        # discovery MUST forward nut_control credentials to `upscmd -l`.
+        captured = {}
+
+        def fake_list(ups, username="", password="", timeout=10):
+            captured.update(ups=ups, username=username, password=password,
+                            timeout=timeout)
+            return True, ["test.battery.start"], ""
+
+        monkeypatch.setattr(self_test.nutctl, "list_commands", fake_list)
+        self_test.discover_self_test_command(
+            "U@h", "test.battery.start", username="mon", password="mon",  # noqa: S106
+            timeout=7)
+        assert captured == {"ups": "U@h", "username": "mon", "password": "mon",
+                            "timeout": 7}
+
+
+# --------------------------------------------------------------------------
+# self_test_control (v6.1.2 narrow permission)
+# --------------------------------------------------------------------------
+
+class _ST:
+    def __init__(self, enabled):
+        self.enabled = enabled
+
+
+class TestSelfTestControl:
+    @pytest.mark.unit
+    def test_self_test_enabled_auto_allows_command(self):
+        # nut_control off + command NOT allowlisted, but self_test on -> permitted,
+        # and the effective nut_control has the command added to its allowlist.
+        nc = _nc(enabled=False, allowed_commands=[])
+        permitted, eff = self_test.self_test_control(
+            nc, _ST(True), "test.battery.start")
+        assert permitted is True
+        assert "test.battery.start" in eff.allowed_commands
+        # The general control surface is untouched: original object unchanged.
+        assert nc.allowed_commands == []
+
+    @pytest.mark.unit
+    def test_self_test_disabled_falls_back_to_general_allowlist(self):
+        # self_test off: permitted only when the GENERAL control surface allows it.
+        nc = _nc(enabled=True, allowed_commands=["test.battery.start"])
+        permitted, eff = self_test.self_test_control(
+            nc, _ST(False), "test.battery.start")
+        assert permitted is True
+        assert eff is nc  # unchanged
+
+    @pytest.mark.unit
+    def test_disabled_and_not_allowlisted_is_denied(self):
+        nc = _nc(enabled=False, allowed_commands=[])
+        permitted, _eff = self_test.self_test_control(
+            nc, _ST(False), "test.battery.start")
+        assert permitted is False
+
+    @pytest.mark.unit
+    def test_general_control_off_denies_even_if_allowlisted(self):
+        # allowlisted but nut_control disabled + self_test disabled -> denied.
+        nc = _nc(enabled=False, allowed_commands=["test.battery.start"])
+        permitted, _eff = self_test.self_test_control(
+            nc, _ST(False), "test.battery.start")
+        assert permitted is False
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Self-test fixes driven by real UniFi UPS testing, on top of 6.1.1. No shutdown-path changes.

Three self-test fixes + a small dashboard/API addition:

1. **Credentialed `upscmd -l` discovery.** `list_commands()` / `discover_self_test_command()` now forward `nut_control` credentials to `upscmd -l`. Some upsd setups (notably **UniFi's NUT**) only return the instant-command list to a *logged-in* client — anonymously the list came back empty and a supported command looked unsupported (`does not expose 'test.battery.start'`). When both username+password are set, listing uses the existing PTY auth path (password never on argv) with a new `upscmd -u <user> -l <ups>` argv shape; **anonymous listing is unchanged** when no creds are set.

2. **Softened self-test permission.** Enabling `self_test` is now its own narrow permission granting **exactly** `self_test.command` — no need to also set `nut_control.enabled` or list the command in `nut_control.allowed_commands`. The general control surface (`/command`, `/variables`) is **unchanged**; API auth stays mandatory. A non-`test.*` command emits a validation **WARNING** (not error), since it's a real control grant.

3. **Effective-auth in validation.** `self_test` (and the `nut_control` → auth rule) now honor **effective** auth — explicit `api.auth.enabled` **or** a user already in the auth DB — matching how the API enforces auth at runtime (`auth.auth_is_active`, shared with `api._auth_is_active`).

4. **Passive self-test observation.** Each poll, Eneru reads `ups.test.result` / `ups.test.date` and records a `source: device` `self_tests` row for new pass/fail results (deduped via a meta fingerprint; stands down while an Eneru-issued test is pending). Works whether or not scheduled self-tests are enabled, so a UPS that tests on its own cadence or by hand surfaces in the dashboard, API, Prometheus, and battery-health score with **no config**.

5. **Dashboard/API.** `GET /api/v1/ups` gains top-level `version` and `runtimeContext`; the dashboard footer shows `Eneru v<ver> · <runtime> · Updated · <time>`.

## Why this fixes the reported issue
The UniFi UPS *does* expose `test.battery.start`, but only to an authenticated `upscmd -l`; Eneru listed anonymously → empty → "does not expose". Fix #1 addresses that; #2/#3 remove the config friction hit when flipping `self_test` on; #4 surfaces the UPS's own `done and passed` result even when Eneru can't (or shouldn't) issue tests.

## Testing
- Full unit suite green (**2838**), all touched files **≥95%** coverage.
- New unit coverage: `auth_is_active`, `self_test_control`, credentialed `list_commands` + argv shape, passive observer (dedup / pending guard / no-date / finalize-stamp / isolation), softened validation + effective-auth (incl. DB-user), and the adversarial invariant that the general `/command` stays 403 when only `self_test` is on.
- **New E2E** (`single-ups-auth` Test 57 + `self-test-passed.dev`): asserts the softened config validates (auth via DB user, `nut_control` off), rejects no-auth, and that Eneru records + surfaces a `source=device` result via the API. (Issuing still isn't E2E-able — the dummy driver has no INSTCMD.)
- Pre-push review by `agent-skills:code-reviewer` (fresh context): APPROVE; its P1 findings (soft warning for non-test commands, adversarial regression test) are addressed in this branch.
- Dashboard footer visually verified against the live daemon (runtime context renders; version confirmed via a working-tree 6.1.2 daemon).

## Security note
The softening is scoped to the single configured `self_test.command`; the general control surface is structurally unchanged and API auth remains required. The one deliberate posture change: `self_test.command` is now self-authorizing for exactly that command (a non-`test.*` value warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-test discovery on NUT setups that list commands only for authenticated clients and simplifies self-test permissions. Adds passive device-run self-test observation, hardens its retry behavior, and surfaces daemon version/runtime; no shutdown-path changes.

- **Bug Fixes**
  - `upscmd -l` now forwards `nut_control` credentials (argv shape `upscmd -u <user> -l <ups>`); password stays off argv. Anonymous listing is unchanged.
  - Validation honors effective auth (explicit `api.auth.enabled` or a user in the auth DB), matching runtime enforcement.
  - Passive observer reliability: fingerprinting happens only after a successful record, so failed writes retry on the next poll instead of dropping a device result.

- **New Features**
  - Softer self-test permission: enabling `self_test` grants exactly `self_test.command` without `nut_control.enabled` or allowlisting. General `/command` and `/variables` remain unchanged and still require API auth. A non-`test.*` command logs a warning. The self-test API endpoint is visible when `self_test` is enabled or when general control is enabled.
  - Passive self-test observation: on each poll, read `ups.test.result`/`ups.test.date` and record a `source: device` result (deduped; pauses while an Eneru-issued test is pending). Surfaces in the dashboard, API, Prometheus, and battery-health.
  - API/dashboard: `GET /api/v1/ups` adds `version` and `runtimeContext`; the dashboard footer shows `Eneru v<ver> · <runtime> · Updated · <time>`.

<sup>Written for commit 23fd8f91063098caccf6d45c20d35c3308b97a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for observing UPS self-test results in the app and UI.
  * Exposed version and runtime details in the status response and dashboard footer.

* **Bug Fixes**
  * Improved self-test permission handling so it works with the correct authentication state.
  * Allowed self-tests to run without requiring broader UPS control settings.
  * Added support for authenticated UPS command discovery when needed.

* **Documentation**
  * Updated configuration and self-test docs to reflect the new behavior.

* **Tests**
  * Expanded end-to-end and unit coverage for self-test, auth, and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->