### PR TITLE
fix(v6.1.3): self-test parser (description-less command lists) + de-dup Battery self-test row

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [6.1.3] - 2026-07-01
+
+Two self-test bug fixes on top of 6.1.2, from live UniFi hardware. No shutdown
+behavior changes.
+
+### Fixed
+
+- **Self-test "does not expose" on UPSes that list commands without
+  descriptions.** `upscmd -l` was only parsed in the standard
+  `name - description` form, so a UPS that lists bare command names (e.g.
+  Ubiquiti/UniFi: `test.battery.start` with no description) produced an empty
+  list — a supported command looked unsupported and every Run-self-test failed.
+  The parser now accepts both the described and description-less forms while
+  still rejecting the header and prose lines. (The 6.1.2 credentialed-`upscmd -l`
+  change fixed a different case; this is the one that affected UniFi.)
+- **Duplicated "Last self-test" on the Battery tab.** Once 6.1.2 began recording
+  device results, the battery-health card showed self-test twice — as a
+  score-factor meter and again as the actual result. It now appears once, as the
+  "Passed/Failed · date" result (the same duplication in the detail modal is gone
+  too).
+
+---
+
 ## [6.1.2] - 2026-07-01
 
 Self-test fixes driven by real UniFi UPS testing, on top of 6.1.1. No shutdown

--- a/src/eneru/nut_control.py
+++ b/src/eneru/nut_control.py
@@ -330,17 +330,29 @@ def list_commands(ups_name: str, *, username: str = "", password: str = "",
 def _parse_command_list(text: str) -> List[str]:
     """Extract command names from ``upscmd -l`` output.
 
-    Lines look like ``  beeper.toggle - Toggle the UPS beeper``; the header line
-    ``Instant commands supported on UPS ...:`` has no `` - `` token.
+    Two formats occur in the wild:
+      * standard NUT drivers: ``  beeper.toggle - Toggle the UPS beeper``
+      * description-less (e.g. Ubiquiti/UniFi): bare ``test.battery.start``
+    Take the FIRST whitespace-delimited token of each line — the command name in
+    BOTH shapes — and keep it only if it looks like a NUT instant command (dotted
+    lowercase). The header line ``Instant commands supported on UPS ...:`` and any
+    blank lines fall out because their first token isn't a valid command name.
+    (Earlier versions required a `` - `` separator and so returned NOTHING for the
+    description-less format, making a supported command look unsupported.)
     """
     commands: List[str] = []
     for line in text.splitlines():
         line = line.strip()
-        if " - " not in line:
+        if not line:
             continue
-        name = line.split(" - ", 1)[0].strip()
+        # Standard "name - description": take the part before the separator.
+        # Description-less: the WHOLE line must itself be the command name — so a
+        # bare "test.battery.start" is accepted while prose ("noise line without
+        # separator", the "Instant commands..." header) is rejected because it
+        # isn't a single command token.
+        name = line.split(" - ", 1)[0].strip() if " - " in line else line
         # A NUT instant command is dotted lowercase tokens (e.g. test.battery.start).
-        if name and re.fullmatch(r"[a-z0-9.+-]+", name):
+        if re.fullmatch(r"[a-z0-9.+-]+", name):
             commands.append(name)
     return commands
 

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.1.2"
+__version__ = "6.1.3"

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -578,7 +578,7 @@ function closeDetail() {
 
 const BH_TERM_LABELS = {
   capacity: "Capacity trend", runtime: "Runtime vs nominal",
-  self_test: "Last self-test", anomaly: "Anomalies", age: "Battery age",
+  anomaly: "Anomalies", age: "Battery age",
 };
 const BH_TERM_HELP = {
   capacity: "Runtime trend over time vs the nominal full runtime. Needs about "
@@ -586,7 +586,6 @@ const BH_TERM_HELP = {
     + "than guessing (a few days of jitter would otherwise look like total loss).",
   runtime: "Current runtime under load vs the expected full runtime. n/a until "
     + "the nominal runtime is configured or learned at a full charge.",
-  self_test: "Result of the latest battery self-test — only a pass or fail counts.",
   anomaly: "Confirmed battery anomalies; each one lowers the score.",
   age: "Battery age vs its expected service life (set battery_install_date and "
     + "expected_life_years).",
@@ -614,8 +613,11 @@ function batteryHealthRows(bh, opts) {
     rows.push(detailRow("Replace in", "~" + Math.round(bh.replacementDaysRemaining) + " days"));
   }
   // Per-term breakdown: each sub-score (0-100) or n/a when that term has no data.
+  // NOTE: self_test is deliberately NOT a meter here — it's shown once as its
+  // actual "Passed/Failed · date" result (Battery tab row + detail modal
+  // section). A 0-100 self-test bar duplicated that under the same label.
   const terms = bh.terms || {};
-  ["capacity", "runtime", "self_test", "anomaly", "age"].forEach((k) => {
+  ["capacity", "runtime", "anomaly", "age"].forEach((k) => {
     if (!(k in terms)) return;
     const v = terms[k];
     // Each factor gets a small 0-100 meter next to its number, so "why is the

--- a/tests/test_nut_control.py
+++ b/tests/test_nut_control.py
@@ -59,6 +59,44 @@ def test_list_commands_failure(monkeypatch):
 
 
 @pytest.mark.unit
+def test_parse_command_list_bare_names():
+    # Regression (v6.1.3): Ubiquiti/UniFi lists commands with NO " - description"
+    # suffix. The pre-6.1.3 parser required " - " and returned NOTHING here,
+    # making a supported command look unsupported ("does not expose").
+    raw = ("Instant commands supported on UPS [ups]:\n\n"
+           "test.battery.start\nload.off\nload.on\nshutdown.reboot\n")
+    assert nc._parse_command_list(raw) == [
+        "test.battery.start", "load.off", "load.on", "shutdown.reboot"]
+
+
+@pytest.mark.unit
+def test_parse_command_list_standard_format_still_works():
+    raw = ("Instant commands supported on UPS [ups]:\n\n"
+           "  beeper.toggle - Toggle the UPS beeper\n"
+           "  test.battery.start - Start a battery test\n")
+    assert nc._parse_command_list(raw) == ["beeper.toggle", "test.battery.start"]
+
+
+@pytest.mark.unit
+def test_parse_command_list_skips_header_and_blanks():
+    assert nc._parse_command_list("") == []
+    # Header-only (no command tokens) yields nothing — the header's first token
+    # "Instant" is not a valid dotted-lowercase command name.
+    assert nc._parse_command_list(
+        "Instant commands supported on UPS [ups]:\n\n") == []
+
+
+@pytest.mark.unit
+def test_list_commands_bare_format_end_to_end(monkeypatch):
+    monkeypatch.setattr(
+        nc, "run_command",
+        lambda cmd, timeout=10:
+            (0, "Instant commands supported on UPS [ups]:\n\ntest.battery.start\n", ""))
+    ok, commands, _ = nc.list_commands("UPS@h")
+    assert ok and commands == ["test.battery.start"]
+
+
+@pytest.mark.unit
 def test_list_commands_anonymous_when_no_creds(monkeypatch):
     # With no credentials, listing stays on the plain (anonymous) runner.
     captured = {}


### PR DESCRIPTION
## Summary

Two follow-ups to 6.1.2, diagnosed on live UniFi hardware. No shutdown-path changes.

1. **Self-test "does not expose" on UPSes that list commands without descriptions (the real UniFi blocker).** `nut_control._parse_command_list` only recognized the standard `upscmd -l` form `name - description`. A UPS that lists **bare** command names — Ubiquiti/UniFi emits `test.battery.start` with no ` - description` — parsed to an **empty list**, so discovery reported the command unsupported and every Run-self-test failed with *"does not expose 'test.battery.start' (upscmd -l)"*. The parser now accepts both the described and description-less forms, while still rejecting the header (`Instant commands supported on UPS …:`) and prose lines. *(The 6.1.2 credentialed-`upscmd -l` change fixed a genuine but different case; this is what actually affected UniFi.)*

2. **Duplicated "Last self-test" on the Battery tab.** Once 6.1.2 began recording device self-test results, the battery-health card rendered self-test twice — as a 0-100 score-factor meter **and** as the actual result row. Dropped the `self_test` factor meter; it now appears once, as the `Passed/Failed · date` result. Same duplication removed from the detail modal.

## Verified live (reporter's UPS + running container)
- Raw `upscmd -l` output has zero ` - ` separators; old parser → `[]`, new parser → `['test.battery.start','load.off','load.on','shutdown.reboot']`.
- `discover_self_test_command('ups@…','test.battery.start')` now returns the command (anon **and** credentialed).
- Issuing already worked (`OK Battery test started`), so the manual **Run self-test** path is now unblocked end-to-end.
- Battery tab screenshotted against the live daemon: a single "Last self-test — Passed · 2026-06-02" row.

## Tests
- New unit tests: bare-name parse, standard-format still parses, header/blank/prose rejection, and a bare-format `list_commands` end-to-end. Existing `test_parse_command_list_skips_header_and_junk` still passes (prose still rejected).
- Full unit suite: **2847 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-test discovery on UPSes that list bare command names and removes the duplicate “Last self-test” row on the Battery tab. No shutdown-path changes.

- **Bug Fixes**
  - Parser now accepts both `name - description` and bare-name outputs from `upscmd -l` (e.g., `test.battery.start` from UniFi). Prevents false “does not expose” errors and unblocks Run self-test.
  - Removed the `self_test` factor meter to eliminate duplicate “Last self-test” display. The result now appears once in the card and detail modal.

<sup>Written for commit 7d0ad0c914ea7b81fc55622e42c7b3d2b4ffecfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-test commands are now discovered correctly even when command listings omit descriptions.
  * The Battery tab now shows the “Last self-test” result only once, instead of duplicating it.
* **Chores**
  * Updated the app version to 6.1.3 and added a changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->