### PR TITLE
v6.1.4: multi-UPS correctness + dashboard UX overhaul (bug-fix release)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,19 @@ release; no config or shutdown behavior changes.
   a UPS reports too little AC telemetry to judge.
 - Self-test result casing, a duplicated Config heading, and config-card spacing
   for long UPS names.
+- **Self-test "command not exposed" is now actionable.** When the configured
+  `self_test.command` isn't offered by a UPS — e.g. APC (via `usbhid-ups`) exposes
+  `test.battery.start.quick` / `.deep`, not the bare `test.battery.start` — the API
+  and CLI now list the battery-test commands the UPS *does* expose so you can set
+  the right one (per-UPS in multi-UPS mode).
+- **Battery age no longer looks broken.** The age factor is a 0-100 sub-score where
+  `0` means "at/past expected life"; the Battery view now shows the actual age
+  (e.g. "~10.0 yr / 5 yr") beside it, so a low score reads as a worn battery rather
+  than "0 = new / not reported". Age is per-UPS: a UPS without its own
+  `battery_install_date` reads "n/a" instead of borrowing another battery's date.
+- The empty **"no redundancy groups configured" hint is gone** from Overview for
+  the majority who run independent UPSes; the section now appears only when
+  redundancy groups actually exist.
 
 ### Changed
 
@@ -59,6 +72,10 @@ release; no config or shutdown behavior changes.
   narrow-viewport handling.
 - The API listen backlog is raised so bursts of concurrent dashboard requests
   aren't refused.
+- Documented per-UPS overrides (credentials, self-test command, battery install
+  date) with a copy-pasteable multi-UPS example in the config reference and the
+  nut-control / self-test guides — the capability already existed but was easy to
+  miss.
 
 ### Notes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [6.1.4] - 2026-07-02
+
+Multi-UPS correctness and a dashboard overhaul for multi-UPS deployments, driven
+by adding a second, monitoring-only UPS to a running system. Shipped as a bug-fix
+release; no config or shutdown behavior changes.
+
+### Fixed
+
+- **Adding a second UPS orphaned all prior history.** Going from one UPS to
+  multiple switched the stats store from `default.db` to per-UPS databases, so
+  the pre-existing UPS's months of history, events, and aggregates vanished from
+  the dashboard, API, CLI, TUI, and reports. On the first multi-UPS boot Eneru
+  now migrates `default.db` into the first group's per-UPS database — idempotent
+  and restart-safe — so history survives the transition.
+- **Spurious 0% battery-charge spikes.** A network-polled (monitoring-only) UPS
+  that returns a transient `0` for `battery.charge` on a partial poll no longer
+  writes a false zero while on line power (mirrors the existing input-voltage
+  guard), so the charge graph and its AVG/MIN aggregates stay clean.
+- **Missing power-quality telemetry rendered as bare units** — "V" / "Hz" / "°C"
+  with no number for a monitoring-only UPS; empty values now read "—".
+- **Battery-health factor meters rendered full-width regardless of value** — the
+  strict CSP stripped their inline width, so the meters silently lied; the bars
+  now reflect the real 0-100 scores. The `data:` favicon (also CSP-blocked) is
+  now a packaged same-origin asset.
+- The line-quality verdict reads **Unknown** (not a confident green "Good") when
+  a UPS reports too little AC telemetry to judge.
+- Self-test result casing, a duplicated Config heading, and config-card spacing
+  for long UPS names.
+
+### Changed
+
+- **A global UPS selector** in the header (default "All UPS") scopes the Power /
+  Battery / Energy / Shutdown tabs and the per-UPS card grids; the per-tab UPS
+  dropdowns are retired. Overview stays fleet-wide.
+- **Overview summarizes the whole fleet** — a persistent fleet-status strip, a
+  "monitoring only" badge on non-local UPSes, and headline KPIs that report the
+  worst battery health, total energy, and worst self-test across all UPSes rather
+  than a single one.
+- **Shutdown plans are per-UPS and discoverable** — "All UPS" stacks every plan,
+  and a monitoring-only UPS shows why it runs no local shutdown.
+- Tab order moves Events and Config to the end; Events gains a Source column and
+  is seeded from the global UPS selection.
+- Status colors are calibrated: on-battery urgency (amber ring, "ON BATTERY"),
+  confidence-tempered battery-health badges, neutral idle regulation states, and
+  a neutral (not alarm) shutdown-trigger banner.
+- Charts gain a time axis, break across data gaps instead of bridging them, and
+  use a categorical (non-status) series palette.
+- Accessibility: WCAG AA status-color contrast, a modal focus trap + Esc, visible
+  focus rings, `prefers-reduced-motion`, ARIA on charts / modals / controls, and
+  narrow-viewport handling.
+- The API listen backlog is raised so bursts of concurrent dashboard requests
+  aren't refused.
+
+### Notes
+
+- Deferred to a follow-up: hero instantaneous watts; a chart-core consolidation
+  (small-multiples for Load & power, nice-number y-ticks, shape-encoded event
+  markers, health-trend hover); and a couple of UI nits.
+
+---
+
 ## [6.1.3] - 2026-07-01
 
 Two self-test bug fixes on top of 6.1.2, from live UniFi hardware. No shutdown

--- a/docs/nut-control.md
+++ b/docs/nut-control.md
@@ -105,3 +105,8 @@ ups:
       allowed_commands: [test.battery.start, beeper.toggle]
   - name: "UPS2@hostB"     # no override -> uses the global credentials
 ```
+
+`self_test` and `battery_health` are per-UPS overridable the same way — set
+`self_test.command` per device (vendors differ; see [self-test.md](self-test.md))
+and give each battery its own `battery_health.battery_install_date`. A complete,
+copy-pasteable multi-UPS block lives in `examples/config-reference.yaml`.

--- a/docs/self-test.md
+++ b/docs/self-test.md
@@ -37,6 +37,19 @@ for that UPS with a logged warning. Note that some upsd setups (notably UniFi's
 NUT) only return the command list to a **logged-in** client — Eneru forwards the
 `nut_control` credentials to `upscmd -l` so discovery works there.
 
+**The command name varies by vendor.** The `test.battery.start` default is not
+universal: APC devices via the `usbhid-ups` driver expose
+`test.battery.start.quick` and `test.battery.start.deep` (plus
+`test.battery.stop`) but **not** the bare `test.battery.start`. When the
+configured command isn't offered, the CLI and the API's 422 response now list
+the battery-test commands the UPS *does* expose, so you can set `self_test.command`
+to the right one. Run `upscmd -l <ups>` yourself to see the full list.
+
+**Multi-UPS:** the self-test command is per-UPS. When UPSes live on different
+upsd servers, set `self_test.command` (and, if that upsd needs a login,
+`nut_control.username` / `password`) under each `ups:` list entry — see the
+multi-UPS example in `examples/config-reference.yaml`.
+
 ## Configuration
 
 ```yaml

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -27,6 +27,47 @@ ups:
     # Send a warning after this many grace-period recoveries (flaps) within 24h (default: 5)
     flap_threshold: 5
 
+# ------------------------------------------------------------------------------
+# MULTI-UPS (list form) — watch several UPSes, each on its own upsd if needed.
+# ------------------------------------------------------------------------------
+# Make `ups:` a LIST instead of the single mapping above. Each entry is an
+# independent group. The global `nut_control:`, `self_test:`, and
+# `battery_health:` sections lower in this file are the DEFAULTS; any of them can
+# be OVERRIDDEN per UPS right here — because credentials, the self-test command,
+# and battery facts are device-specific. Unset fields in a per-UPS block inherit
+# the global default (an explicitly-empty allowed_commands means deny-all).
+#
+# ups:
+#   # --- The UPS that powers THIS host (drives local shutdown). ---
+#   - name: "ups@192.168.178.11"
+#     display_name: "Lab"
+#     is_local: true
+#
+#   # --- A second UPS on a DIFFERENT upsd (e.g. a Pi NUT server), monitor-only. ---
+#   - name: "apc@192.168.178.225"
+#     display_name: "APC"
+#     is_local: false                # never powers off this host; watch/notify only
+#     check_interval: 5
+#     # Independent AUTH: this UPS lives on another upsd with its own upsd.users.
+#     # These creds are used for upscmd (list + issue) against THIS device only;
+#     # the global nut_control.enabled still gates the write feature overall.
+#     nut_control:
+#       username: "apc-monitor"
+#       password: "<this-upsd's-secret>"
+#       allowed_commands:
+#         - test.battery.start.quick
+#     # Independent COMMAND: APC exposes quick/deep, not the bare default. Enabling
+#     # self_test auto-permits exactly this command for this UPS.
+#     self_test:
+#       enabled: true
+#       command: test.battery.start.quick
+#     # Independent BATTERY facts: the age term needs THIS battery's own install
+#     # date. Leave unset to read "unavailable" rather than borrowing the global
+#     # (Lab) date — a physical battery's age can't be inherited from another.
+#     battery_health:
+#       battery_install_date: "2021-06-25"
+#       expected_life_years: 5.0
+
 # ==============================================================================
 # SHUTDOWN TRIGGERS
 # ==============================================================================
@@ -234,8 +275,13 @@ self_test:
   schedule: monthly
   # Wall-clock time for calendar schedules (HH:MM, daemon local time).
   time: "03:00"
-  # The instant command to issue. Adapts to whatever `upscmd -l` exposes; many
-  # UPSes only support `test.battery.start`. Enabling self_test auto-permits it.
+  # The instant command to issue. It must be one that `upscmd -l` actually
+  # exposes for the UPS. Many devices differ from the default: APC (via
+  # usbhid-ups) offers `test.battery.start.quick` / `test.battery.start.deep`
+  # (and `test.battery.stop`), NOT the bare `test.battery.start`. If the
+  # configured command isn't exposed, the API/CLI tell you which test commands
+  # ARE available so you can set the right one (per-UPS in multi-UPS mode).
+  # Enabling self_test auto-permits exactly this command.
   command: test.battery.start
   # Seconds to wait after issuing before polling ups.test.result.
   result_poll_after: 60

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -399,6 +399,13 @@ contents:
       owner: root
       group: root
 
+  - src: src/eneru/web/favicon.svg
+    dst: /opt/ups-monitor/eneru/web/favicon.svg
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+
   # Systemd service file (use /lib for packages, not /etc)
   - src: packaging/eneru.service
     dst: /lib/systemd/system/eneru.service

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -42,6 +42,7 @@ _STATIC_CONTENT_TYPES = {
     ".html": "text/html",
     ".js": "application/javascript",
     ".css": "text/css",
+    ".svg": "image/svg+xml",
 }
 _DASHBOARD_INDEX = "index.html"
 # A conservative charset for upsrw values. NUT values are short tokens (numbers,
@@ -59,6 +60,7 @@ _CONTENT_TYPE_HEADERS = {
     "text/html": "text/html; charset=utf-8",
     "application/javascript": "application/javascript; charset=utf-8",
     "text/css": "text/css; charset=utf-8",
+    "image/svg+xml": "image/svg+xml; charset=utf-8",
 }
 
 # Serialize control writes per UPS so two concurrent requests can't race an
@@ -194,19 +196,6 @@ def _auth_is_active(config: Any) -> bool:
     return auth_is_active(getattr(getattr(config, "api", None), "auth", None))
 
 
-class _EneruHTTPServer(ThreadingHTTPServer):
-    """Threaded server with a deeper listen backlog.
-
-    The stdlib default ``request_queue_size`` is 5, so a short burst of
-    concurrent connections (a browser dashboard polling several endpoints at
-    once, plus a scripted client) can overflow the accept queue and surface as
-    intermittent ``connection refused`` even though the daemon is healthy and
-    every handler runs on its own worker thread. 128 absorbs realistic bursts.
-    """
-
-    request_queue_size = 128
-
-
 class EneruAPIServer:
     """Small stdlib HTTP server for read-only observability endpoints."""
 
@@ -253,9 +242,19 @@ class EneruAPIServer:
 
         addr = (self.config.api.bind, int(self.config.api.port))
         try:
-            self._httpd = _EneruHTTPServer(addr, Handler)
+            # bind_and_activate=False so we can raise the listen backlog before
+            # listen() is called. The stdlib default request_queue_size is 5, so a
+            # burst of concurrent dashboard/API connections could overflow the
+            # accept queue and surface as intermittent "connection refused" even
+            # though the daemon is healthy and every handler runs on its own
+            # worker thread. 128 absorbs realistic bursts.
+            self._httpd = ThreadingHTTPServer(addr, Handler, bind_and_activate=False)
+            self._httpd.request_queue_size = 128
+            self._httpd.server_bind()
+            self._httpd.server_activate()
         except OSError as exc:
             self.log_fn(f"⚠️  API server failed to bind {addr[0]}:{addr[1]}: {exc}")
+            self._httpd = None
             return
         # v6.0: worker threads are NON-daemon. The API now has non-idempotent
         # write endpoints (control commands, config reload), so a worker must

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -937,17 +937,24 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         # API honors the same "self-disable if unsupported" contract the docs
         # promise rather than letting NUT reject it after the fact.
         try:
-            exposed = selftest.discover_self_test_command(
-                real, command, username=nc.username, password=nc.password,
+            supported = selftest.list_supported_commands(
+                real, username=nc.username, password=nc.password,
                 timeout=nc.timeout)
         except selftest.SelfTestUnavailable as exc:
             self._audit(principal, "self-test", f"{real}:{command}", "failed")
             return 502, "application/json", self._error("NUT_ERROR", str(exc))
-        if exposed is None:
+        if command not in supported:
             self._audit(principal, "self-test", f"{real}:{command}", "failed")
+            # Point the operator at what this UPS actually offers — many devices
+            # expose test.battery.start.quick/.deep, not the bare default — so a
+            # 422 is actionable ("set self_test.command to X") not a dead end.
+            candidates = selftest.test_command_candidates(supported)
+            hint = (" Available battery-test commands: " + ", ".join(candidates)
+                    + " — set this UPS's self_test.command to one of them."
+                    ) if candidates else ""
             return 422, "application/json", self._error(
                 "UNSUPPORTED",
-                f"UPS {real} does not expose {command!r} (upscmd -l)")
+                f"UPS {real} does not expose {command!r} (upscmd -l).{hint}")
         # A self-test must record a `running` row so its result can be finalised
         # later; without an open stats store it would orphan that state, so
         # refuse (mirrors the CLI --direct and scheduler guards). A store that

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -194,6 +194,19 @@ def _auth_is_active(config: Any) -> bool:
     return auth_is_active(getattr(getattr(config, "api", None), "auth", None))
 
 
+class _EneruHTTPServer(ThreadingHTTPServer):
+    """Threaded server with a deeper listen backlog.
+
+    The stdlib default ``request_queue_size`` is 5, so a short burst of
+    concurrent connections (a browser dashboard polling several endpoints at
+    once, plus a scripted client) can overflow the accept queue and surface as
+    intermittent ``connection refused`` even though the daemon is healthy and
+    every handler runs on its own worker thread. 128 absorbs realistic bursts.
+    """
+
+    request_queue_size = 128
+
+
 class EneruAPIServer:
     """Small stdlib HTTP server for read-only observability endpoints."""
 
@@ -240,7 +253,7 @@ class EneruAPIServer:
 
         addr = (self.config.api.bind, int(self.config.api.port))
         try:
-            self._httpd = ThreadingHTTPServer(addr, Handler)
+            self._httpd = _EneruHTTPServer(addr, Handler)
         except OSError as exc:
             self.log_fn(f"⚠️  API server failed to bind {addr[0]}:{addr[1]}: {exc}")
             return

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -254,6 +254,14 @@ class EneruAPIServer:
             self._httpd.server_activate()
         except OSError as exc:
             self.log_fn(f"⚠️  API server failed to bind {addr[0]}:{addr[1]}: {exc}")
+            # bind_and_activate=False bypasses TCPServer.__init__'s cleanup, so a
+            # failed server_bind() leaves the freshly-created socket open. Close it
+            # explicitly to avoid leaking the fd on a retry / repeated reload.
+            if self._httpd is not None:
+                try:
+                    self._httpd.server_close()
+                except OSError:
+                    pass
             self._httpd = None
             return
         # v6.0: worker threads are NON-daemon. The API now has non-idempotent

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -1999,15 +1999,22 @@ def _self_test_run_direct(
               "credentials in the config.")
         sys.exit(2)
     try:
-        cmd = selftest.discover_self_test_command(
-            name, command, username=nc.username, password=nc.password,
+        supported = selftest.list_supported_commands(
+            name, username=nc.username, password=nc.password,
             timeout=nc.timeout)
     except selftest.SelfTestUnavailable as exc:
         print(f"Could not query the UPS ({exc}); try again.")
         sys.exit(1)
-    if cmd is None:
+    if command not in supported:
+        # Surface the startable tests this UPS actually offers (APC & friends
+        # expose test.battery.start.quick/.deep, not the bare default).
+        candidates = selftest.test_command_candidates(supported)
         print(f"UPS {name} does not expose {command!r} (upscmd -l); nothing to do.")
+        if candidates:
+            print("   Available battery-test commands: " + ", ".join(candidates))
+            print("   Set this UPS's self_test.command to one of them.")
         sys.exit(1)
+    cmd = command
     store = _open_stats_store(config, group)
     if store is None:
         # Without the stats DB the issued test records no `running` row, so its

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -1308,13 +1308,23 @@ class ConfigLoader:
         base = base or BatteryHealthConfig()
         raw_rep = bh_data.get('replacement')
         rep = raw_rep if isinstance(raw_rep, dict) else {}
+        # PyYAML parses an UNQUOTED `battery_install_date: 2016-06-25` as a
+        # datetime.date, which is not JSON-serializable and breaks the status
+        # payload. Normalize to the "YYYY-MM-DD" string the scorer + API expect,
+        # so quoting the date in config is optional.
+        install_date = bh_data.get(
+            'battery_install_date', base.battery_install_date)
+        if install_date is not None and not isinstance(install_date, str):
+            try:
+                install_date = install_date.strftime("%Y-%m-%d")
+            except (AttributeError, ValueError):
+                install_date = str(install_date)
         return BatteryHealthConfig(
             enabled=bh_data.get('enabled', base.enabled),
             update_interval=bh_data.get('update_interval', base.update_interval),
             nominal_runtime_seconds=bh_data.get(
                 'nominal_runtime_seconds', base.nominal_runtime_seconds),
-            battery_install_date=bh_data.get(
-                'battery_install_date', base.battery_install_date),
+            battery_install_date=install_date,
             expected_life_years=bh_data.get(
                 'expected_life_years', base.expected_life_years),
             warn_score=bh_data.get('warn_score', base.warn_score),

--- a/src/eneru/health/battery.py
+++ b/src/eneru/health/battery.py
@@ -330,6 +330,10 @@ class BatteryMonitorMixin:
             min_history_days=min_history_days,
         )
         score, confidence, available = prediction.composite_score(terms)
+        # Carry the raw age alongside the 0-100 age sub-score so the UI can show
+        # "this battery is ~N years old" — a bare age score of 0 otherwise reads
+        # like "brand new" when it actually means "past its expected life".
+        age_years = prediction.battery_age_years(cfg.battery_install_date, now)
         return {
             "score": score,
             "confidence": round(confidence, 3),
@@ -337,6 +341,9 @@ class BatteryMonitorMixin:
             "terms": terms,
             "runtime_s": runtime_s,
             "nominalRuntime": nominal,
+            "installDate": cfg.battery_install_date,
+            "expectedLifeYears": cfg.expected_life_years,
+            "ageYears": round(age_years, 2) if age_years is not None else None,
             "ts": int(now),
         }
 

--- a/src/eneru/health/prediction.py
+++ b/src/eneru/health/prediction.py
@@ -21,6 +21,7 @@ __all__ = [
     "TERM_WEIGHTS",
     "age_score",
     "anomaly_score",
+    "battery_age_years",
     "capacity_score",
     "composite_score",
     "compute_terms",
@@ -106,22 +107,30 @@ def anomaly_score(anomaly_count: int, *, penalty: float = 25.0) -> float:
     return _clamp(100.0 - max(0, anomaly_count) * penalty)
 
 
-def age_score(battery_install_date: Optional[str],
-              expected_life_years: float,
-              now: float) -> Optional[float]:
-    """Battery age vs expected life. Unavailable if the install date is unset
-    or unparseable."""
-    if not battery_install_date or expected_life_years is None \
-            or expected_life_years <= 0:
+def battery_age_years(battery_install_date: Optional[str],
+                      now: float) -> Optional[float]:
+    """Battery age in years from its install date. ``None`` when the date is
+    unset or unparseable; never negative (a future install date reads as 0)."""
+    if not battery_install_date:
         return None
     try:
         installed = datetime.strptime(
             str(battery_install_date).strip(), "%Y-%m-%d").timestamp()
     except (ValueError, TypeError):
         return None
-    age_years = (now - installed) / (365.25 * 86400)
-    if age_years < 0:
-        age_years = 0.0
+    return max(0.0, (now - installed) / (365.25 * 86400))
+
+
+def age_score(battery_install_date: Optional[str],
+              expected_life_years: float,
+              now: float) -> Optional[float]:
+    """Battery age vs expected life. Unavailable if the install date is unset
+    or unparseable."""
+    if expected_life_years is None or expected_life_years <= 0:
+        return None
+    age_years = battery_age_years(battery_install_date, now)
+    if age_years is None:
+        return None
     return _clamp(100.0 * (1.0 - age_years / expected_life_years))
 
 

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -26,7 +26,7 @@ from eneru.remote_health import RemoteHealthManager, remote_health_sidecar_path
 from eneru.deferred_delivery import schedule_deferred_stop_or_eager_send
 from eneru.redundancy import RedundancyGroupEvaluator, RedundancyGroupExecutor
 from eneru.stats import StatsStore
-from eneru.status import redundancy_state_file_path
+from eneru.status import redundancy_state_file_path, sanitize_name
 from eneru.lifecycle import (
     REASON_SEQUENCE_COMPLETE,
     REASON_SIGNAL,
@@ -183,6 +183,10 @@ class MultiUPSCoordinator:
         # a notification worker is configured. Otherwise the markers
         # would leak across configurations (P2 finding from review).
         stats_dir = Path(self.config.statistics.db_directory)
+        # Before any monitor opens a write connection: rescue a single-UPS
+        # deployment's default.db into the first group's per-UPS DB, so adding
+        # a second UPS never silently orphans months of history.
+        self._migrate_legacy_default_db(stats_dir)
         shutdown_marker = read_shutdown_marker(stats_dir)
         upgrade_marker = read_upgrade_marker(stats_dir)
 
@@ -270,6 +274,49 @@ class MultiUPSCoordinator:
                     self._log(
                         f"⚠️  Failed to close stats DB {db_path.name}: {e}"
                     )
+
+    def _migrate_legacy_default_db(self, stats_dir: Path) -> None:
+        """One-time: promote the single-UPS ``default.db`` to the first group's
+        per-UPS stats DB when a deployment becomes multi-UPS.
+
+        A single-UPS install writes stats to ``default.db``. The moment a
+        second UPS is configured, ``stats_db_path_for_group`` switches every
+        group to ``<sanitized-name>.db`` -- and the pre-existing UPS's whole
+        history (raw + agg_5min + agg_hourly + events + battery_health) is
+        stranded in ``default.db``, read by nothing. This renames it into the
+        first group's per-UPS file so history, events, and the aggregate tiers
+        survive the transition on web, CLI, TUI, and reports at once.
+
+        Runs in the coordinator's pre-writer window (before any monitor opens
+        its write connection). Idempotent and restart-safe: no-op once the
+        rename has happened (``default.db`` gone) or if a per-UPS DB already
+        exists (leave both untouched rather than clobber live history)."""
+        if not self.config.ups_groups:
+            return
+        legacy = stats_dir / "default.db"
+        if not legacy.exists():
+            return
+        first = self.config.ups_groups[0]
+        target = stats_dir / f"{sanitize_name(first.ups.name)}.db"
+        if target.exists():
+            # A per-UPS DB is already accumulating; a blind rename would lose
+            # it. Leave default.db in place (recoverable) rather than guess a
+            # merge -- the pre-multi-UPS history can be merged manually.
+            return
+        try:
+            legacy.rename(target)
+            # Carry any SQLite WAL/SHM sidecars so no committed data is lost.
+            for suffix in ("-wal", "-shm"):
+                side = stats_dir / f"default.db{suffix}"
+                if side.exists():
+                    side.rename(stats_dir / f"{target.name}{suffix}")
+            self._log(
+                f"📦  Migrated single-UPS history {legacy.name} → {target.name} "
+                f"for {first.ups.label} (single→multi-UPS transition)")
+        except OSError as e:
+            self._log(
+                f"⚠️  Could not migrate {legacy.name} → {target.name}: {e} "
+                f"(history for {first.ups.label} may be unavailable until fixed)")
 
     def _read_last_seen_version_from_first_group(self, stats_dir):
         """Read meta.last_seen_version from the first group's stats DB

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -304,12 +304,28 @@ class MultiUPSCoordinator:
             # merge -- the pre-multi-UPS history can be merged manually.
             return
         try:
+            # Fold any committed WAL frames back into default.db BEFORE moving it.
+            # A clean single-UPS stop checkpoints on close, but a crash can leave a
+            # populated default.db-wal; renaming only the main file would strand
+            # those committed frames in an orphaned sidecar while the migration
+            # looks "done" (default.db gone). checkpoint(TRUNCATE) collapses the
+            # WAL into the DB and empties the sidecar first, so the single file we
+            # move is self-contained.
+            self._checkpoint_wal(legacy)
             legacy.rename(target)
-            # Carry any SQLite WAL/SHM sidecars so no committed data is lost.
+            # Post-checkpoint the sidecars hold no committed data, so relocating
+            # them is just tidy-up: best-effort PER FILE (a failure here can no
+            # longer lose data) rather than a rename that could abort mid-way.
             for suffix in ("-wal", "-shm"):
                 side = stats_dir / f"default.db{suffix}"
                 if side.exists():
-                    side.rename(stats_dir / f"{target.name}{suffix}")
+                    try:
+                        side.replace(stats_dir / f"{target.name}{suffix}")
+                    except OSError:
+                        try:
+                            side.unlink()
+                        except OSError:
+                            pass
             self._log(
                 f"📦  Migrated single-UPS history {legacy.name} → {target.name} "
                 f"for {first.ups.label} (single→multi-UPS transition)")
@@ -317,6 +333,21 @@ class MultiUPSCoordinator:
             self._log(
                 f"⚠️  Could not migrate {legacy.name} → {target.name}: {e} "
                 f"(history for {first.ups.label} may be unavailable until fixed)")
+
+    @staticmethod
+    def _checkpoint_wal(db_path: Path) -> None:
+        """Fold WAL frames into the main DB file and truncate the ``-wal`` sidecar
+        so the file is self-contained before it is moved. Best-effort: a missing
+        DB, a non-WAL DB, or a checkpoint error is a no-op (the sidecar relocation
+        in the caller is the fallback)."""
+        try:
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            pass
 
     def _read_last_seen_version_from_first_group(self, stats_dir):
         """Read meta.last_seen_version from the first group's stats DB

--- a/src/eneru/self_test.py
+++ b/src/eneru/self_test.py
@@ -22,10 +22,12 @@ __all__ = [
     "SelfTestUnavailable",
     "discover_self_test_command",
     "issue_self_test",
+    "list_supported_commands",
     "normalize_result",
     "parse_schedule",
     "record_self_test_result",
     "self_test_control",
+    "test_command_candidates",
 ]
 
 
@@ -63,6 +65,39 @@ def normalize_result(raw: Optional[str]) -> str:
     return "unknown"
 
 
+def list_supported_commands(ups_name: str, *,
+                            username: str = "", password: str = "",
+                            timeout: int = 10) -> list:
+    """Return the instant commands ``upscmd -l`` exposes for this UPS.
+
+    A *transient* ``upscmd -l`` failure raises ``SelfTestUnavailable`` (distinct
+    from an empty-but-successful list) so callers can retry instead of mistaking
+    a dropped connection for "nothing supported".
+
+    Credentials are forwarded because some upsd setups only return the command
+    list to a logged-in client — without them the list comes back empty and a
+    supported command looks unsupported.
+    """
+    ok, commands, err = nutctl.list_commands(
+        ups_name, username=username, password=password, timeout=timeout)
+    if not ok:
+        raise SelfTestUnavailable(err or "upscmd -l failed")
+    return commands
+
+
+def test_command_candidates(commands) -> list:
+    """The startable battery-test commands from an ``upscmd -l`` list.
+
+    Powers a "did you mean" hint when the configured ``self_test.command`` isn't
+    offered: many UPSes (e.g. APC via usbhid-ups) expose
+    ``test.battery.start.quick`` / ``test.battery.start.deep`` but NOT the bare
+    ``test.battery.start`` default. ``test.battery.stop`` is excluded — it ends a
+    test, it doesn't start one.
+    """
+    return sorted(c for c in (commands or [])
+                  if c.startswith("test.") and "start" in c)
+
+
 def discover_self_test_command(ups_name: str, command: str, *,
                                username: str = "", password: str = "",
                                timeout: int = 10) -> Optional[str]:
@@ -72,15 +107,9 @@ def discover_self_test_command(ups_name: str, command: str, *,
     UPS). A *transient* ``upscmd -l`` failure raises ``SelfTestUnavailable`` so
     the caller can retry instead of mistaking a dropped connection for an
     unsupported command (which on a 30-day cadence would skip a whole cycle).
-
-    Credentials are forwarded to ``upscmd -l`` because some upsd setups only
-    return the command list to a logged-in client — without them the list comes
-    back empty and a supported command looks unsupported.
     """
-    ok, commands, err = nutctl.list_commands(
+    commands = list_supported_commands(
         ups_name, username=username, password=password, timeout=timeout)
-    if not ok:
-        raise SelfTestUnavailable(err or "upscmd -l failed")
     return command if command in commands else None
 
 

--- a/src/eneru/shutdown/plan.py
+++ b/src/eneru/shutdown/plan.py
@@ -189,10 +189,18 @@ def build_shutdown_plan(config: Any, *, is_local: bool = True,
 
     # 7) Terminal step — coordinator handoff, or the local host poweroff.
     if coordinator_mode:
+        # The coordinator performs the single host poweroff — but that is a
+        # LOCAL-ownership action. A non-local (monitoring-only) group must NOT
+        # show a host-poweroff handoff: losing a UPS that doesn't power this host
+        # triggers nothing here. Gate it exactly like the other local phases.
+        handoff_skip = _local_skip(is_local, delegated, True)
+        handoff_on = handoff_skip is None
         phases.append(_phase(
-            "local-poweroff", "Group handoff", enabled=True,
+            "local-poweroff", "Group handoff", enabled=handoff_on,
+            skipped=handoff_skip,
             steps=[{"label": "Report group shutdown complete to the coordinator",
-                    "detail": "the coordinator performs the host poweroff"}]))
+                    "detail": "the coordinator performs the host poweroff"}]
+            if handoff_on else []))
     else:
         ls = config.local_shutdown
         # Host poweroff is a LOCAL-ownership action: gate it the same way as the

--- a/src/eneru/stats.py
+++ b/src/eneru/stats.py
@@ -110,6 +110,27 @@ def _to_input_voltage(value, *, ups_status: str) -> Optional[float]:
     return f
 
 
+def _to_battery_charge(value, *, ups_status: str) -> Optional[float]:
+    """Sanitize ``battery.charge`` against on-line phantom zeros.
+
+    A network-polled UPS (notably a monitoring-only NUT slave) occasionally
+    returns ``0`` for ``battery.charge`` on a partial / mid-transition poll --
+    seen as brief ``OL LB RB`` / ``ALARM OL`` flaps in the log. Stored
+    verbatim it draws a false plunge-to-zero on the charge graph and drags the
+    AVG/MIN aggregates. A genuine 0% only occurs deep in an outage -- on line
+    power the UPS would have shut down long before -- so drop a ``<= 0`` reading
+    only while on-line (mirrors ``_to_input_voltage``); on battery / FSD the low
+    reading is kept so real depletion history stays intact.
+    """
+    f = _to_float(value)
+    if f is None:
+        return None
+    status = ups_status or ""
+    if f <= 0.0 and "OL" in status and "OB" not in status and "FSD" not in status:
+        return None
+    return f
+
+
 def _sample_from_ups_data(
     ups_data: Dict[str, str],
     *,
@@ -128,7 +149,7 @@ def _sample_from_ups_data(
     return (
         int(ts if ts is not None else time.time()),
         status,
-        _to_float(ups_data.get("battery.charge")),
+        _to_battery_charge(ups_data.get("battery.charge"), ups_status=status),
         _to_float(ups_data.get("battery.runtime")),
         _to_float(ups_data.get("ups.load")),
         _to_input_voltage(ups_data.get("input.voltage"), ups_status=status),

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.1.3"
+__version__ = "6.1.4"

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -2904,24 +2904,8 @@ function shutdownTriggerNodes(name, plan) {
 }
 
 let _sdGen = 0;
-async function renderShutdownPlan() {
-  const host = document.getElementById("shutdown-plan");
-  if (!host) return;
-  const name = populateShutdownUpsSelect();
-  if (!name) {
-    host.replaceChildren(el("p", { class: "chart-note", text: "No UPS data yet." }));
-    return;
-  }
-  const myGen = ++_sdGen;
-  const res = await api("/api/v1/ups/" + encodeURIComponent(name) + "/shutdown-plan");
-  if (myGen !== _sdGen) return;
-  const plan = res.ok && res.data && res.data.plan;
-  if (!plan) {
-    host.replaceChildren(el("p", { class: "chart-note",
-      text: "Shutdown plan unavailable." }));
-    return;
-  }
-  host.replaceChildren();
+// Append one UPS's shutdown-plan body (trigger + phase flow) into a container.
+function appendShutdownPlanBody(host, name, plan) {
   shutdownTriggerNodes(name, plan).forEach((nd) => host.appendChild(nd));
   const intro = el("p", { class: "chart-note" },
     [el("span", { text: "What runs when a power-loss shutdown is triggered, top "
@@ -2985,6 +2969,43 @@ async function renderShutdownPlan() {
     flow.appendChild(node);
   });
   host.appendChild(flow);
+}
+
+// Render shutdown plans driven by the global UPS scope. Under "All UPS" (fleet)
+// every plan is stacked so a monitoring-only UPS's "only remote shutdown runs"
+// explanation is visible without hunting a dropdown; a single scope shows just
+// that UPS's plan under a clear "Viewing plan for" header. (operator #3)
+async function renderShutdownPlan() {
+  const host = document.getElementById("shutdown-plan");
+  if (!host) return;
+  const ctl = document.getElementById("shutdown-controls");
+  if (ctl) ctl.hidden = true;   // the header UPS selector is the scope control now
+  const rows = lastUpsRows;
+  if (!rows.length) {
+    host.replaceChildren(el("p", { class: "chart-note", text: "No UPS data yet." }));
+    return;
+  }
+  const targets = (scopeIsAll() && rows.length > 1)
+    ? rows.slice()
+    : rows.filter((u) => u.name === scopedName());
+  const stacked = targets.length > 1;
+  const myGen = ++_sdGen;
+  host.replaceChildren();
+  for (const u of targets) {
+    const res = await api("/api/v1/ups/" + encodeURIComponent(u.name) + "/shutdown-plan");
+    if (myGen !== _sdGen) return;   // a newer render superseded us
+    const plan = res.ok && res.data && res.data.plan;
+    const section = el("div", { class: "sd-plan" });
+    section.appendChild(el("div", { class: "sd-plan-title card-title" },
+      [el("h3", { text: (stacked ? "Plan · " : "Viewing plan for: ") + (u.label || u.name) }),
+       monitoringBadge(u)].filter(Boolean)));
+    if (!plan) {
+      section.appendChild(el("p", { class: "chart-note", text: "Shutdown plan unavailable." }));
+    } else {
+      appendShutdownPlanBody(section, u.name, plan);
+    }
+    host.appendChild(section);
+  }
 }
 
 function onTabActivated(name) {

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -440,9 +440,13 @@ function heroCard(u) {
     vital("Runtime", formatRuntimeSeconds(u.runtime)),
     vital("Load", u.load != null ? u.load + "%" : "—"),
     vital("Input", pq.inputVoltage != null ? pq.inputVoltage + " V" : "—"),
-    vital("On battery", u.timeOnBattery != null ? u.timeOnBattery + "s" : "—",
-      onBattery ? (low ? "crit" : "warn") : null),
   ];
+  // Time-on-battery only when actually on battery — a permanent "0s" is noise,
+  // and during an outage it's already the prominent ON BATTERY chip in the title.
+  if (onBattery) {
+    vitals.push(vital("On battery",
+      u.timeOnBattery != null ? u.timeOnBattery + "s" : "—", low ? "crit" : "warn"));
+  }
   // Surface line quality on the Overview only when it's NOT good — otherwise it's
   // buried on the Power tab where the operator rarely looks. (operator #14)
   const lq = lineQuality(pq);
@@ -595,6 +599,7 @@ function renderFleetStrip(rows) {
       el("span", { class: "fleet-metric",
         text: (isNaN(charge) ? "—" : charge + "%") + " · " + formatRuntimeSeconds(u.runtime) }),
       u.isLocal === false ? el("span", { class: "fleet-tag", text: "monitoring" }) : null,
+      el("span", { class: "fleet-go", "aria-hidden": "true", text: "›" }),
     ].filter(Boolean));
     chip.addEventListener("click", () => openDetail(u.name));
     strip.appendChild(chip);
@@ -613,20 +618,34 @@ function renderUps(payload) {
   if (upsSec) upsSec.hidden = true;
   renderOverviewSummary(rows);
 
-  const groups = (payload && payload.redundancyGroups) || [];
-  lastGroups = groups;
+  lastGroups = (payload && payload.redundancyGroups) || [];
+  renderRedundancy();
+  renderRemoteHealth();
+  updateEventSourceFilter(rows, lastGroups);
+}
+
+// Redundancy-groups section, scoped by the global selector (groups are per-UPS
+// via upsSources). Re-rendered on scope change from onTabActivated("overview").
+function renderRedundancy() {
   const gsec = document.getElementById("groups-section");
   const gwrap = document.getElementById("group-cards");
+  if (!gsec || !gwrap) return;
+  const rows = lastUpsRows;
+  let groups = lastGroups || [];
+  const all = scopeIsAll();
+  if (!all) groups = groups.filter((g) => (g.upsSources || []).includes(currentScope()));
   gwrap.replaceChildren();
-  // In a fleet with no redundancy groups configured, show a discoverable hint
-  // rather than hiding the section entirely — otherwise the feature is invisible.
-  // Single-UPS deployments (where groups make no sense) still hide it. (operator #15)
-  gsec.hidden = groups.length === 0 && rows.length <= 1;
-  if (groups.length === 0 && rows.length > 1) {
-    gwrap.appendChild(el("div", { class: "card" }, [
-      el("p", { class: "chart-note", text: "No redundancy groups configured. "
-        + "Group UPSes so a shutdown only triggers when quorum is lost — see the "
-        + "redundancy-groups docs." })]));
+  // The "configure redundancy groups" hint only makes sense in the fleet view
+  // (All UPS, >1 UPS, none configured); a scoped view just hides the section.
+  gsec.hidden = groups.length === 0 && !(all && rows.length > 1);
+  if (groups.length === 0) {
+    if (all && rows.length > 1) {
+      gwrap.appendChild(el("div", { class: "card" }, [
+        el("p", { class: "chart-note", text: "No redundancy groups configured. "
+          + "Group UPSes so a shutdown only triggers when quorum is lost — see the "
+          + "redundancy-groups docs." })]));
+    }
+    return;
   }
   groups.forEach((g) => {
     const sources = g.upsSources || [];
@@ -642,8 +661,6 @@ function renderUps(payload) {
         el("b", { text: String(sources.length) })]),
     ]));
   });
-  renderRemoteHealth();
-  updateEventSourceFilter(rows, groups);
 }
 
 // ----- UPS detail drill-down (Slice D) -----
@@ -690,7 +707,14 @@ function renderRemoteHealth() {
   const sec = document.getElementById("remote-section");
   const wrap = document.getElementById("remote-cards");
   if (!sec || !wrap) return;
-  const servers = remoteHealthSnapshot || [];
+  // Remote servers are per-UPS shutdown targets (row.group = owning UPS label),
+  // so honor the global scope: scoped to one UPS → just its servers; "All" → all.
+  let servers = remoteHealthSnapshot || [];
+  if (!scopeIsAll()) {
+    const u = lastUpsRows.find((r) => r.name === currentScope());
+    const lbl = u && (u.label || u.name);
+    servers = servers.filter((s) => s.group === lbl);
+  }
   sec.hidden = servers.length === 0;
   if (!servers.length) { wrap.replaceChildren(); return; }
   wrap.replaceChildren(...servers.map((r) => {
@@ -713,7 +737,8 @@ function renderRemoteHealth() {
     if (r.latency_ms != null && reachable) {
       rows.push(configKv("Latency", Math.round(r.latency_ms) + " ms"));
     }
-    rows.push(configKv("Last checked", relTime(r.last_checked_at)));
+    rows.push(hintedRow("Last checked", relTime(r.last_checked_at),
+      r.last_checked_at ? new Date(r.last_checked_at * 1000).toLocaleString() : null));
     if (r.consecutive_failures) {
       rows.push(el("div", { class: "row" }, [el("span", { text: "Failures" }),
         el("b", { class: "crit", text: String(r.consecutive_failures) })]));
@@ -1365,7 +1390,14 @@ function eventMarkerClass(type) {
 // chart marker color, so a marker and its row read the same at a glance.
 function eventTypeBadge(e) {
   const type = e.eventType || e.event || "";
-  const cls = eventMarkerClass(type);
+  let cls = eventMarkerClass(type);
+  // Fold a command / self-test OUTCOME into the tone so "… -> failed" isn't a
+  // neutral bell identical to "… -> ok" (self-test is a KPI + battery-card row).
+  const detail = (e.detail || e.details || "").toLowerCase();
+  const m = detail.match(/(?:->|→)\s*([a-z]+)\b/);
+  if (m && ["failed", "error", "timeout"].includes(m[1])) cls = "ev-crit";
+  else if (/\bfailed\b/.test(detail)) cls = "ev-crit";
+  else if (cls === "ev-info" && m && ["ok", "passed", "done", "success"].includes(m[1])) cls = "ev-ok";
   const tone = { "ev-ok": "ok", "ev-warn": "warn", "ev-crit": "crit" }[cls] || "info";
   const ico = { "ev-ok": "check", "ev-warn": "alert", "ev-crit": "alert" }[cls] || "bell";
   return el("span", { class: "ev-badge " + tone }, [icon(ico), el("span", { text: type })]);
@@ -1615,6 +1647,103 @@ function chartGapThresh(drawn) {
   return med > 0 ? med * 3 : Infinity;
 }
 
+// Min/max decimation: reduce a dense point run to ~2 points per bucket (the
+// bucket's min AND max value, in time order) so a 24h/2s series (~19k points,
+// an unreadable "barcode") thins to ~1-2 points/pixel while spikes survive.
+function decimateMinMax(seg, valueOf, buckets) {
+  if (seg.length <= buckets * 2) return seg;
+  const out = [], per = seg.length / buckets;
+  for (let b = 0; b < buckets; b++) {
+    const start = Math.floor(b * per), end = Math.min(seg.length, Math.floor((b + 1) * per));
+    if (end <= start) continue;
+    let mn = seg[start], mx = seg[start];
+    for (let i = start + 1; i < end; i++) {
+      if (valueOf(seg[i]) < valueOf(mn)) mn = seg[i];
+      if (valueOf(seg[i]) > valueOf(mx)) mx = seg[i];
+    }
+    const a = mn.ts <= mx.ts ? mn : mx, z = mn.ts <= mx.ts ? mx : mn;
+    out.push(a); if (z !== a) out.push(z);
+  }
+  return out;
+}
+
+// Build an SVG path that BREAKS across real gaps and decimates dense segments.
+// Splits `drawn` (numeric, ts-sorted) into gap-free segments, decimates each to
+// its width share, and starts a new sub-path (M) per segment. Returns {d,hasGap}.
+function gapDecimatedPath(drawn, valueOf, x, y, plotWidth) {
+  if (!drawn.length) return { d: "", hasGap: false };
+  const thresh = chartGapThresh(drawn);
+  const segs = []; let seg = [], prev = null;
+  drawn.forEach((p) => {
+    if (prev !== null && (p.ts - prev) > thresh) { segs.push(seg); seg = []; }
+    seg.push(p); prev = p.ts;
+  });
+  if (seg.length) segs.push(seg);
+  const budgetTotal = Math.max(2, Math.floor(plotWidth));
+  let d = "";
+  segs.forEach((s) => {
+    const budget = Math.max(2, Math.round(budgetTotal * s.length / drawn.length));
+    const ps = decimateMinMax(s, valueOf, budget);
+    ps.forEach((p, i) => {
+      d += (d ? " " : "") + (i === 0 ? "M" : "L")
+        + x(p.ts).toFixed(1) + " " + y(valueOf(p)).toFixed(1);
+    });
+  });
+  return { d, hasGap: segs.length > 1 };
+}
+
+// Home-Assistant-style statistics rendering for a DENSE series: bucket the
+// points per-pixel and return a min–max envelope band (bandD) + a mean line
+// (meanD), gap-aware (a new sub-path per gap-free segment). For a sparse series
+// bandD is empty and meanD is just the raw line. This turns a 24h/2s "barcode"
+// into a readable trend with high/low context.
+function statsBandPaths(drawn, valueOf, x, y, plotWidth) {
+  if (!drawn.length) return { meanD: "", bandD: "", hasGap: false };
+  const thresh = chartGapThresh(drawn);
+  const segs = []; let seg = [], prev = null;
+  drawn.forEach((p) => {
+    if (prev !== null && (p.ts - prev) > thresh) { segs.push(seg); seg = []; }
+    seg.push(p); prev = p.ts;
+  });
+  if (seg.length) segs.push(seg);
+  const budgetTotal = Math.max(2, Math.floor(plotWidth));
+  const dense = drawn.length > budgetTotal * 3;   // ≥3 points/pixel → worth banding
+  let meanD = "", bandD = "";
+  segs.forEach((s) => {
+    const budget = Math.max(2, Math.round(budgetTotal * s.length / drawn.length));
+    if (dense && s.length > budget * 2) {
+      const buckets = [], per = s.length / budget;
+      for (let b = 0; b < budget; b++) {
+        const st = Math.floor(b * per), en = Math.min(s.length, Math.floor((b + 1) * per));
+        if (en <= st) continue;
+        let mn = Infinity, mx = -Infinity, sum = 0;
+        for (let i = st; i < en; i++) {
+          const v = valueOf(s[i]); if (v < mn) mn = v; if (v > mx) mx = v; sum += v;
+        }
+        buckets.push({ ts: s[Math.floor((st + en) / 2)].ts, min: mn, max: mx, mean: sum / (en - st) });
+      }
+      buckets.forEach((bk, i) => {
+        meanD += (meanD ? " " : "") + (i === 0 ? "M" : "L")
+          + x(bk.ts).toFixed(1) + " " + y(bk.mean).toFixed(1);
+      });
+      let top = "", bot = "";
+      buckets.forEach((bk, i) => {
+        top += (i === 0 ? "M" : "L") + x(bk.ts).toFixed(1) + " " + y(bk.max).toFixed(1) + " ";
+      });
+      for (let i = buckets.length - 1; i >= 0; i--) {
+        bot += "L" + x(buckets[i].ts).toFixed(1) + " " + y(buckets[i].min).toFixed(1) + " ";
+      }
+      if (buckets.length) bandD += top + bot + "Z ";
+    } else {
+      s.forEach((p, i) => {
+        meanD += (meanD ? " " : "") + (i === 0 ? "M" : "L")
+          + x(p.ts).toFixed(1) + " " + y(valueOf(p)).toFixed(1);
+      });
+    }
+  });
+  return { meanD, bandD: bandD.trim(), hasGap: segs.length > 1 };
+}
+
 // X-axis time ticks: count scales with width; times snap to round steps; the
 // date is shown for day+ steps and at local-midnight boundaries within a
 // sub-day window that crosses midnight. Appended to `svg`.
@@ -1701,7 +1830,14 @@ function drawChart(hostId, series, options) {
     const t = document.createElementNS(SVG_NS, "text");
     t.setAttribute("x", W / 2); t.setAttribute("y", H / 2);
     t.setAttribute("text-anchor", "middle"); t.setAttribute("class", "lbl");
-    t.textContent = "Not enough data yet"; svg.appendChild(t);
+    // Distinguish "this UPS never reports this metric" (a monitoring-only UPS
+    // with no frequency/output-voltage/temperature) from "still warming up", so
+    // a new user doesn't wait for data that will never come.
+    t.textContent = options.unavailable
+      ? (options.upsLabel || "This UPS") + " doesn't report "
+        + metricLabel(options.metric || "").toLowerCase()
+      : "Not enough data yet";
+    svg.appendChild(t);
     host.appendChild(svg);
     return;
   }
@@ -1800,25 +1936,21 @@ function drawChart(hostId, series, options) {
   // over data we don't have — and a rejected reading reads as a gap, not an
   // invented trend or a plunge to zero.
   const drawn = pts.filter((p) => typeof p.value === "number" && !isNaN(p.value));
-  let gapThresh = Infinity;
-  if (drawn.length > 2) {
-    const gaps = [];
-    for (let i = 1; i < drawn.length; i++) gaps.push(drawn[i].ts - drawn[i - 1].ts);
-    gaps.sort((a, b) => a - b);
-    const med = gaps[Math.floor(gaps.length / 2)] || 0;
-    if (med > 0) gapThresh = med * 2.5;
+  // Dense series → HA-style min–max band + mean line; sparse → plain line.
+  const stats = statsBandPaths(drawn, (p) => p.value, x, y, W - pad - 5);
+  const d = stats.meanD, hasGap = stats.hasGap;
+  if (stats.bandD) {
+    const band = document.createElementNS(SVG_NS, "path");
+    band.setAttribute("d", stats.bandD); band.setAttribute("class", "plot-band");
+    svg.appendChild(band);
   }
-  let d = "", prevTs = null, hasGap = false;
-  drawn.forEach((p) => {
-    const move = prevTs === null || (p.ts - prevTs) > gapThresh;
-    if (move && prevTs !== null) hasGap = true;
-    d += (d ? " " : "") + (move ? "M" : "L") + x(p.ts).toFixed(1) + " " + y(p.value).toFixed(1);
-    prevTs = p.ts;
-  });
   // Subtle gradient area fill under the line (single-series charts without a
   // threshold band) — skipped when the path has gaps, since a single closed fill
   // would span the missing region.
-  if (!wantBand && d && !hasGap) {
+  // Area fill only when the domain baseline is zero — a fill rising from a
+  // non-zero minimum (voltage 207, a zoomed 98% charge) implies quantity-from-
+  // zero that isn't there. Zero-based metrics keep the fill. (data-viz #11)
+  if (!wantBand && d && !hasGap && !stats.bandD && min <= 0.001) {
     const gid = hostId + "-areagrad";
     const defs = document.createElementNS(SVG_NS, "defs");
     const grad = document.createElementNS(SVG_NS, "linearGradient");
@@ -2072,12 +2204,22 @@ function makeChart(opts) {
     const u = lastUpsRows.find((r) => r.name === upsName());
     return (u && (u.label || u.name)) || "";
   }
+  // True when the selected UPS never reports this metric (its live value is
+  // empty) — so the empty chart can say "not reported" vs "warming up".
+  function metricUnavailable() {
+    const field = { voltage: "inputVoltage", output_voltage: "outputVoltage",
+      frequency: "inputFrequency", temperature: "temperature" }[metric()];
+    if (!field) return false;
+    const u = lastUpsRows.find((r) => r.name === upsName());
+    return numOrNull(((u && u.powerQuality) || {})[field]) == null;
+  }
   function draw() {
     drawChart(opts.hostId, state.series, {
       metric: metric(),
       // Only label the UPS in a fleet; a lone UPS needs no disambiguation.
       upsLabel: lastUpsRows.length > 1 ? upsLabel() : "",
       scopeAll: typeof scopeIsAll === "function" && scopeIsAll(),
+      unavailable: metricUnavailable(),
       from: state.from, to: state.to,
       bands: opts.bands ? state.thresholds : null,
       events: opts.events ? state.events : null,
@@ -2202,13 +2344,7 @@ function drawEnergyChart(hostId, rows, options) {
   function plot(key, sc, cls) {
     if (!sc) return;
     const drawn = pts.filter((p) => typeof p[key] === "number" && !isNaN(p[key]));
-    const thresh = chartGapThresh(drawn);   // break the line across real gaps
-    let d = "", prev = null;
-    drawn.forEach((p) => {
-      const move = prev === null || (p.ts - prev) > thresh;
-      d += (d ? " " : "") + (move ? "M" : "L") + x(p.ts).toFixed(1) + " " + sc.y(p[key]).toFixed(1);
-      prev = p.ts;
-    });
+    const { d } = gapDecimatedPath(drawn, (p) => p[key], x, sc.y, W - pad - 5);
     if (!d) return;
     const path = document.createElementNS(SVG_NS, "path");
     path.setAttribute("d", d); path.setAttribute("class", cls);
@@ -2229,12 +2365,12 @@ function drawEnergyChart(hostId, rows, options) {
     const t = document.createElementNS(SVG_NS, "text");
     t.setAttribute("x", lx + 14); t.setAttribute("y", 11);
     t.setAttribute("class", "lbl");
-    t.textContent = label + (max != null ? (" (max " + max.toFixed(0) + unit + ")") : "");
+    t.textContent = label;   // the max is on the y-axis; no need to repeat it here
     svg.appendChild(t);
-    lx += 150;
+    lx += 70;
   };
-  if (wattS) legend("Power", "plot-watts", wattS.mx, "W");
-  if (showLoad && loadS) legend("Load", "plot-load", loadS.mx, "%");
+  if (wattS) legend("Power", "plot-watts");
+  if (showLoad && loadS) legend("Load", "plot-load");
   // Min/max axis numbers for the primary series (watts if present, else load).
   const prim = wattS || loadS;
   if (prim) {
@@ -3201,7 +3337,9 @@ async function renderShutdownPlan() {
 }
 
 function onTabActivated(name) {
-  if (name === "overview") renderOverviewSummary(lastUpsRows);
+  if (name === "overview") {
+    renderOverviewSummary(lastUpsRows); renderRedundancy(); renderRemoteHealth();
+  }
   else if (name === "power") { renderLineQuality(); if (charts.power) charts.power.load(); }
   else if (name === "battery") { renderBatteryHealthTab(); if (charts.battery) charts.battery.load(); }
   else if (name === "energy") { renderEnergyTab(); if (charts.energy) charts.energy.load(); }

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -102,6 +102,7 @@ const ICONS = {
   gauge:   "M4.5 16.5a8 8 0 1 1 15 0 M12 13l3-3",
   check:   "M5 12.5 9.5 17 19 7",
   alert:   "M12 4 21 19H3z M12 10v4 M12 16.6v.4",
+  info:    "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18 M12 11v5 M12 7.6v.4",
   close:   "M6 6l12 12 M18 6 6 18",
   power:   "M12 3v9 M7.8 6.4a7 7 0 1 0 8.4 0",
   vm:      "M3 5h18v11H3z M8 20h8 M11 16v4",
@@ -371,7 +372,7 @@ function seedEventSourceFromScope() {
 
 // SVG battery ring gauge: a track circle + a value arc (dasharray), centered
 // label. Colored by status class. The signature visual of the Overview.
-function batteryRing(pct, statusCls) {
+function batteryRing(pct, statusCls, caption) {
   const R = 52, C = 2 * Math.PI * R;
   const p = Math.max(0, Math.min(100, isNaN(pct) ? 0 : pct));
   const svg = document.createElementNS(SVG_NS, "svg");
@@ -396,7 +397,9 @@ function batteryRing(pct, statusCls) {
     t.textContent = s; svg.appendChild(t);
   };
   txt("ring-big", 60, isNaN(pct) ? "—" : Math.round(p) + "%");
-  txt("ring-cap", 78, p >= 95 ? "CHARGED" : p >= 20 ? "ON LINE" : "LOW");
+  // Caption is a CHARGE band, not a power word ("ON LINE" read as a power state
+  // even mid-outage). heroCard overrides it to "ON BATTERY" during an outage.
+  txt("ring-cap", 78, caption || (p >= 95 ? "CHARGED" : p >= 20 ? "READY" : "LOW"));
   return svg;
 }
 
@@ -404,24 +407,45 @@ function heroCard(u) {
   const charge = parseFloat(u.batteryCharge);
   const sCls = statusClass(u.status);
   const pq = u.powerQuality || {};
-  const wrap = el("div", { class: "hero card-click s-" + sCls, tabindex: "0",
+  const st = (u.status || "").toUpperCase();
+  const onBattery = st.includes("OB");
+  const low = st.includes("LB") || st.includes("FSD");
+  // Ring turns amber the moment we're on battery (red once low/FSD), and the
+  // caption says ON BATTERY — so an outage doesn't read as a calm green ring.
+  const ringCls = low ? "crit" : (onBattery ? "warn" : (batteryClass(charge) || sCls));
+  const wrap = el("div", { class: "hero card-click s-" + sCls
+    + (onBattery ? " hero-alarm" : ""), tabindex: "0",
     role: "button", title: "View details" });
-  wrap.appendChild(batteryRing(charge, batteryClass(charge) || sCls));
-  const vital = (label, value) => el("div", null, [
+  wrap.appendChild(batteryRing(charge, ringCls, onBattery ? "ON BATTERY" : null));
+  const vital = (label, value, cls) => el("div", null, [
     el("div", { class: "v-label", text: label }),
-    el("div", { class: "v-value", text: value }),
+    el("div", { class: "v-value" + (cls ? " " + cls : ""), text: value }),
   ]);
+  const title = el("div", { class: "hero-title" }, [
+    icon("battery"), el("h3", { text: u.label || u.name }),
+    el("span", { class: "badge " + sCls, text: u.status || "—" }),
+  ]);
+  // Promote time-on-battery to a prominent alarm chip during an outage — it's
+  // the number the operator needs first, and it was the last, easily-missed vital.
+  if (onBattery) {
+    title.appendChild(el("span", { class: "badge " + (low ? "crit" : "warn") + " hero-ob",
+      text: "ON BATTERY · " + (u.timeOnBattery != null ? u.timeOnBattery + "s" : "—") }));
+  }
+  const vitals = [
+    vital("Runtime", formatRuntimeSeconds(u.runtime)),
+    vital("Load", u.load != null ? u.load + "%" : "—"),
+    vital("Input", pq.inputVoltage != null ? pq.inputVoltage + " V" : "—"),
+    vital("On battery", u.timeOnBattery != null ? u.timeOnBattery + "s" : "—",
+      onBattery ? (low ? "crit" : "warn") : null),
+  ];
+  // Surface line quality on the Overview only when it's NOT good — otherwise it's
+  // buried on the Power tab where the operator rarely looks. (operator #14)
+  const lq = lineQuality(pq);
+  if (lq.cls === "warn" || lq.cls === "crit") {
+    vitals.push(vital("Line quality", lq.label, lq.cls));
+  }
   wrap.appendChild(el("div", { class: "hero-main" }, [
-    el("div", { class: "hero-title" }, [
-      icon("battery"), el("h3", { text: u.label || u.name }),
-      el("span", { class: "badge " + sCls, text: u.status || "—" }),
-    ]),
-    el("div", { class: "hero-vitals" }, [
-      vital("Runtime", formatRuntimeSeconds(u.runtime)),
-      vital("Load", u.load != null ? u.load + "%" : "—"),
-      vital("Input", pq.inputVoltage != null ? pq.inputVoltage + " V" : "—"),
-      vital("On battery", u.timeOnBattery != null ? u.timeOnBattery + "s" : "—"),
-    ]),
+    title, el("div", { class: "hero-vitals" }, vitals),
   ]));
   const open = () => openDetail(u.name);
   wrap.addEventListener("click", open);
@@ -482,7 +506,8 @@ function renderOverviewSummary(rows) {
       value: Math.round(bh.score), unit: "/100",
       cap: (multi ? named(worst) + " · " : "")
         + (bh.confidence != null ? "confidence " + Math.round(bh.confidence * 100) + "%" : ""),
-      valueStatus: scoreClass(bh.score), tab: "battery" }));
+      valueStatus: (bh.confidence != null && bh.confidence < 0.75)
+        ? "muted" : scoreClass(bh.score), tab: "battery" }));
   } else {
     summary.appendChild(kpiCard({ iconName: "shield", label: "Battery health",
       value: "—", unit: "", cap: "no data yet", tab: "battery" }));
@@ -606,7 +631,16 @@ function renderUps(payload) {
   const gsec = document.getElementById("groups-section");
   const gwrap = document.getElementById("group-cards");
   gwrap.replaceChildren();
-  gsec.hidden = groups.length === 0;
+  // In a fleet with no redundancy groups configured, show a discoverable hint
+  // rather than hiding the section entirely — otherwise the feature is invisible.
+  // Single-UPS deployments (where groups make no sense) still hide it. (operator #15)
+  gsec.hidden = groups.length === 0 && rows.length <= 1;
+  if (groups.length === 0 && rows.length > 1) {
+    gwrap.appendChild(el("div", { class: "card" }, [
+      el("p", { class: "chart-note", text: "No redundancy groups configured. "
+        + "Group UPSes so a shutdown only triggers when quorum is lost — see the "
+        + "redundancy-groups docs." })]));
+  }
   groups.forEach((g) => {
     const sources = g.upsSources || [];
     const healthy = groupHealthyCount(g, rows);
@@ -692,7 +726,7 @@ function renderRemoteHealth() {
     if (r.latency_ms != null && reachable) {
       rows.push(configKv("Latency", Math.round(r.latency_ms) + " ms"));
     }
-    rows.push(configKv("Checked", relTime(r.last_checked_at)));
+    rows.push(configKv("Last checked", relTime(r.last_checked_at)));
     if (r.consecutive_failures) {
       rows.push(el("div", { class: "row" }, [el("span", { text: "Failures" }),
         el("b", { class: "crit", text: String(r.consecutive_failures) })]));
@@ -914,7 +948,7 @@ function renderDetail(name) {
   const cfgUps = ((cfgSnapshot && cfgSnapshot.ups) || []).find((c) => c.name === name);
   if (cfgUps) {
     const rows = [
-      detailRow("Local host", cfgUps.isLocal ? "yes" : "no"),
+      detailRow("Triggers local shutdown", cfgUps.isLocal ? "yes" : "no — monitoring only"),
       detailRow("Remote servers", (cfgUps.remoteServers || []).length),
     ];
     (cfgUps.remoteServers || []).forEach((s, i) =>
@@ -2274,7 +2308,13 @@ function renderBatteryHealthTab() {
     const bh = u.batteryHealth;
     const st = u.selfTest;
     if (bh) {
-      const scoreTxt = bh.score != null ? Math.round(bh.score) + "/100" : "unknown";
+      // Temper the badge on confidence: a 100/100 built on 2 default terms at
+      // 60% confidence shouldn't shout green like a fully-measured 100. Below
+      // ~0.75 confidence the badge goes neutral and shows the % inline. (heuristic H1)
+      const lowConf = bh.confidence != null && bh.confidence < 0.75;
+      const scoreTxt = (bh.score != null ? Math.round(bh.score) + "/100" : "unknown")
+        + (lowConf ? " · " + Math.round(bh.confidence * 100) + "%" : "");
+      const badgeCls = lowConf ? "muted" : scoreClass(bh.score);
       // Header badge carries the score, so the rows omit it (no duplicate).
       const cardRows = batteryHealthRows(bh, { includeScore: false });
       // Only show a self-test row once a test has actually run.
@@ -2286,8 +2326,8 @@ function renderBatteryHealthTab() {
         ]));
       }
       wrap.appendChild(widgetCard(u.label || u.name, cardRows,
-        { badge: scoreTxt, badgeClass: scoreClass(bh.score),
-          icon: "shield", iconClass: scoreClass(bh.score) }));
+        { badge: scoreTxt, badgeClass: badgeCls,
+          icon: "shield", iconClass: badgeCls }));
     } else {
       wrap.appendChild(widgetCard(u.label || u.name,
         [el("p", { class: "chart-note", text: "Battery health not available." })],
@@ -2438,7 +2478,10 @@ function lineQuality(pq) {
 // amber when Active.
 function stateRow(label, value) {
   const v = String(value || "").toUpperCase();
-  const cls = v === "ACTIVE" ? "warn" : (v === "NORMAL" || v === "INACTIVE" ? "ok" : "");
+  // Idle/quiet states (Normal / Inactive) read NEUTRAL, not green — green means
+  // "active & good", and a wall of green for features that are simply OFF flattens
+  // the hierarchy so a real ACTIVE (amber) doesn't stand out. (heuristic M2/M5)
+  const cls = v === "ACTIVE" ? "warn" : (v === "NORMAL" || v === "INACTIVE" ? "muted" : "");
   return el("div", { class: "row" }, [el("span", { text: label }),
     el("span", { class: "badge " + cls, text: titleCase(value) })]);
 }
@@ -2567,7 +2610,7 @@ function renderConfigTab() {
   (cfg.ups || []).forEach((c) => {
     cards.push(widgetCard(c.label || c.name, [
       configKv("Name", c.name),
-      configKv("Local host", c.isLocal ? "yes" : "no"),
+      configKv("Triggers local shutdown", c.isLocal ? "yes" : "no — monitoring only"),
       configKv("Remote servers", (c.remoteServers || []).length),
     ], { icon: "battery" }));
   });
@@ -2893,12 +2936,12 @@ function shutdownTriggerNodes(name, plan) {
   const coord = plan && plan.coordinatorMode ? " — coordinator-run" : "";
   if (groups.length) {
     return groups.map((g) => el("div", { class: "sd-trigger" }, [
-      icon("alert"),
+      icon("info"),
       el("span", { text: "Triggers when group “" + g.name + "” drops below "
         + g.minHealthy + " of " + (g.upsSources || []).length + " healthy" + coord }),
     ]));
   }
-  return [el("div", { class: "sd-trigger" }, [icon("alert"),
+  return [el("div", { class: "sd-trigger" }, [icon("info"),
     el("span", { text: "Triggers when this UPS reaches low battery or a forced "
       + "shutdown (FSD)" + coord })])];
 }

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -352,23 +352,25 @@ function applyScopeChrome() {
     const inert = activeTab === "config";
     wrap.classList.toggle("inactive", inert);
     const msg = inert ? "Config is fleet-wide; the UPS selector doesn't apply here"
-      : (activeTab === "events" ? "Also seeds the Events source filter" : "");
+      : (activeTab === "events" ? "Filters the events by UPS" : "");
     wrap.title = msg;
     if (msg) wrap.setAttribute("aria-label", "UPS to show — " + msg);
     else wrap.removeAttribute("aria-label");
   }
-  if (activeTab === "events" && !scopeIsAll()) seedEventSourceFromScope();
+  if (activeTab === "events") seedEventSourceFromScope();
 }
 
-// Seed the Events Source filter from the global scope, but NEVER override a
-// manual pick — only seed when the filter is still on "All sources". (review)
+// The header UPS selector is the Events source control now (the separate Source
+// dropdown is retired), so mirror the scope into the events source filter —
+// "All UPS" → all sources, a pick → that UPS.
 function seedEventSourceFromScope() {
   const src = document.getElementById("event-source-filter");
   if (!src) return;
   const scope = currentScope();
-  if (scope === SCOPE_ALL || src.value !== "") return;
-  if ([...src.options].some((o) => o.value === scope)) {
-    src.value = scope;
+  const target = scope === SCOPE_ALL ? "" : scope;
+  if (src.value === target) return;
+  if (target === "" || [...src.options].some((o) => o.value === target)) {
+    src.value = target;
     if (typeof applyEventFilters === "function") applyEventFilters();
   }
 }
@@ -2282,6 +2284,17 @@ function drawEnergyChart(hostId, rows, options) {
   mkline(pad, H - pad, W - 5, H - pad, "axis");
   mkline(pad, 5, pad, H - pad, "axis");
 
+  // Title names the UPS the (single-series) chart shows — "· Lab (primary)"
+  // under "All UPS" — so it's clear which UPS, like the metric charts.
+  if (options.upsLabel) {
+    const tt = document.createElementNS(SVG_NS, "text");
+    tt.setAttribute("x", (W / 2).toFixed(0)); tt.setAttribute("y", "12");
+    tt.setAttribute("text-anchor", "middle"); tt.setAttribute("class", "chart-title");
+    tt.textContent = "Load & power · " + options.upsLabel
+      + (options.scopeAll ? " (primary)" : "");
+    svg.appendChild(tt);
+  }
+
   const pts = rows || [];
   const loads = pts.map((p) => p.loadPct).filter((v) => typeof v === "number" && !isNaN(v));
   const watts = pts.map((p) => p.watts).filter((v) => typeof v === "number" && !isNaN(v));
@@ -2293,7 +2306,9 @@ function drawEnergyChart(hostId, rows, options) {
     host.appendChild(svg);
     return;
   }
-  const t0 = pts[0].ts, t1 = pts[pts.length - 1].ts, tspan = (t1 - t0) || 1;
+  const t0 = (options.from != null) ? options.from : pts[0].ts;
+  const t1 = (options.to != null) ? options.to : pts[pts.length - 1].ts;
+  const tspan = (t1 - t0) || 1;
   const x = (t) => pad + ((t - t0) / tspan) * (W - pad - 5);
 
   function scale(vals, floorZero) {
@@ -2341,19 +2356,26 @@ function drawEnergyChart(hostId, rows, options) {
       appendEventMarker(svg, e, x(e.ts).toFixed(1), 5, (H - pad).toFixed(1));
     });
 
-  function plot(key, sc, cls) {
+  function plot(key, sc, cls, bandCls) {
     if (!sc) return;
     const drawn = pts.filter((p) => typeof p[key] === "number" && !isNaN(p[key]));
-    const { d } = gapDecimatedPath(drawn, (p) => p[key], x, sc.y, W - pad - 5);
-    if (!d) return;
+    // Same HA-style stats rendering as the metric charts: a dense series draws a
+    // min–max band + mean line (was an unreadable dense spike mass); sparse → line.
+    const stats = statsBandPaths(drawn, (p) => p[key], x, sc.y, W - pad - 5);
+    if (stats.bandD) {
+      const band = document.createElementNS(SVG_NS, "path");
+      band.setAttribute("d", stats.bandD); band.setAttribute("class", bandCls);
+      svg.appendChild(band);
+    }
+    if (!stats.meanD) return;
     const path = document.createElementNS(SVG_NS, "path");
-    path.setAttribute("d", d); path.setAttribute("class", cls);
+    path.setAttribute("d", stats.meanD); path.setAttribute("class", cls);
     path.setAttribute("vector-effect", "non-scaling-stroke");
     svg.appendChild(path);
   }
   drawTimeTicks(svg, t0, t1, x, W, H, pad, pad);   // anchor the window in time
-  if (wattS) plot("watts", wattS, "plot plot-watts");
-  if (showLoad) plot("loadPct", loadS, "plot plot-load");
+  if (wattS) plot("watts", wattS, "plot plot-watts", "plot-band-watts");
+  if (showLoad) plot("loadPct", loadS, "plot plot-load", "plot-band-load");
 
   // Legend + per-line max labels (each line has its own unit/scale).
   let lx = pad + 4;
@@ -2521,10 +2543,20 @@ function makeEnergyChart(opts) {
     state.rows = rows;
     state.events = r.events;
     state.hiddenEvents = r.hidden;
+    state.from = from; state.to = to;
     draw();
   }
+  function upsLabel() {
+    const u = lastUpsRows.find((r) => r.name === upsName());
+    return (u && (u.label || u.name)) || "";
+  }
   function draw() {
-    drawEnergyChart(opts.hostId, state.rows, { events: state.events });
+    drawEnergyChart(opts.hostId, state.rows, {
+      events: state.events,
+      upsLabel: lastUpsRows.length > 1 ? upsLabel() : "",
+      scopeAll: typeof scopeIsAll === "function" && scopeIsAll(),
+      from: state.from, to: state.to,
+    });
     setEventsHint(opts.eventsNoteId, state.hiddenEvents);
   }
   function observe() {

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -208,6 +208,15 @@ function numOrNull(v) {
   return Number.isFinite(n) ? n : null;
 }
 
+// Format a numeric telemetry value with its unit, or null when it's
+// missing/empty. An empty string ("") from a monitoring-only UPS passes a bare
+// `!= null` check, so callers that concatenated a unit first rendered a stray
+// " V"/" Hz"/" °C" with no number. Routing unit'd fields through here makes a
+// blank read as "—" (null → detailRow/configKv/hintedRow render the dash).
+function fmtUnit(v, unit) {
+  return numOrNull(v) != null ? v + " " + unit : null;
+}
+
 function statusClass(status) {
   const s = (status || "").toUpperCase();
   if (s.includes("OB") || s.includes("LB") || s.includes("FSD")) return "crit";
@@ -718,24 +727,24 @@ function renderDetail(name) {
   ]));
 
   sections.push(detailSection("Power quality", [
-    hintedRow("Input voltage", pq.inputVoltage != null ? pq.inputVoltage + " V" : null,
+    hintedRow("Input voltage", fmtUnit(pq.inputVoltage, "V"),
       "Mains voltage entering the UPS. Eneru classifies brownout (sag) and surge "
       + "against the configured warning band — the shaded thresholds on the Power "
       + "tab — not arbitrary cutoffs."),
-    hintedRow("Output voltage", pq.outputVoltage != null ? pq.outputVoltage + " V" : null,
+    hintedRow("Output voltage", fmtUnit(pq.outputVoltage, "V"),
       "Voltage delivered to the load. On line power the UPS regulates / AVR-"
       + "corrects it toward nominal; during an outage it's inverter output from "
       + "the battery."),
-    hintedRow("Battery voltage", pq.batteryVoltage != null ? pq.batteryVoltage + " V" : null,
+    hintedRow("Battery voltage", fmtUnit(pq.batteryVoltage, "V"),
       "Terminal voltage of the battery string. It sags under load and as charge "
       + "depletes; on line power it floats near the charger's nominal."),
-    hintedRow("Input frequency", pq.inputFrequency != null ? pq.inputFrequency + " Hz" : null,
+    hintedRow("Input frequency", fmtUnit(pq.inputFrequency, "Hz"),
       "Mains frequency. Nominal is 50 Hz (EU) or 60 Hz (US); sustained excursions "
       + "point to unstable mains or generator power."),
-    hintedRow("Output frequency", pq.outputFrequency != null ? pq.outputFrequency + " Hz" : null,
+    hintedRow("Output frequency", fmtUnit(pq.outputFrequency, "Hz"),
       "Frequency the UPS delivers. Line-interactive units track the mains on line "
       + "power and synthesize nominal on battery."),
-    hintedRow("Temperature", pq.temperature != null ? pq.temperature + " °C" : null,
+    hintedRow("Temperature", fmtUnit(pq.temperature, "°C"),
       "As reported by the UPS. Many models (including some UniFi UPS firmware) "
       + "report a fixed placeholder such as a constant 25 °C rather than a live "
       + "sensor reading."),
@@ -747,13 +756,15 @@ function renderDetail(name) {
   }
   // v6.1 Energy (today/month kWh + optional cost; cost hidden when disabled).
   if (u.energy) {
-    sections.push(detailSection("Energy", energyRows(u.energy)));
+    sections.push(detailSection(
+      u.energy.estimated ? "Energy (estimated)" : "Energy",
+      energyRows(u.energy)));
   }
   // v6.1 Self-test (latest normalized result).
   const st = u.selfTest;
   if (st) {
     sections.push(detailSection("Self-test", [
-      detailRow("Result", st.result || "unknown"),
+      detailRow("Result", st.result ? titleCase(st.result) : "unknown"),
       detailRow("When", st.date || null),
     ]));
   }
@@ -2209,7 +2220,10 @@ function renderEnergyTab() {
     const en = u.energy;
     if (en) {
       if (energyCostConfigured(en)) costConfigured = true;
-      wrap.appendChild(widgetCard(u.label || u.name, energyRows(en), { icon: "chart" }));
+      wrap.appendChild(widgetCard(u.label || u.name, energyRows(en),
+        en.estimated
+          ? { icon: "chart", badge: "estimated", badgeClass: "muted" }
+          : { icon: "chart" }));
     } else {
       wrap.appendChild(widgetCard(u.label || u.name,
         [el("p", { class: "chart-note",
@@ -2242,12 +2256,22 @@ function lineQuality(pq) {
   const banded = inV != null && lo != null && hi != null;
   const active = (v) => String(v || "").toUpperCase() === "ACTIVE";
   const vState = String(pq.voltageState || "").toUpperCase();
+  // A real fault wins regardless of how sparse the rest of the telemetry is.
   if ((banded && (inV < lo || inV > hi)) || active(pq.overloadState)
       || active(pq.bypassState) || (vState && vState !== "NORMAL")) {
     return { cls: "crit", label: "Poor" };
   }
+  // A monitoring-only UPS may report almost no AC telemetry (empty frequency /
+  // output voltage). Without a usable input voltage and at least one of
+  // frequency / output voltage there isn't enough to assert "Good" — say so
+  // rather than paint a confident green verdict over blank rows.
+  const freq = numOrNull(pq.inputFrequency);
+  const outV = numOrNull(pq.outputVoltage);
+  if (inV == null || (freq == null && outV == null)) {
+    return { cls: "muted", label: "Unknown" };
+  }
   const nearEdge = banded && (inV < lo + (hi - lo) * 0.1 || inV > hi - (hi - lo) * 0.1);
-  if (active(pq.avrState) || nearEdge || !nearNominalFreq(numOrNull(pq.inputFrequency))) {
+  if (active(pq.avrState) || nearEdge || !nearNominalFreq(freq)) {
     return { cls: "warn", label: "Fair" };
   }
   return { cls: "ok", label: "Good" };
@@ -2288,17 +2312,20 @@ function renderLineQuality() {
     el("b", { class: banded && (inV < lo || inV > hi) ? "crit" : "ok",
       text: inV != null ? inV + " V" : "—" }),
   ]));
-  if (pq.outputVoltage != null) rows.push(configKv("Output", pq.outputVoltage + " V"));
-  if (pq.inputFrequency != null) {
+  const outV = fmtUnit(pq.outputVoltage, "V");
+  if (outV) rows.push(configKv("Output", outV));
+  const freqN = numOrNull(pq.inputFrequency);
+  if (freqN != null) {
     rows.push(el("div", { class: "row" }, [el("span", { text: "Frequency" }),
-      el("b", { class: nearNominalFreq(numOrNull(pq.inputFrequency)) ? "ok" : "warn",
+      el("b", { class: nearNominalFreq(freqN) ? "ok" : "warn",
         text: pq.inputFrequency + " Hz" })]));
   }
   [["Voltage", pq.voltageState], ["AVR", pq.avrState], ["Bypass", pq.bypassState],
    ["Overload", pq.overloadState]].forEach(([lab, val]) => {
     if (val != null && val !== "") rows.push(stateRow(lab, val));
   });
-  if (pq.temperature != null) rows.push(configKv("Temperature", pq.temperature + " °C"));
+  const temp = fmtUnit(pq.temperature, "°C");
+  if (temp) rows.push(configKv("Temperature", temp));
   wrap.appendChild(el("div", { class: "card s-" + q.cls }, rows));
 }
 

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -1650,6 +1650,28 @@ function drawChart(hostId, series, options) {
     line(pad, gy, W - 5, gy, "grid");
   }
 
+  // X-axis time ticks — a time series with no time reference is unreadable
+  // (outage bands + event markers otherwise float in an unanchored window).
+  const spanDays = tspan / 86400;
+  const fmtTick = (ts) => {
+    const dt = new Date(ts * 1000);
+    return spanDays <= 2
+      ? dt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+      : dt.toLocaleDateString([], { month: "short", day: "numeric" });
+  };
+  const N_TICKS = 4;
+  for (let i = 0; i <= N_TICKS; i++) {
+    const tts = t0 + (tspan * i) / N_TICKS;
+    const tx = x(tts);
+    const tk = document.createElementNS(SVG_NS, "text");
+    tk.setAttribute("x", tx.toFixed(1));
+    tk.setAttribute("y", (H - pad + 15).toFixed(1));
+    tk.setAttribute("text-anchor", i === 0 ? "start" : i === N_TICKS ? "end" : "middle");
+    tk.setAttribute("class", "lbl xtick");
+    tk.textContent = fmtTick(tts);
+    svg.appendChild(tk);
+  }
+
   // Voltage threshold band: a faint zone bounded by dashed edge lines (reads as
   // thresholds, not a slab of page-tint), plus the nominal center line.
   if (wantBand && bands.low != null && bands.high != null) {
@@ -1700,15 +1722,30 @@ function drawChart(hostId, series, options) {
     }
   }
 
-  // The data line.
-  let d = "";
-  pts.forEach((p) => {
-    if (typeof p.value !== "number" || isNaN(p.value)) return;
-    d += (d ? " L" : "M") + x(p.ts).toFixed(1) + " " + y(p.value).toFixed(1);
+  // The data line. Break the path across gaps (a run of missing samples longer
+  // than ~2.5x the typical spacing) so we don't draw a confident straight line
+  // over data we don't have — and a rejected reading reads as a gap, not an
+  // invented trend or a plunge to zero.
+  const drawn = pts.filter((p) => typeof p.value === "number" && !isNaN(p.value));
+  let gapThresh = Infinity;
+  if (drawn.length > 2) {
+    const gaps = [];
+    for (let i = 1; i < drawn.length; i++) gaps.push(drawn[i].ts - drawn[i - 1].ts);
+    gaps.sort((a, b) => a - b);
+    const med = gaps[Math.floor(gaps.length / 2)] || 0;
+    if (med > 0) gapThresh = med * 2.5;
+  }
+  let d = "", prevTs = null, hasGap = false;
+  drawn.forEach((p) => {
+    const move = prevTs === null || (p.ts - prevTs) > gapThresh;
+    if (move && prevTs !== null) hasGap = true;
+    d += (d ? " " : "") + (move ? "M" : "L") + x(p.ts).toFixed(1) + " " + y(p.value).toFixed(1);
+    prevTs = p.ts;
   });
   // Subtle gradient area fill under the line (single-series charts without a
-  // threshold band) — premium depth, not a flat slab.
-  if (!wantBand && d) {
+  // threshold band) — skipped when the path has gaps, since a single closed fill
+  // would span the missing region.
+  if (!wantBand && d && !hasGap) {
     const gid = hostId + "-areagrad";
     const defs = document.createElementNS(SVG_NS, "defs");
     const grad = document.createElementNS(SVG_NS, "linearGradient");
@@ -1722,7 +1759,7 @@ function drawChart(hostId, series, options) {
     });
     defs.appendChild(grad); svg.appendChild(defs);
     const area = document.createElementNS(SVG_NS, "path");
-    const xL = x(pts[pts.length - 1].ts).toFixed(1), xF = x(pts[0].ts).toFixed(1);
+    const xL = x(drawn[drawn.length - 1].ts).toFixed(1), xF = x(drawn[0].ts).toFixed(1);
     area.setAttribute("d", `${d} L${xL} ${(H - pad).toFixed(1)} L${xF} ${(H - pad).toFixed(1)} Z`);
     area.setAttribute("class", "area"); area.setAttribute("fill", `url(#${gid})`);
     svg.appendChild(area);

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -1642,7 +1642,13 @@ function drawChart(hostId, series, options) {
     const t = document.createElementNS(SVG_NS, "text");
     t.setAttribute("x", (W / 2).toFixed(0)); t.setAttribute("y", "12");
     t.setAttribute("text-anchor", "middle"); t.setAttribute("class", "chart-title");
-    t.textContent = metricLabel(options.metric);
+    // Name the UPS the (single-series) chart is showing, so "All UPS" makes clear
+    // it's the primary — the per-UPS comparison lives in the cards above.
+    let title = metricLabel(options.metric);
+    if (options.upsLabel) {
+      title += " · " + options.upsLabel + (options.scopeAll ? " (primary)" : "");
+    }
+    t.textContent = title;
     svg.appendChild(t);
   }
 
@@ -2034,9 +2040,16 @@ function makeChart(opts) {
     draw();
   }
 
+  function upsLabel() {
+    const u = lastUpsRows.find((r) => r.name === upsName());
+    return (u && (u.label || u.name)) || "";
+  }
   function draw() {
     drawChart(opts.hostId, state.series, {
       metric: metric(),
+      // Only label the UPS in a fleet; a lone UPS needs no disambiguation.
+      upsLabel: lastUpsRows.length > 1 ? upsLabel() : "",
+      scopeAll: typeof scopeIsAll === "function" && scopeIsAll(),
       bands: opts.bands ? state.thresholds : null,
       events: opts.events ? state.events : null,
     });
@@ -2547,13 +2560,14 @@ function lineQuality(pq) {
       || active(pq.bypassState) || (vState && vState !== "NORMAL")) {
     return { cls: "crit", label: "Poor" };
   }
-  // A monitoring-only UPS may report almost no AC telemetry (empty frequency /
-  // output voltage). Without a usable input voltage and at least one of
-  // frequency / output voltage there isn't enough to assert "Good" — say so
-  // rather than paint a confident green verdict over blank rows.
+  // Only "Unknown" when there's truly nothing to judge — no input voltage AND no
+  // regulation state. A monitoring-only UPS that reports in-band input voltage
+  // and normal regulation states is legitimately "Good", even without frequency
+  // / output-voltage telemetry (those rows just don't render). (v6.1.4 review)
   const freq = numOrNull(pq.inputFrequency);
-  const outV = numOrNull(pq.outputVoltage);
-  if (inV == null || (freq == null && outV == null)) {
+  const anyState = [pq.voltageState, pq.avrState, pq.bypassState, pq.overloadState]
+    .some((s) => s != null && s !== "");
+  if (inV == null && !anyState) {
     return { cls: "muted", label: "Unknown" };
   }
   const nearEdge = banded && (inV < lo + (hi - lo) * 0.1 || inV > hi - (hi - lo) * 0.1);

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -271,18 +271,53 @@ function formatRuntimeSeconds(value) {
 }
 
 const CHART_UPS_SELECTS = ["power-ups", "battery-ups", "energy-ups"];
+const SCOPE_ALL = "__all__";
 
-// Populate every per-chart UPS <select> with the current UPS list, keeping the
-// selection SHARED across the Power/Battery/Energy tabs (like the Range control)
-// so switching tabs doesn't snap back to a different UPS.
+// The global UPS scope (header selector). "" / missing → All UPS.
+function currentScope() {
+  const s = document.getElementById("global-ups");
+  return (s && s.value) || SCOPE_ALL;
+}
+function scopeIsAll() { return currentScope() === SCOPE_ALL; }
+
+// Concrete UPS name for single-series views (charts): the scoped UPS, or the
+// primary (first) UPS when scope is "All".
+function scopedName() {
+  const scope = currentScope();
+  if (scope !== SCOPE_ALL && lastUpsRows.some((u) => u.name === scope)) return scope;
+  return lastUpsRows.length ? lastUpsRows[0].name : "";
+}
+
+// UPS rows honoring the scope: every row under "All", else just the scoped one.
+// Used by the per-UPS card grids (line quality / battery health / energy).
+function scopedRows() {
+  const scope = currentScope();
+  if (scope === SCOPE_ALL) return lastUpsRows;
+  const one = lastUpsRows.filter((u) => u.name === scope);
+  return one.length ? one : lastUpsRows;
+}
+
+// Populate the header global UPS selector and mirror the pick into the (now
+// hidden) per-tab chart selects so the existing chart controllers, which read
+// their upsSelId, resolve to the scoped/primary UPS. The global selector is the
+// single source of truth; the per-tab dropdowns are retired from the UI.
 function populateChartUpsSelects(rows) {
-  // Prefer an existing selection that is still valid; else the first UPS.
-  let chosen = "";
-  for (const id of CHART_UPS_SELECTS) {
-    const s = document.getElementById(id);
-    if (s && s.value) { chosen = s.value; break; }
+  const g = document.getElementById("global-ups");
+  const wrap = document.getElementById("global-ups-wrap");
+  const multi = rows.length > 1;
+  // Preserve a valid prior scope; default to All. Single-UPS → that UPS, no control.
+  let scope = g && g.value ? g.value : SCOPE_ALL;
+  if (scope !== SCOPE_ALL && !rows.some((u) => u.name === scope)) scope = SCOPE_ALL;
+  if (!multi) scope = rows.length ? rows[0].name : SCOPE_ALL;
+  if (wrap) wrap.hidden = !multi;
+  if (g) {
+    g.replaceChildren();
+    if (multi) g.appendChild(el("option", { value: SCOPE_ALL, text: "All UPS" }));
+    rows.forEach((u) => g.appendChild(el("option", { value: u.name, text: u.label || u.name })));
+    g.value = scope;
   }
-  if (!rows.some((u) => u.name === chosen)) chosen = rows.length ? rows[0].name : "";
+  const chosen = (scope === SCOPE_ALL || !rows.some((u) => u.name === scope))
+    ? (rows.length ? rows[0].name : "") : scope;
   CHART_UPS_SELECTS.forEach((id) => {
     const sel = document.getElementById(id);
     if (!sel) return;
@@ -290,7 +325,46 @@ function populateChartUpsSelects(rows) {
     rows.forEach((u) =>
       sel.appendChild(el("option", { value: u.name, text: u.label || u.name })));
     if (chosen) sel.value = chosen;
+    const lbl = sel.closest("label");
+    if (lbl) lbl.hidden = true;   // retired: the global selector drives these
   });
+}
+
+// React to a global-scope change: mirror into the chart selects, refresh the
+// scope-dependent chrome, and redraw the active tab.
+function onScopeChanged() {
+  const chosen = scopedName();
+  CHART_UPS_SELECTS.forEach((id) => {
+    const s = document.getElementById(id);
+    if (s && chosen) s.value = chosen;
+  });
+  applyScopeChrome();
+  onTabActivated(activeTab);
+}
+
+// The global selector only affects the scoped tabs; on Events (own filter) and
+// Config (fleet-wide) it does nothing, so dim it there to avoid a "broken
+// control" read. On Events, seed the Source filter from the current scope.
+function applyScopeChrome() {
+  const wrap = document.getElementById("global-ups-wrap");
+  const scoped = SCOPED_TABS.includes(activeTab);
+  if (wrap) {
+    wrap.classList.toggle("inactive", !scoped);
+    wrap.title = scoped ? "" : "This tab isn't scoped by the UPS selector";
+  }
+  if (activeTab === "events" && !scopeIsAll()) seedEventSourceFromScope();
+}
+
+// Seed the Events Source filter from the global scope (still user-overridable).
+function seedEventSourceFromScope() {
+  const src = document.getElementById("event-source-filter");
+  if (!src) return;
+  const scope = currentScope();
+  if (scope === SCOPE_ALL) return;
+  if ([...src.options].some((o) => o.value === scope) && src.value !== scope) {
+    src.value = scope;
+    if (typeof applyEventFilters === "function") applyEventFilters();
+  }
 }
 
 // ----- Overview hero + KPI summary (rc9) -----------------------------------
@@ -391,35 +465,98 @@ function renderOverviewSummary(rows) {
   hero.appendChild(heroCard(primary));
 
   // Three drill-through KPI cards surfacing the v6.1 data otherwise buried on
-  // other tabs: battery health, energy today, last self-test.
-  const bh = primary.batteryHealth;
-  summary.appendChild(kpiCard({
-    iconName: "shield", label: "Battery health",
-    value: bh && bh.score != null ? Math.round(bh.score) : "—",
-    unit: bh && bh.score != null ? "/100" : "",
-    cap: bh && bh.confidence != null ? "confidence " + Math.round(bh.confidence * 100) + "%"
-      : "no data yet",
-    valueStatus: bh ? scoreClass(bh.score) : null, tab: "battery" }));
+  // other tabs. In a fleet these summarize ACROSS all UPSes (worst battery
+  // health, total energy, worst self-test) so a second UPS is never hidden —
+  // the header is "System", not "the primary UPS". (operator #11, plan #4)
+  const multi = rows.length > 1;
+  const named = (u) => u.label || u.name;
 
-  const en = primary.energy;
-  summary.appendChild(kpiCard({
-    iconName: "chart", label: "Energy today",
-    value: en && en.todayKwh != null ? en.todayKwh.toFixed(2) : "—",
-    unit: en && en.todayKwh != null ? " kWh" : "",
-    cap: en && en.todayCostFormatted ? en.todayCostFormatted + " today"
-      : (en && en.monthKwh != null ? en.monthKwh.toFixed(1) + " kWh this month" : "—"),
-    tab: "energy" }));
+  // Battery health: the lowest score in the fleet (the one that needs attention).
+  const bhRows = rows.filter((u) => u.batteryHealth && u.batteryHealth.score != null);
+  if (bhRows.length) {
+    const worst = bhRows.slice().sort(
+      (a, b) => a.batteryHealth.score - b.batteryHealth.score)[0];
+    const bh = worst.batteryHealth;
+    summary.appendChild(kpiCard({
+      iconName: "shield", label: multi ? "Battery health · lowest" : "Battery health",
+      value: Math.round(bh.score), unit: "/100",
+      cap: (multi ? named(worst) + " · " : "")
+        + (bh.confidence != null ? "confidence " + Math.round(bh.confidence * 100) + "%" : ""),
+      valueStatus: scoreClass(bh.score), tab: "battery" }));
+  } else {
+    summary.appendChild(kpiCard({ iconName: "shield", label: "Battery health",
+      value: "—", unit: "", cap: "no data yet", tab: "battery" }));
+  }
 
-  // Self-test KPI only when a test has actually run — a "never run" box is noise
-  // (and most UPSes never get one). The Battery tab still explains the term.
-  const st = primary.selfTest;
-  if (st && ["passed", "failed", "running"].includes(st.result)) {
+  // Energy today: the fleet total (a single UPS keeps its cost caption).
+  const enRows = rows.filter((u) => u.energy && u.energy.todayKwh != null);
+  if (enRows.length) {
+    const totalKwh = enRows.reduce((s, u) => s + u.energy.todayKwh, 0);
+    let cap;
+    if (multi) {
+      cap = enRows.length + " of " + rows.length + " UPS · today";
+    } else {
+      const en = enRows[0].energy;
+      cap = en.todayCostFormatted ? en.todayCostFormatted + " today"
+        : (en.monthKwh != null ? en.monthKwh.toFixed(1) + " kWh this month" : "today");
+    }
+    summary.appendChild(kpiCard({
+      iconName: "chart", label: multi ? "Energy today · fleet" : "Energy today",
+      value: totalKwh.toFixed(2), unit: " kWh", cap, tab: "energy" }));
+  } else {
+    summary.appendChild(kpiCard({ iconName: "chart", label: "Energy today",
+      value: "—", unit: "", cap: "—", tab: "energy" }));
+  }
+
+  // Last self-test: the worst result across the fleet (failed > running > passed),
+  // so a single failed test isn't masked by another UPS's pass. Only shown once
+  // a test has actually run somewhere.
+  const stRows = rows.filter(
+    (u) => u.selfTest && ["passed", "failed", "running"].includes(u.selfTest.result));
+  if (stRows.length) {
+    const rankSt = { failed: 0, running: 1, passed: 2 };
+    const worstSt = stRows.slice().sort(
+      (a, b) => rankSt[a.selfTest.result] - rankSt[b.selfTest.result])[0];
+    const st = worstSt.selfTest;
     const stStatus = { passed: "ok", failed: "crit", running: "warn" }[st.result] || null;
     summary.appendChild(kpiCard({
-      iconName: "check", label: "Last self-test",
+      iconName: "check", label: multi ? "Self-test · worst" : "Last self-test",
       value: titleCase(st.result),
-      cap: st.date ? st.date : "", valueStatus: stStatus, tab: "battery" }));
+      cap: multi ? named(worstSt) + (st.date ? " · " + st.date : "") : (st.date || ""),
+      valueStatus: stStatus, tab: "battery" }));
   }
+}
+
+// A neutral "monitoring only" tag for a non-local (remote-monitored) UPS, so it
+// reads differently from the UPS that actually protects this host. (operator #4)
+function monitoringBadge(u) {
+  return u && u.isLocal === false
+    ? el("span", { class: "badge muted mon-badge", text: "monitoring only" }) : null;
+}
+
+// Persistent fleet-status strip (above the tabs, every tab): each UPS at a
+// glance so a second UPS is never below the fold during an outage. Chips drill
+// into the detail modal. Hidden for a single-UPS deployment. (operator #1)
+function renderFleetStrip(rows) {
+  const strip = document.getElementById("fleet-strip");
+  if (!strip) return;
+  strip.replaceChildren();
+  if (rows.length <= 1) { strip.hidden = true; return; }
+  strip.hidden = false;
+  rows.forEach((u) => {
+    const cls = statusClass(u.status);
+    const charge = parseFloat(u.batteryCharge);
+    const chip = el("button", { class: "fleet-chip s-" + cls, type: "button",
+      title: "View " + (u.label || u.name) + " details" }, [
+      el("span", { class: "fleet-name", text: u.label || u.name }),
+      el("span", { class: "badge " + cls, text: u.status || "—" }),
+      el("span", { class: "fleet-metric",
+        text: (isNaN(charge) ? "—" : charge + "%") + " · " + formatRuntimeSeconds(u.runtime) }),
+      u.isLocal === false ? el("span", { class: "fleet-tag", text: "monitoring" }) : null,
+    ].filter(Boolean));
+    chip.addEventListener("click", () => openDetail(u.name));
+    strip.appendChild(chip);
+  });
 }
 
 function renderUps(payload) {
@@ -432,7 +569,8 @@ function renderUps(payload) {
     const barValue = isNaN(charge) ? 0 : Math.max(0, Math.min(100, charge));
     const card = el("div", { class: "card card-click", tabindex: "0",
       role: "button", title: "View details" }, [
-      el("h3", { text: u.label || u.name }),
+      el("div", { class: "card-title" },
+        [el("h3", { text: u.label || u.name }), monitoringBadge(u)].filter(Boolean)),
       el("div", { class: "row" }, [
         el("span", { text: "Status" }),
         el("span", { class: "badge " + statusClass(u.status), text: u.status || "—" }),
@@ -457,6 +595,7 @@ function renderUps(payload) {
     wrap.appendChild(card);
   });
   populateChartUpsSelects(rows);
+  renderFleetStrip(rows);
   // Single UPS → the Overview is the hero + KPI summary; the raw per-UPS card
   // grid only appears for a fleet (multi-UPS).
   document.getElementById("ups-section").hidden = rows.length <= 1;
@@ -710,8 +849,10 @@ function energyRows(en) {
 function renderDetail(name) {
   const u = lastUpsRows.find((r) => r.name === name);
   const body = document.getElementById("detail-body");
-  document.getElementById("detail-title").textContent =
-    (u && (u.label || u.name)) || name;
+  const titleEl = document.getElementById("detail-title");
+  titleEl.textContent = (u && (u.label || u.name)) || name;
+  const mb = monitoringBadge(u);
+  if (mb) titleEl.appendChild(mb);
   if (!u) { body.replaceChildren(el("p", { text: "No data for this UPS." })); return; }
   const pq = u.powerQuality || {};
   const sections = [];
@@ -1046,22 +1187,37 @@ function updateDeleteButton() {
   btn.textContent = n ? ("Delete selected (" + n + ")") : "Delete selected";
 }
 
+// Human label for the UPS that emitted an event (matches the same fields the
+// source filter does). Used by the multi-UPS Source column.
+function eventSourceLabel(e) {
+  const u = lastUpsRows.find((r) =>
+    r.name === e.ups || r.name === e.source || r.name === e.group
+    || r.groupId === e.source || r.groupId === e.group);
+  return u ? (u.label || u.name) : (e.ups || e.source || e.group || "—");
+}
+
 function applyEventFilters() {
   const body = document.querySelector("#events tbody");
   body.replaceChildren();
   const signedIn = !!token();
+  // Show a Source column only in a fleet, so a multi-UPS "All sources" view
+  // isn't ambiguous. (operator #8)
+  const multi = lastUpsRows.length > 1;
   // The selection column + Delete action only exist when signed in; keep the
   // header and empty-state colspan in sync so widths never mismatch.
   document.getElementById("events-head").replaceChildren(...[
     ...(signedIn ? [el("th", { text: "" })] : []),
-    timeSortHeader(), el("th", { text: "Type" }),
+    timeSortHeader(),
+    ...(multi ? [el("th", { text: "Source" })] : []),
+    el("th", { text: "Type" }),
     el("th", { text: "Detail" }),
   ]);
   updateDeleteButton();
   const rows = visibleEvents();
+  const colspan = String(3 + (signedIn ? 1 : 0) + (multi ? 1 : 0));
   if (rows.length === 0) {
     body.appendChild(el("tr", null, [
-      el("td", { colspan: signedIn ? "4" : "3", text: "No events." })]));
+      el("td", { colspan, text: "No events." })]));
     return;
   }
   rows.forEach((e) => {
@@ -1077,8 +1233,9 @@ function applyEventFilters() {
       });
       const td = el("td"); td.appendChild(cb); cells.push(td);
     }
+    cells.push(el("td", { text: ts }));
+    if (multi) cells.push(el("td", { class: "ev-src", text: eventSourceLabel(e) }));
     cells.push(
-      el("td", { text: ts }),
       el("td", null, [eventTypeBadge(e)]),
       el("td", { text: e.detail || e.details || "" }),
     );
@@ -2108,7 +2265,7 @@ function renderBatteryHealthTab() {
   const wrap = document.getElementById("battery-health");
   if (!wrap) return;
   wrap.replaceChildren();
-  const rows = lastUpsRows;
+  const rows = scopedRows();
   if (!rows.length) {
     wrap.appendChild(el("p", { class: "chart-note", text: "No UPS data yet." }));
     return;
@@ -2210,7 +2367,7 @@ function renderEnergyTab() {
   const wrap = document.getElementById("energy-cards");
   if (!wrap) return;
   wrap.replaceChildren();
-  const rows = lastUpsRows;
+  const rows = scopedRows();
   if (!rows.length) {
     wrap.appendChild(el("p", { class: "chart-note", text: "No UPS data yet." }));
     return;
@@ -2286,22 +2443,19 @@ function stateRow(label, value) {
     el("span", { class: "badge " + cls, text: titleCase(value) })]);
 }
 
-function renderLineQuality() {
-  const wrap = document.getElementById("line-quality");
-  if (!wrap) return;
-  wrap.replaceChildren();
-  const sel = document.getElementById("power-ups");
-  const name = sel && sel.value;
-  const u = lastUpsRows.find((r) => r.name === name) || lastUpsRows[0];
+// One line-quality card for a UPS. In a multi-UPS fleet the header carries the
+// UPS name (so "All UPS" renders a card each); a lone UPS keeps "Line quality".
+function lineQualityCard(u) {
   const pq = u && u.powerQuality;
-  if (!pq) return;   // nothing to summarize; the chart below still renders
+  if (!pq) return null;
   const q = lineQuality(pq);
   const inV = numOrNull(pq.inputVoltage);
   const lo = numOrNull(pq.warningLow), hi = numOrNull(pq.warningHigh);
   const banded = inV != null && lo != null && hi != null;
+  const title = lastUpsRows.length > 1 ? (u.label || u.name) : "Line quality";
   const rows = [el("div", { class: "card-head" }, [
     el("span", { class: "card-ico s-" + q.cls }, [icon("gauge")]),
-    el("h3", { text: "Line quality" }),
+    el("h3", { text: title }),
     el("span", { class: "badge " + q.cls, text: q.label }),
   ])];
   rows.push(el("div", { class: "row" }, [
@@ -2326,7 +2480,17 @@ function renderLineQuality() {
   });
   const temp = fmtUnit(pq.temperature, "°C");
   if (temp) rows.push(configKv("Temperature", temp));
-  wrap.appendChild(el("div", { class: "card s-" + q.cls }, rows));
+  return el("div", { class: "card s-" + q.cls }, rows);
+}
+
+function renderLineQuality() {
+  const wrap = document.getElementById("line-quality");
+  if (!wrap) return;
+  wrap.replaceChildren();
+  scopedRows().forEach((u) => {
+    const card = lineQualityCard(u);
+    if (card) wrap.appendChild(card);
+  });
 }
 
 // ----- config tab ----------------------------------------------------------
@@ -2648,7 +2812,10 @@ async function doLogout() {
 // Real ARIA tabs: roving tabindex, arrow-key nav, and URL-hash routing so views
 // are linkable. The 10s refresh redraws only the active tab's chart/widgets.
 
-const TAB_IDS = ["overview", "power", "battery", "energy", "events", "control", "shutdown", "config"];
+const TAB_IDS = ["overview", "power", "battery", "energy", "control", "shutdown", "events", "config"];
+// Tabs whose content is scoped by the global UPS selector. Events (own Source
+// filter) and Config (fleet-wide) are intentionally excluded.
+const SCOPED_TABS = ["overview", "power", "battery", "energy", "shutdown"];
 let activeTab = "overview";
 
 function tabButtons() {
@@ -2690,6 +2857,7 @@ function selectTab(name, opts) {
   // instead of inheriting the previous tab's scroll position.
   if (opts.updateHash) window.scrollTo(0, 0);
   onTabActivated(name);
+  applyScopeChrome();
 }
 
 // Draw/refresh whatever the freshly-activated tab needs from the latest data.
@@ -2957,6 +3125,12 @@ async function init() {
   charts.energy = makeEnergyChart({ hostId: "energy-graph", upsSelId: "energy-ups",
     rangeSelId: "energy-range", eventsNoteId: "energy-events-note" });
   Object.values(charts).forEach((c) => c.observe());
+
+  // Global UPS scope selector drives Power/Battery/Energy/Shutdown + the scoped
+  // card grids. It is the single source of truth; the per-tab dropdowns are
+  // hidden and mirrored from it (see populateChartUpsSelects/onScopeChanged).
+  const gsel = document.getElementById("global-ups");
+  if (gsel) gsel.addEventListener("change", onScopeChanged);
 
   // Shutdown-tab UPS selector: re-render the plan for the chosen UPS/group.
   const sdSel = document.getElementById("shutdown-ups");

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -605,7 +605,7 @@ function renderUps(payload) {
       el("meter", {
         class: "bar " + batteryClass(charge),
         min: "0", max: "100", value: String(barValue),
-        "aria-label": "Battery charge",
+        "aria-label": "Battery charge for " + (u.label || u.name),
       }),
       el("div", { class: "row" }, [el("span", { text: "Runtime" }),
         el("b", { text: formatRuntimeSeconds(u.runtime) })]),
@@ -743,15 +743,33 @@ function openDetail(name) {
   detailReturnFocus = document.activeElement;
   openDetailName = name;
   renderDetail(name);
-  document.getElementById("detail-modal").hidden = false;
+  const modal = document.getElementById("detail-modal");
+  modal.hidden = false;
   // Pull focus into the dialog so Tab stays among its controls and assistive
   // tech announces it; the close button is the first focusable element.
   document.getElementById("detail-close").focus();
+  // Trap Tab within the dialog and close on Esc so keyboard/AT users can't tab
+  // out to the page behind it and can always dismiss it. (a11y #10)
+  const onKey = (ev) => {
+    if (ev.key === "Escape") { ev.preventDefault(); closeDetail(); return; }
+    if (ev.key !== "Tab") return;
+    const f = Array.from(modal.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+      .filter((e) => !e.disabled && e.offsetParent !== null);
+    if (!f.length) return;
+    const first = f[0], last = f[f.length - 1];
+    if (ev.shiftKey && document.activeElement === first) { ev.preventDefault(); last.focus(); }
+    else if (!ev.shiftKey && document.activeElement === last) { ev.preventDefault(); first.focus(); }
+  };
+  modal.addEventListener("keydown", onKey);
+  modal._trap = onKey;
 }
 
 function closeDetail() {
+  const modal = document.getElementById("detail-modal");
+  if (modal._trap) { modal.removeEventListener("keydown", modal._trap); modal._trap = null; }
   openDetailName = null;
-  document.getElementById("detail-modal").hidden = true;
+  modal.hidden = true;
   if (detailReturnFocus && typeof detailReturnFocus.focus === "function") {
     detailReturnFocus.focus();
   }
@@ -1187,7 +1205,8 @@ function timeSortHeader() {
     type: "button",
     class: "th-sort",
     text: label,
-    "aria-label": "Sort events by time",
+    "aria-label": "Sort events by time, currently "
+      + (eventSortDirection === "asc" ? "ascending" : "descending"),
     "aria-pressed": eventSortDirection === "desc" ? "true" : "false",
   });
   btn.addEventListener("click", toggleEventSort);
@@ -1585,6 +1604,11 @@ function drawChart(hostId, series, options) {
   const H = 220, pad = 34;
   const svg = document.createElementNS(SVG_NS, "svg");
   svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+  // Expose the chart to assistive tech as a labelled image (the per-point data
+  // is also reachable via the metric selectors + the API). (a11y #8)
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label",
+    (options.metric ? metricLabel(options.metric) : "Metric") + " over the selected range");
   const line = (x1, y1, x2, y2, cls) => {
     const l = document.createElementNS(SVG_NS, "line");
     l.setAttribute("x1", x1); l.setAttribute("y1", y1);

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -343,26 +343,31 @@ function onScopeChanged() {
   onTabActivated(activeTab);
 }
 
-// The global selector only affects the scoped tabs; on Events (own filter) and
-// Config (fleet-wide) it does nothing, so dim it there to avoid a "broken
-// control" read. On Events, seed the Source filter from the current scope.
+// The global selector drives the scoped tabs; on Events it also seeds the Source
+// filter (so it's still doing something), and only on Config is it truly inert —
+// dim + explain it only there. aria-label carries the reason for AT users.
 function applyScopeChrome() {
   const wrap = document.getElementById("global-ups-wrap");
-  const scoped = SCOPED_TABS.includes(activeTab);
   if (wrap) {
-    wrap.classList.toggle("inactive", !scoped);
-    wrap.title = scoped ? "" : "This tab isn't scoped by the UPS selector";
+    const inert = activeTab === "config";
+    wrap.classList.toggle("inactive", inert);
+    const msg = inert ? "Config is fleet-wide; the UPS selector doesn't apply here"
+      : (activeTab === "events" ? "Also seeds the Events source filter" : "");
+    wrap.title = msg;
+    if (msg) wrap.setAttribute("aria-label", "UPS to show — " + msg);
+    else wrap.removeAttribute("aria-label");
   }
   if (activeTab === "events" && !scopeIsAll()) seedEventSourceFromScope();
 }
 
-// Seed the Events Source filter from the global scope (still user-overridable).
+// Seed the Events Source filter from the global scope, but NEVER override a
+// manual pick — only seed when the filter is still on "All sources". (review)
 function seedEventSourceFromScope() {
   const src = document.getElementById("event-source-filter");
   if (!src) return;
   const scope = currentScope();
-  if (scope === SCOPE_ALL) return;
-  if ([...src.options].some((o) => o.value === scope) && src.value !== scope) {
+  if (scope === SCOPE_ALL || src.value !== "") return;
+  if ([...src.options].some((o) => o.value === scope)) {
     src.value = scope;
     if (typeof applyEventFilters === "function") applyEventFilters();
   }
@@ -577,8 +582,14 @@ function renderFleetStrip(rows) {
   rows.forEach((u) => {
     const cls = statusClass(u.status);
     const charge = parseFloat(u.batteryCharge);
+    // Full accessible name — the status/charge/runtime/monitoring live in
+    // separate spans that a screen reader would run together ambiguously.
+    const aria = (u.label || u.name) + ": " + (u.status || "unknown") + ", "
+      + (isNaN(charge) ? "charge unknown" : charge + "% charge") + ", "
+      + formatRuntimeSeconds(u.runtime) + " runtime"
+      + (u.isLocal === false ? ", monitoring only" : "") + " — view details";
     const chip = el("button", { class: "fleet-chip s-" + cls, type: "button",
-      title: "View " + (u.label || u.name) + " details" }, [
+      title: "View " + (u.label || u.name) + " details", "aria-label": aria }, [
       el("span", { class: "fleet-name", text: u.label || u.name }),
       el("span", { class: "badge " + cls, text: u.status || "—" }),
       el("span", { class: "fleet-metric",
@@ -1582,6 +1593,58 @@ function addChartHover(svg, geom, series) {
 
 // Draw `series` (a /history payload) into the host element, with optional
 // `bands` (voltage thresholds) and `events` (overlay markers).
+// ---- shared chart helpers (v6.1.4) ----------------------------------------
+// Pad a degenerate (flat) value domain so a constant series (a steady 100%
+// charge, a fixed runtime) doesn't collapse onto the bottom axis and read as
+// empty. Returns [min, max].
+function padFlatDomain(min, max) {
+  if (max > min) return [min, max];
+  const p = Math.max(1, Math.abs(min) * 0.02);
+  return [min - p, max + p];
+}
+
+// Gap threshold for breaking a line across missing data: ~3x the median sample
+// spacing (so a routine poll hiccup doesn't fragment a dense series, but a real
+// outage-length gap breaks the path). Returns Infinity when too few points.
+function chartGapThresh(drawn) {
+  if (drawn.length <= 2) return Infinity;
+  const gaps = [];
+  for (let i = 1; i < drawn.length; i++) gaps.push(drawn[i].ts - drawn[i - 1].ts);
+  gaps.sort((a, b) => a - b);
+  const med = gaps[Math.floor(gaps.length / 2)] || 0;
+  return med > 0 ? med * 3 : Infinity;
+}
+
+// X-axis time ticks: count scales with width; times snap to round steps; the
+// date is shown for day+ steps and at local-midnight boundaries within a
+// sub-day window that crosses midnight. Appended to `svg`.
+function drawTimeTicks(svg, t0, t1, x, W, H, bottomPad, leftPad) {
+  const spanS = Math.max(1, t1 - t0);
+  const target = Math.max(2, Math.min(8, Math.floor((W - leftPad - 5) / 90)));
+  const STEPS = [60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200,
+                 86400, 172800, 604800, 1209600, 2592000];
+  let step = STEPS[STEPS.length - 1];
+  for (const s of STEPS) { if (spanS / s <= target) { step = s; break; } }
+  const crosses = new Date(t0 * 1000).toDateString() !== new Date(t1 * 1000).toDateString();
+  const yy = (H - bottomPad + 15).toFixed(1);
+  const fmt = (ts) => {
+    const dt = new Date(ts * 1000);
+    if (step >= 86400) return dt.toLocaleDateString([], { month: "short", day: "numeric" });
+    if (crosses && dt.getHours() === 0 && dt.getMinutes() === 0) {
+      return dt.toLocaleDateString([], { month: "short", day: "numeric" });
+    }
+    return dt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  };
+  for (let ts = Math.ceil(t0 / step) * step; ts <= t1; ts += step) {
+    const tx = x(ts);
+    if (tx < leftPad - 1 || tx > W - 4) continue;
+    const t = document.createElementNS(SVG_NS, "text");
+    t.setAttribute("x", tx.toFixed(1)); t.setAttribute("y", yy);
+    t.setAttribute("text-anchor", "middle"); t.setAttribute("class", "lbl xtick");
+    t.textContent = fmt(ts); svg.appendChild(t);
+  }
+}
+
 function drawChart(hostId, series, options) {
   options = options || {};
   const host = document.getElementById(hostId);
@@ -1594,7 +1657,7 @@ function drawChart(hostId, series, options) {
   if (!W) return;
   host.replaceChildren();
   const pts = (series && series.data) || [];
-  const H = 220, pad = 34;
+  const H = 220, pad = 34, padT = options.metric ? 20 : 8;
   const svg = document.createElementNS(SVG_NS, "svg");
   svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
   // Expose the chart to assistive tech as a labelled image (the per-point data
@@ -1611,7 +1674,7 @@ function drawChart(hostId, series, options) {
     svg.appendChild(l);
   };
   line(pad, H - pad, W - 5, H - pad, "axis");
-  line(pad, 5, pad, H - pad, "axis");
+  line(pad, padT, pad, H - pad, "axis");
 
   // Metric name + unit, top-centered, so the numbers on the axis are identifiable.
   if (options.metric) {
@@ -1661,39 +1724,26 @@ function drawChart(hostId, series, options) {
     min = mid - floor / 2;
     max = mid + floor / 2;
   }
+  // Pad a still-flat domain so a constant series doesn't pin to the axis.
+  [min, max] = padFlatDomain(min, max);
   const span = (max - min) || 1;
-  const t0 = pts[0].ts, t1 = pts[pts.length - 1].ts, tspan = (t1 - t0) || 1;
+  // Domain is the REQUESTED window when known (so leading/trailing silence shows
+  // as empty space), else the data extent.
+  const t0 = (options.from != null) ? options.from : pts[0].ts;
+  const t1 = (options.to != null) ? options.to : pts[pts.length - 1].ts;
+  const tspan = (t1 - t0) || 1;
   const x = (t) => pad + ((t - t0) / tspan) * (W - pad - 5);
-  const y = (v) => (H - pad) - ((v - min) / span) * (H - pad - 5);
+  const y = (v) => (H - pad) - ((v - min) / span) * (H - pad - padT);
 
   // Horizontal gridlines (quarter divisions) — the single biggest "this is a
   // real chart" cue. Drawn first, behind everything.
   for (let i = 1; i <= 3; i++) {
-    const gy = (5 + i * (H - pad - 5) / 4).toFixed(1);
+    const gy = (padT + i * (H - pad - padT) / 4).toFixed(1);
     line(pad, gy, W - 5, gy, "grid");
   }
 
-  // X-axis time ticks — a time series with no time reference is unreadable
-  // (outage bands + event markers otherwise float in an unanchored window).
-  const spanDays = tspan / 86400;
-  const fmtTick = (ts) => {
-    const dt = new Date(ts * 1000);
-    return spanDays <= 2
-      ? dt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-      : dt.toLocaleDateString([], { month: "short", day: "numeric" });
-  };
-  const N_TICKS = 4;
-  for (let i = 0; i <= N_TICKS; i++) {
-    const tts = t0 + (tspan * i) / N_TICKS;
-    const tx = x(tts);
-    const tk = document.createElementNS(SVG_NS, "text");
-    tk.setAttribute("x", tx.toFixed(1));
-    tk.setAttribute("y", (H - pad + 15).toFixed(1));
-    tk.setAttribute("text-anchor", i === 0 ? "start" : i === N_TICKS ? "end" : "middle");
-    tk.setAttribute("class", "lbl xtick");
-    tk.textContent = fmtTick(tts);
-    svg.appendChild(tk);
-  }
+  // X-axis time ticks (shared helper: width-scaled count, round-time snapping).
+  drawTimeTicks(svg, t0, t1, x, W, H, pad, pad);
 
   // Voltage threshold band: a faint zone bounded by dashed edge lines (reads as
   // thresholds, not a slab of page-tint), plus the nominal center line.
@@ -2004,6 +2054,8 @@ function makeChart(opts) {
     state.series = series;
     state.events = events;
     state.hiddenEvents = hidden;
+    state.from = from;   // requested window → chart domain (trailing gaps show)
+    state.to = to;
     if (opts.bands) {
       const u = lastUpsRows.find((r) => r.name === ups);
       const pq = (u && u.powerQuality) || {};
@@ -2026,6 +2078,7 @@ function makeChart(opts) {
       // Only label the UPS in a fleet; a lone UPS needs no disambiguation.
       upsLabel: lastUpsRows.length > 1 ? upsLabel() : "",
       scopeAll: typeof scopeIsAll === "function" && scopeIsAll(),
+      from: state.from, to: state.to,
       bands: opts.bands ? state.thresholds : null,
       events: opts.events ? state.events : null,
     });
@@ -2105,6 +2158,7 @@ function drawEnergyChart(hostId, rows, options) {
     if (vals.length < 2) return null;
     let mn = Math.min(...vals), mx = Math.max(...vals);
     if (floorZero) mn = Math.min(mn, 0);
+    [mn, mx] = padFlatDomain(mn, mx);
     const span = (mx - mn) || 1;
     return { mn, mx, y: (v) => (H - pad) - ((v - mn) / span) * (H - pad - 5) };
   }
@@ -2147,11 +2201,13 @@ function drawEnergyChart(hostId, rows, options) {
 
   function plot(key, sc, cls) {
     if (!sc) return;
-    let d = "";
-    pts.forEach((p) => {
-      const v = p[key];
-      if (typeof v !== "number" || isNaN(v)) return;
-      d += (d ? " L" : "M") + x(p.ts).toFixed(1) + " " + sc.y(v).toFixed(1);
+    const drawn = pts.filter((p) => typeof p[key] === "number" && !isNaN(p[key]));
+    const thresh = chartGapThresh(drawn);   // break the line across real gaps
+    let d = "", prev = null;
+    drawn.forEach((p) => {
+      const move = prev === null || (p.ts - prev) > thresh;
+      d += (d ? " " : "") + (move ? "M" : "L") + x(p.ts).toFixed(1) + " " + sc.y(p[key]).toFixed(1);
+      prev = p.ts;
     });
     if (!d) return;
     const path = document.createElementNS(SVG_NS, "path");
@@ -2159,6 +2215,7 @@ function drawEnergyChart(hostId, rows, options) {
     path.setAttribute("vector-effect", "non-scaling-stroke");
     svg.appendChild(path);
   }
+  drawTimeTicks(svg, t0, t1, x, W, H, pad, pad);   // anchor the window in time
   if (wattS) plot("watts", wattS, "plot plot-watts");
   if (showLoad) plot("loadPct", loadS, "plot plot-load");
 
@@ -2206,12 +2263,17 @@ function drawSimpleSeries(host, pts, opts) {
   svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
   const t0 = pts[0].ts;
   const tLast = pts[pts.length - 1].ts;
-  // Extend the x-axis to opts.tEnd (e.g. a future replacement date) so a marker
-  // beyond the data is visible; the plotted line still stops at the last reading.
-  const t1 = (opts.tEnd != null && opts.tEnd > tLast) ? opts.tEnd : tLast;
+  // Extend the x-axis toward opts.tEnd (e.g. a future replacement date) so a
+  // marker beyond the data is visible — but CAP the extension at 2x the data
+  // span so a far-off ETA (years out) doesn't crush the real history into a few
+  // pixels. A capped-off ETA is shown as an edge annotation by the caller.
+  const dataSpan = Math.max(1, tLast - t0);
+  const t1 = (opts.tEnd != null && opts.tEnd > tLast)
+    ? Math.min(opts.tEnd, tLast + 2 * dataSpan) : tLast;
   const span = Math.max(1, t1 - t0);
-  const lo = opts.min != null ? opts.min : Math.min(...pts.map((p) => p.value));
-  const hi = opts.max != null ? opts.max : Math.max(...pts.map((p) => p.value));
+  let lo = opts.min != null ? opts.min : Math.min(...pts.map((p) => p.value));
+  let hi = opts.max != null ? opts.max : Math.max(...pts.map((p) => p.value));
+  if (opts.min == null && opts.max == null) [lo, hi] = padFlatDomain(lo, hi);
   const rng = Math.max(1e-9, hi - lo);
   const x = (ts) => pad + (ts - t0) / span * (W - pad - padR);
   const y = (v) => padT + (1 - (v - lo) / rng) * (H - padT - pad);
@@ -2222,6 +2284,7 @@ function drawSimpleSeries(host, pts, opts) {
     ln.setAttribute("y1", yy); ln.setAttribute("y2", yy);
     ln.setAttribute("class", "grid"); svg.appendChild(ln);
   }
+  drawTimeTicks(svg, t0, t1, x, W, H, pad, pad);   // shared time axis
   const txt = (s, xx, yy, cls, anchor) => {
     const t = document.createElementNS(SVG_NS, "text");
     t.setAttribute("x", xx); t.setAttribute("y", yy); t.setAttribute("class", cls);
@@ -2450,8 +2513,15 @@ async function renderBatteryHealthGraph() {
   const scores = pts.map((p) => p.value);
   let floorRef = Math.min.apply(null, scores);
   if (repl.thresholdScore != null) floorRef = Math.min(floorRef, repl.thresholdScore);
+  // Name the UPS in the title (with "(primary)" under All UPS), matching the
+  // other charts — the cards above show every UPS, so the trend needs to say
+  // whose it is.
+  const bhU = lastUpsRows.find((r) => r.name === name);
+  const bhLabel = bhU ? (bhU.label || bhU.name) : name;
+  const title = "Health score"
+    + (lastUpsRows.length > 1 ? " · " + bhLabel + (scopeIsAll() ? " (primary)" : "") : "");
   const opts = {
-    title: "Health score", unit: "",
+    title, unit: "",
     min: Math.max(0, Math.floor((floorRef - 8) / 5) * 5), max: 100,
   };
   // Mark the replacement threshold (horizontal) and the projected replacement

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -2550,8 +2550,12 @@ function drawSimpleSeries(host, pts, opts) {
   // Vertical markers (e.g. the projected replacement date), with a label kept
   // inside the plot.
   (opts.vmarkers || []).forEach((m) => {
-    if (m.ts == null || m.ts < t0 || m.ts > t1) return;
-    const mx = x(m.ts);
+    if (m.ts == null || m.ts < t0) return;
+    // A far-future ETA past the capped x-axis is PINNED to the right edge (its
+    // real date is in the label) instead of dropped — otherwise "Replace ~YYYY-MM"
+    // silently vanishes exactly when replacement is furthest out.
+    const mts = Math.min(m.ts, t1);
+    const mx = x(mts);
     const ln = document.createElementNS(SVG_NS, "line");
     ln.setAttribute("x1", mx.toFixed(1)); ln.setAttribute("x2", mx.toFixed(1));
     ln.setAttribute("y1", padT); ln.setAttribute("y2", H - pad);

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -637,18 +637,12 @@ function renderRedundancy() {
   const all = scopeIsAll();
   if (!all) groups = groups.filter((g) => (g.upsSources || []).includes(currentScope()));
   gwrap.replaceChildren();
-  // The "configure redundancy groups" hint only makes sense in the fleet view
-  // (All UPS, >1 UPS, none configured); a scoped view just hides the section.
-  gsec.hidden = groups.length === 0 && !(all && rows.length > 1);
-  if (groups.length === 0) {
-    if (all && rows.length > 1) {
-      gwrap.appendChild(el("div", { class: "card" }, [
-        el("p", { class: "chart-note", text: "No redundancy groups configured. "
-          + "Group UPSes so a shutdown only triggers when quorum is lost — see the "
-          + "redundancy-groups docs." })]));
-    }
-    return;
-  }
+  // Only surface the Redundancy section when groups are actually configured.
+  // The vast majority run independent UPSes, for whom an empty "configure
+  // redundancy groups" hint is permanent noise on the Overview — hide it
+  // entirely rather than advertising a feature they haven't opted into.
+  gsec.hidden = groups.length === 0;
+  if (groups.length === 0) return;
   groups.forEach((g) => {
     const sources = g.upsSources || [];
     const healthy = groupHealthyCount(g, rows);
@@ -801,8 +795,9 @@ const BH_TERM_HELP = {
   runtime: "Current runtime under load vs the expected full runtime. n/a until "
     + "the nominal runtime is configured or learned at a full charge.",
   anomaly: "Confirmed battery anomalies; each one lowers the score.",
-  age: "Battery age vs its expected service life (set battery_install_date and "
-    + "expected_life_years).",
+  age: "Battery age vs its expected service life. Higher is younger; a low "
+    + "score means the battery is near or past its expected life. Set this "
+    + "UPS's own battery_install_date + expected_life_years (they're per-UPS).",
 };
 
 // Build the v6.1 battery-health rows shared by the detail modal and the Battery
@@ -850,6 +845,14 @@ function batteryHealthRows(bh, opts) {
       fill.style.setProperty("--w", pct + "%");
       value.appendChild(el("span", { class: "term-meter" }, [fill]));
       value.appendChild(el("b", { class: cls, text: String(Math.round(v)) }));
+    }
+    // Age is the one sub-score that inverts intuition: "0" means OLD (past its
+    // expected life), not new. Show the actual age next to it so a low number
+    // reads as "worn out", not "brand new / not reported".
+    if (k === "age" && bh.ageYears != null) {
+      value.appendChild(el("span", { class: "term-age",
+        text: "~" + bh.ageYears.toFixed(1) + " yr"
+          + (bh.expectedLifeYears ? " / " + bh.expectedLifeYears + " yr" : "") }));
     }
     rows.push(el("div", { class: "row term-row" }, [
       el("span", { class: "label-tip" },

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -1560,6 +1560,7 @@ function metricMinSpan(metric) {
 // `series`: [{ y(v)->py, valueAt(point)->number, fmt(number)->string, label }].
 function addChartHover(svg, geom, series) {
   const { x, W, H, pad } = geom;
+  const readout = geom.readout;   // persistent top-right value/min/max/time readout
   const base = (series.find((s) => s.pts && s.pts.length) || {}).pts || [];
   const cross = document.createElementNS(SVG_NS, "g");
   cross.setAttribute("class", "crosshair");
@@ -1591,7 +1592,10 @@ function addChartHover(svg, geom, series) {
   // Hide the crosshair + floating tip. Used on mouseleave AND on every early
   // exit from move(): a sample with no plottable value (a gap) must clear any
   // readout left pinned by a prior move, not leave it stuck until mouseleave.
-  const hideHover = () => { cross.style.display = "none"; hideTip(); };
+  const hideHover = () => {
+    cross.style.display = "none"; hideTip();
+    if (readout) readout.textContent = readout.getAttribute("data-idle") || "";
+  };
   const move = (ev) => {
     if (!base.length) return hideHover();
     const r = svg.getBoundingClientRect();
@@ -1614,6 +1618,29 @@ function addChartHover(svg, geom, series) {
       }
     });
     if (!valueLines.length) return hideHover();
+    // Persistent readout: actual value at this time, plus the min–max of the
+    // surrounding bucket for a stats-band chart (the "what was the range here").
+    if (readout) {
+      const prim = series[0];
+      const av = prim.valueAt(p);
+      if (typeof av === "number" && !isNaN(av)) {
+        let txt = prim.fmt(av);
+        if (geom.band && base.length > 2) {
+          const spanS = base[base.length - 1].ts - base[0].ts;
+          const halfW = Math.max(1, (spanS / Math.max(1, W - pad - 5)) * 3);
+          let mn = Infinity, mx = -Infinity;
+          for (const q of base) {
+            if (Math.abs(q.ts - p.ts) > halfW) continue;
+            const qv = prim.valueAt(q);
+            if (typeof qv === "number" && !isNaN(qv)) { if (qv < mn) mn = qv; if (qv > mx) mx = qv; }
+          }
+          if (mn !== Infinity && mx > mn) txt += "  ·  ↓" + prim.fmt(mn) + " ↑" + prim.fmt(mx);
+        }
+        txt += "  ·  " + new Date(p.ts * 1000)
+          .toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+        readout.textContent = txt;
+      }
+    }
     cross.style.display = "";
     showTip(valueLines.concat([el("div", { class: "tip-sub",
       text: new Date(p.ts * 1000).toLocaleString() })]),
@@ -1822,6 +1849,14 @@ function drawChart(hostId, series, options) {
     svg.appendChild(t);
   }
 
+  // Persistent top-right readout — live actual value (+ bucket min/max on a
+  // stats-band chart) at the hovered time; idle shows the latest reading.
+  const readout = document.createElementNS(SVG_NS, "text");
+  readout.setAttribute("x", (W - 5).toFixed(0)); readout.setAttribute("y", "12");
+  readout.setAttribute("text-anchor", "end");
+  readout.setAttribute("class", "chart-readout");
+  svg.appendChild(readout);
+
   const vals = pts.map((p) => p.value).filter((v) => typeof v === "number" && !isNaN(v));
   const bands = options.bands || null;
   const metric = options.metric;
@@ -1900,11 +1935,17 @@ function drawChart(hostId, series, options) {
     line(pad, y(bands.nominal).toFixed(1), W - 5, y(bands.nominal).toFixed(1), "band-nominal");
   }
 
+  // Dense series → HA-style min–max band + mean line; sparse → plain line.
+  // Computed BEFORE the hover so the crosshair readout can report bucket min/max.
+  const drawn = pts.filter((p) => typeof p.value === "number" && !isNaN(p.value));
+  const stats = statsBandPaths(drawn, (p) => p.value, x, y, W - pad - 5);
+  const d = stats.meanD, hasGap = stats.hasGap;
+
   // Hover crosshair + value readout. The capture rect is added now, BELOW the
   // outage bands + event markers added next, so those keep their own tooltips
   // and the readout only fires over empty plot area. The crosshair group itself
   // is appended last (on top of the plotted line).
-  const crosshair = addChartHover(svg, { x, W, H, pad },
+  const crosshair = addChartHover(svg, { x, W, H, pad, readout, band: !!stats.bandD },
     [{ label: metricLabel(metric), pts,
        valueAt: (p) => p.value, y, fmt: (v) => formatMetricValue(metric, v) }]);
 
@@ -1937,10 +1978,6 @@ function drawChart(hostId, series, options) {
   // than ~2.5x the typical spacing) so we don't draw a confident straight line
   // over data we don't have — and a rejected reading reads as a gap, not an
   // invented trend or a plunge to zero.
-  const drawn = pts.filter((p) => typeof p.value === "number" && !isNaN(p.value));
-  // Dense series → HA-style min–max band + mean line; sparse → plain line.
-  const stats = statsBandPaths(drawn, (p) => p.value, x, y, W - pad - 5);
-  const d = stats.meanD, hasGap = stats.hasGap;
   if (stats.bandD) {
     const band = document.createElementNS(SVG_NS, "path");
     band.setAttribute("d", stats.bandD); band.setAttribute("class", "plot-band");
@@ -1986,6 +2023,8 @@ function drawChart(hostId, series, options) {
     dot.setAttribute("cy", y(lastPt.value).toFixed(1));
     dot.setAttribute("r", "3.5"); dot.setAttribute("class", "now-dot");
     svg.appendChild(dot);
+    const idle = "now " + formatMetricValue(metric, lastPt.value);
+    readout.setAttribute("data-idle", idle); readout.textContent = idle;
   }
   const lab = (txt, yy) => {
     const t = document.createElementNS(SVG_NS, "text");
@@ -2346,7 +2385,21 @@ function drawEnergyChart(hostId, rows, options) {
     valueAt: (p) => p.watts, fmt: (v) => v.toFixed(0) + " W" });
   if (showLoad && loadS) hoverSeries.push({ label: "Load", pts, y: loadS.y,
     valueAt: (p) => p.loadPct, fmt: (v) => v.toFixed(0) + " %" });
-  const crosshair = addChartHover(svg, { x, W, H, pad }, hoverSeries);
+  // Persistent top-right readout (actual + bucket min/max on the primary series).
+  const readout = document.createElementNS(SVG_NS, "text");
+  readout.setAttribute("x", (W - 5).toFixed(0)); readout.setAttribute("y", "12");
+  readout.setAttribute("text-anchor", "end");
+  readout.setAttribute("class", "chart-readout");
+  svg.appendChild(readout);
+  const dense = pts.length > Math.max(2, W - pad - 5) * 3;
+  const lastVal = hoverSeries.length
+    ? [...pts].reverse().map((p) => hoverSeries[0].valueAt(p))
+        .find((v) => typeof v === "number" && !isNaN(v)) : null;
+  if (lastVal != null) {
+    const idle = "now " + hoverSeries[0].fmt(lastVal);
+    readout.setAttribute("data-idle", idle); readout.textContent = idle;
+  }
+  const crosshair = addChartHover(svg, { x, W, H, pad, readout, band: dense }, hoverSeries);
 
   // Outage spans behind the markers (see appendOutageBands).
   appendOutageBands(svg, options.events || [], x, t0, t1, 5, H - pad);
@@ -3266,6 +3319,18 @@ function shutdownTriggerNodes(name, plan) {
 let _sdGen = 0;
 // Append one UPS's shutdown-plan body (trigger + phase flow) into a container.
 function appendShutdownPlanBody(host, name, plan) {
+  // A monitoring-only UPS whose plan has NO enabled phase runs nothing on this
+  // host — don't render a full (all-skipped) sequence + a "triggers…" banner
+  // that reads as if it does. Say plainly that it takes no action.
+  const anyEnabled = (plan.phases || []).some((p) => p.enabled);
+  if (!anyEnabled) {
+    host.appendChild(el("p", { class: "sd-noop" },
+      [icon("info"), el("span", { text: "Monitoring only — Eneru runs no shutdown "
+        + "actions for this UPS. It doesn't power this host, so losing it triggers "
+        + "nothing here (it's still monitored, with events and alerts)." })]));
+    if (plan.note) host.appendChild(el("p", { class: "chart-note", text: plan.note }));
+    return;
+  }
   shutdownTriggerNodes(name, plan).forEach((nd) => host.appendChild(nd));
   const intro = el("p", { class: "chart-note" },
     [el("span", { text: "What runs when a power-loss shutdown is triggered, top "

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -482,21 +482,27 @@ function renderOverviewSummary(rows) {
     hero.appendChild(el("p", { class: "chart-note", text: "No UPS data yet." }));
     return;
   }
-  // Hero shows the worst-status UPS so a problem surfaces immediately.
+  // The global UPS selector scopes the Overview too: a single pick drives the
+  // hero + KPIs to that UPS; "All UPS" shows the whole fleet (worst status,
+  // lowest health, total energy). The fleet strip above always lists every UPS.
+  const picked = !scopeIsAll() && rows.filter((u) => u.name === currentScope());
+  const view = (picked && picked.length) ? picked : rows;
+
+  // Hero shows the (scoped) worst-status UPS so a problem surfaces immediately.
   const rank = { crit: 0, warn: 1, ok: 2 };
-  const primary = rows.slice().sort(
+  const primary = view.slice().sort(
     (a, b) => rank[statusClass(a.status)] - rank[statusClass(b.status)])[0];
   hero.appendChild(heroCard(primary));
 
   // Three drill-through KPI cards surfacing the v6.1 data otherwise buried on
-  // other tabs. In a fleet these summarize ACROSS all UPSes (worst battery
-  // health, total energy, worst self-test) so a second UPS is never hidden —
-  // the header is "System", not "the primary UPS". (operator #11, plan #4)
-  const multi = rows.length > 1;
+  // other tabs. Under "All UPS" they summarize ACROSS the fleet (worst battery
+  // health, total energy, worst self-test); scoped to one UPS they show its
+  // values. (operator #11, plan #4)
+  const multi = view.length > 1;
   const named = (u) => u.label || u.name;
 
   // Battery health: the lowest score in the fleet (the one that needs attention).
-  const bhRows = rows.filter((u) => u.batteryHealth && u.batteryHealth.score != null);
+  const bhRows = view.filter((u) => u.batteryHealth && u.batteryHealth.score != null);
   if (bhRows.length) {
     const worst = bhRows.slice().sort(
       (a, b) => a.batteryHealth.score - b.batteryHealth.score)[0];
@@ -514,12 +520,12 @@ function renderOverviewSummary(rows) {
   }
 
   // Energy today: the fleet total (a single UPS keeps its cost caption).
-  const enRows = rows.filter((u) => u.energy && u.energy.todayKwh != null);
+  const enRows = view.filter((u) => u.energy && u.energy.todayKwh != null);
   if (enRows.length) {
     const totalKwh = enRows.reduce((s, u) => s + u.energy.todayKwh, 0);
     let cap;
     if (multi) {
-      cap = enRows.length + " of " + rows.length + " UPS · today";
+      cap = enRows.length + " of " + view.length + " UPS · today";
     } else {
       const en = enRows[0].energy;
       cap = en.todayCostFormatted ? en.todayCostFormatted + " today"
@@ -536,7 +542,7 @@ function renderOverviewSummary(rows) {
   // Last self-test: the worst result across the fleet (failed > running > passed),
   // so a single failed test isn't masked by another UPS's pass. Only shown once
   // a test has actually run somewhere.
-  const stRows = rows.filter(
+  const stRows = view.filter(
     (u) => u.selfTest && ["passed", "failed", "running"].includes(u.selfTest.result));
   if (stRows.length) {
     const rankSt = { failed: 0, running: 1, passed: 2 };
@@ -585,45 +591,15 @@ function renderFleetStrip(rows) {
 }
 
 function renderUps(payload) {
-  const wrap = document.getElementById("ups-cards");
-  wrap.replaceChildren();
   const rows = (payload && payload.ups) || [];
   lastUpsRows = rows;
-  rows.forEach((u) => {
-    const charge = parseFloat(u.batteryCharge);
-    const barValue = isNaN(charge) ? 0 : Math.max(0, Math.min(100, charge));
-    const card = el("div", { class: "card card-click", tabindex: "0",
-      role: "button", title: "View details" }, [
-      el("div", { class: "card-title" },
-        [el("h3", { text: u.label || u.name }), monitoringBadge(u)].filter(Boolean)),
-      el("div", { class: "row" }, [
-        el("span", { text: "Status" }),
-        el("span", { class: "badge " + statusClass(u.status), text: u.status || "—" }),
-      ]),
-      el("div", { class: "row" }, [el("span", { text: "Battery" }),
-        el("b", { class: batteryClass(charge), text: isNaN(charge) ? "—" : charge + "%" })]),
-      el("meter", {
-        class: "bar " + batteryClass(charge),
-        min: "0", max: "100", value: String(barValue),
-        "aria-label": "Battery charge for " + (u.label || u.name),
-      }),
-      el("div", { class: "row" }, [el("span", { text: "Runtime" }),
-        el("b", { text: formatRuntimeSeconds(u.runtime) })]),
-      el("div", { class: "row" }, [el("span", { text: "Load" }),
-        el("b", { text: u.load != null ? u.load + "%" : "—" })]),
-    ]);
-    card.classList.add("s-" + statusClass(u.status));   // status accent rail
-    card.addEventListener("click", () => openDetail(u.name));
-    card.addEventListener("keydown", (ev) => {
-      if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); openDetail(u.name); }
-    });
-    wrap.appendChild(card);
-  });
   populateChartUpsSelects(rows);
   renderFleetStrip(rows);
-  // Single UPS → the Overview is the hero + KPI summary; the raw per-UPS card
-  // grid only appears for a fleet (multi-UPS).
-  document.getElementById("ups-section").hidden = rows.length <= 1;
+  // The per-UPS "UPS status" grid is retired — it duplicated the always-on fleet
+  // strip (every UPS at a glance, chips drill into the detail modal) and the
+  // scoped hero. Keep the section element hidden. (v6.1.4 review)
+  const upsSec = document.getElementById("ups-section");
+  if (upsSec) upsSec.hidden = true;
   renderOverviewSummary(rows);
 
   const groups = (payload && payload.redundancyGroups) || [];
@@ -3155,7 +3131,8 @@ async function renderShutdownPlan() {
 }
 
 function onTabActivated(name) {
-  if (name === "power") { renderLineQuality(); if (charts.power) charts.power.load(); }
+  if (name === "overview") renderOverviewSummary(lastUpsRows);
+  else if (name === "power") { renderLineQuality(); if (charts.power) charts.power.load(); }
   else if (name === "battery") { renderBatteryHealthTab(); if (charts.battery) charts.battery.load(); }
   else if (name === "energy") { renderEnergyTab(); if (charts.energy) charts.energy.load(); }
   else if (name === "shutdown") renderShutdownPlan();

--- a/src/eneru/web/app.js
+++ b/src/eneru/web/app.js
@@ -828,8 +828,13 @@ function batteryHealthRows(bh, opts) {
     } else {
       const cls = scoreClass(v);
       const pct = Math.max(0, Math.min(100, v));
-      value.appendChild(el("span", { class: "term-meter" },
-        [el("span", { class: "term-meter-fill " + cls, style: "width:" + pct + "%" })]));
+      // Width is set via a CSSOM custom property, NOT an inline style attribute:
+      // the dashboard's strict CSP (no style-src 'unsafe-inline') blocks the
+      // style="" attribute, which previously left every bar at its default full
+      // width — so the meters silently lied. CSSOM .style.setProperty is exempt.
+      const fill = el("span", { class: "term-meter-fill " + cls });
+      fill.style.setProperty("--w", pct + "%");
+      value.appendChild(el("span", { class: "term-meter" }, [fill]));
       value.appendChild(el("b", { class: cls, text: String(Math.round(v)) }));
     }
     rows.push(el("div", { class: "row term-row" }, [
@@ -1269,8 +1274,17 @@ function applyEventFilters() {
   const rows = visibleEvents();
   const colspan = String(3 + (signedIn ? 1 : 0) + (multi ? 1 : 0));
   if (rows.length === 0) {
-    body.appendChild(el("tr", null, [
-      el("td", { colspan, text: "No events." })]));
+    // Contextual empty state — distinguish "genuinely nothing" from "filtered
+    // out" so the operator knows whether to widen the filters. (heuristic M6)
+    const rangeSel = document.getElementById("event-range");
+    const rangeTxt = rangeSel ? rangeSel.options[rangeSel.selectedIndex].text.toLowerCase() : "range";
+    const filtered = document.getElementById("event-source-filter").value
+      || document.getElementById("event-text-filter").value.trim()
+      || document.getElementById("event-tier").value !== "power";
+    const msg = filtered
+      ? "No matching events — try a wider range or tier."
+      : "No power events in the " + rangeTxt + ".";
+    body.appendChild(el("tr", null, [el("td", { colspan, text: msg })]));
     return;
   }
   rows.forEach((e) => {
@@ -1302,6 +1316,9 @@ async function deleteSelected() {
   const chosen = visibleEvents().filter(
     (e) => selectedEvents.has(eventKey(e)) && e.id !== undefined && e.id !== null);
   if (chosen.length === 0) return;
+  // Deleting event history is irreversible — confirm first. (heuristic M7)
+  if (!window.confirm("Delete " + chosen.length + " selected event"
+      + (chosen.length === 1 ? "" : "s") + "? This can't be undone.")) return;
   // Group the chosen events by UPS name (the DELETE path is
   // /api/v1/ups/{name}/events). Every event carries BOTH a raw `ups`
   // (group.ups.name) and a sanitized `source` (the groupId that eventKey uses
@@ -2109,6 +2126,17 @@ function drawEnergyChart(hostId, rows, options) {
   // watts is a real measurement (then they genuinely differ).
   const realWatts = pts.some((p) => typeof p.watts === "number" && p.estimated === false);
   const showLoad = !wattS || realWatts;
+  // Explain the single line when watts are estimated (the Load% line is hidden
+  // because it's an identical shape), so it doesn't look like a series vanished.
+  const enote = document.getElementById("energy-note");
+  if (enote) {
+    if (wattS && !realWatts) {
+      enote.textContent = "Power is estimated from load × rated power; the Load% "
+        + "line (an identical shape) is hidden. Set energy.nominal_power for "
+        + "measured watts.";
+      enote.hidden = false;
+    } else { enote.hidden = true; enote.textContent = ""; }
+  }
 
   // Hover crosshair + readout for whichever line(s) are shown. The capture rect
   // is added now, BELOW the outage bands + event markers added next, so those
@@ -2692,7 +2720,7 @@ function renderConfigTab() {
   }
   // The (sanitized) config as a colored, collapsible tree — each section
   // expands/collapses on its own.
-  body.appendChild(el("h2", { text: "Configuration (JSON)" }));
+  body.appendChild(el("h2", { text: "Raw config (JSON)" }));
   body.appendChild(el("div", { class: "json-tree" }, [jsonNode(undefined, cfg, true)]));
 }
 

--- a/src/eneru/web/favicon.svg
+++ b/src/eneru/web/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 2 L4 14 h6 l-1 8 9-12 h-6 z" fill="#4f8cf7"/></svg>

--- a/src/eneru/web/index.html
+++ b/src/eneru/web/index.html
@@ -183,7 +183,10 @@
              aria-labelledby="tab-events" tabindex="0" hidden>
       <h2>Events</h2>
       <div class="event-filters">
-        <label>Source
+        <!-- Source is driven by the header UPS selector (no redundant second
+             dropdown); the select stays in the DOM, hidden, as the filter's
+             internal state. -->
+        <label hidden>Source
           <select id="event-source-filter">
             <option value="">All sources</option>
           </select>

--- a/src/eneru/web/index.html
+++ b/src/eneru/web/index.html
@@ -112,6 +112,7 @@
             <option value="86400" selected>Last 24 hours</option>
             <option value="604800">Last 7 days</option>
             <option value="2592000">Last 30 days</option>
+            <option value="all">All</option>
           </select>
         </label>
       </div>
@@ -145,6 +146,7 @@
             <option value="86400" selected>Last 24 hours</option>
             <option value="604800">Last 7 days</option>
             <option value="2592000">Last 30 days</option>
+            <option value="all">All</option>
           </select>
         </label>
       </div>
@@ -167,6 +169,7 @@
             <option value="86400" selected>Last 24 hours</option>
             <option value="604800">Last 7 days</option>
             <option value="2592000">Last 30 days</option>
+            <option value="all">All</option>
           </select>
         </label>
       </div>

--- a/src/eneru/web/index.html
+++ b/src/eneru/web/index.html
@@ -214,7 +214,7 @@
         <button type="button" id="event-load-older">Load older</button>
       </div>
       <table id="events" class="events">
-        <thead><tr id="events-head"><th><button id="event-sort-time" type="button" class="th-sort">Time ↑</button></th><th>Type</th><th>Detail</th></tr></thead>
+        <thead><tr id="events-head"><th><button id="event-sort-time" type="button" class="th-sort" aria-label="Sort by time, ascending" aria-pressed="true">Time ↑</button></th><th>Type</th><th>Detail</th></tr></thead>
         <tbody></tbody>
       </table>
     </section>
@@ -251,8 +251,9 @@
 
   <!-- Login dialog -->
   <div id="login-modal" class="modal" hidden>
-    <form id="login-form" class="modal-card">
-      <h3>Sign in</h3>
+    <form id="login-form" class="modal-card" role="dialog" aria-modal="true"
+          aria-labelledby="login-title">
+      <h3 id="login-title">Sign in</h3>
       <label>Username <input id="login-user" autocomplete="username"></label>
       <label>Password <input id="login-pass" type="password" autocomplete="current-password"></label>
       <div class="modal-actions">
@@ -268,7 +269,9 @@
     <div class="modal-card detail-card" role="dialog" aria-modal="true" aria-labelledby="detail-title">
       <div class="modal-head">
         <h3 id="detail-title">UPS details</h3>
-        <button type="button" id="detail-close" aria-label="Close">✕</button>
+        <button type="button" id="detail-close" aria-label="Close">
+          <svg class="ic" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12 M18 6 6 18"/></svg>
+        </button>
       </div>
       <div id="detail-body"></div>
     </div>

--- a/src/eneru/web/index.html
+++ b/src/eneru/web/index.html
@@ -13,6 +13,12 @@
   <header>
     <h1><svg class="ic brand-bolt" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 3 6 13h5l-1 8 8-11h-5z"/></svg>Eneru</h1>
     <div id="authbox" class="authbox">
+      <!-- Global UPS scope: drives Power/Battery/Energy/Shutdown + the scoped
+           Overview/Battery/Energy cards. "All UPS" keeps the fleet comparison.
+           Hidden for single-UPS deployments (wired in app.js). -->
+      <label class="ups-scope" id="global-ups-wrap" hidden>UPS
+        <select id="global-ups" aria-label="UPS to show"></select>
+      </label>
       <label class="theme-pick">Theme
         <select id="theme-select" aria-label="Color theme">
           <option value="system">System</option>
@@ -31,6 +37,15 @@
   <!-- Tab bar (Nutify-style). Real ARIA tabs: arrow-key nav + hash sync wired in
        app.js, which also prepends each tab's inline-SVG icon (see TAB_ICONS).
        The Control tab is hidden until authenticated + nut_control. -->
+  <!-- Persistent fleet-status strip: every UPS at-a-glance on every tab, so a
+       second UPS is never below the fold during an outage. Hidden for a
+       single-UPS deployment (wired in app.js). -->
+  <div id="fleet-strip" class="fleet-strip" role="status"
+       aria-label="Fleet status" hidden></div>
+
+  <!-- Tab order: scoped telemetry tabs first (driven by the global UPS
+       selector), then the unscoped tail (Events has its own filter, Config is
+       fleet-wide) after a divider. -->
   <nav id="tabs" class="tabs" role="tablist" aria-label="Dashboard sections">
     <button class="tab" role="tab" id="tab-overview" data-tab="overview"
             aria-controls="panel-overview" aria-selected="true">Overview</button>
@@ -40,12 +55,13 @@
             aria-controls="panel-battery" aria-selected="false" tabindex="-1">Battery</button>
     <button class="tab" role="tab" id="tab-energy" data-tab="energy"
             aria-controls="panel-energy" aria-selected="false" tabindex="-1">Energy</button>
-    <button class="tab" role="tab" id="tab-events" data-tab="events"
-            aria-controls="panel-events" aria-selected="false" tabindex="-1">Events</button>
     <button class="tab" role="tab" id="tab-control" data-tab="control"
             aria-controls="panel-control" aria-selected="false" tabindex="-1" hidden>Control</button>
     <button class="tab" role="tab" id="tab-shutdown" data-tab="shutdown"
             aria-controls="panel-shutdown" aria-selected="false" tabindex="-1">Shutdown</button>
+    <span class="tab-divider" aria-hidden="true"></span>
+    <button class="tab" role="tab" id="tab-events" data-tab="events"
+            aria-controls="panel-events" aria-selected="false" tabindex="-1">Events</button>
     <button class="tab" role="tab" id="tab-config" data-tab="config"
             aria-controls="panel-config" aria-selected="false" tabindex="-1">Config</button>
   </nav>

--- a/src/eneru/web/index.html
+++ b/src/eneru/web/index.html
@@ -40,8 +40,9 @@
   <!-- Persistent fleet-status strip: every UPS at-a-glance on every tab, so a
        second UPS is never below the fold during an outage. Hidden for a
        single-UPS deployment (wired in app.js). -->
-  <div id="fleet-strip" class="fleet-strip" role="status"
-       aria-label="Fleet status" hidden></div>
+  <!-- Not role=status: it's rebuilt every 10s poll, so a live region would
+       re-announce the whole fleet each cycle. The #banner is the live alarm. -->
+  <div id="fleet-strip" class="fleet-strip" aria-label="Fleet status" hidden></div>
 
   <!-- Tab order: scoped telemetry tabs first (driven by the global UPS
        selector), then the unscoped tail (Events has its own filter, Config is

--- a/src/eneru/web/index.html
+++ b/src/eneru/web/index.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Eneru</title>
-  <!-- Inline ⚡ favicon (a lightning-bolt path, so it renders without an emoji
-       font and needs no extra packaged asset). -->
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13 2 L4 14 h6 l-1 8 9-12 h-6 z' fill='%234f8cf7'/%3E%3C/svg%3E">
+  <!-- Packaged ⚡ favicon served same-origin. A data: URL was blocked by the
+       strict CSP (img-src falls back to default-src 'self', which forbids data:). -->
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
@@ -170,6 +170,7 @@
         </label>
       </div>
       <div id="energy-graph" class="graph"></div>
+      <p class="chart-note" id="energy-note" hidden></p>
       <p class="chart-note" id="energy-events-note" hidden></p>
     </section>
 

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -259,6 +259,9 @@ select, input:not([type="checkbox"]) { background: var(--panel-2); color: var(--
 .graph .lbl { fill: var(--muted); font-size: 11px; }
 .graph .chart-title { fill: var(--muted); font-size: 11px; font-weight: 600;
                       letter-spacing: 0.03em; }
+/* Live value/min/max/time readout, top-right of a chart (updates on hover). */
+.graph .chart-readout { fill: var(--text); font-size: 12px; font-weight: 600;
+                        font-variant-numeric: tabular-nums; }
 .events { width: 100%; border-collapse: collapse; font-size: 0.9rem;
   table-layout: fixed; }
 .events th, .events td { text-align: left; padding: 0.4rem 0.6rem;
@@ -509,7 +512,8 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 .graph .grid, .graph .axis, .graph .area, .graph .plot, .graph .plot-load,
 .graph .plot-watts, .graph .plot-band, .graph .plot-band-watts,
 .graph .plot-band-load, .graph .now-dot, .graph .band,
-.graph .band-edge, .graph .band-nominal, .graph .chart-title { pointer-events: none; }
+.graph .band-edge, .graph .band-nominal, .graph .chart-title,
+.graph .chart-readout { pointer-events: none; }
 .graph .ev-line { stroke-width: 1; opacity: 0.12; }
 .graph .ev-hit { stroke: transparent; stroke-width: 11; }
 /* Hover crosshair: a transparent capture rect over the plot area drives a
@@ -537,6 +541,11 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
   background: var(--accent-weak); border: 1px solid var(--line);
   font-size: 0.9rem; }
 .sd-trigger .ic { width: 16px; height: 16px; color: var(--muted); flex: none; }
+/* Monitoring-only UPS: no shutdown sequence — a calm, informative note. */
+.sd-noop { display: flex; align-items: center; gap: 0.5rem; margin: 0.3rem 0 0.9rem;
+  padding: 0.7rem 0.9rem; border-radius: var(--r-md); background: var(--accent-weak);
+  border: 1px solid var(--line); font-size: 0.95rem; }
+.sd-noop .ic { width: 18px; height: 18px; color: var(--muted); flex: none; }
 .sd-flow { display: flex; flex-direction: column; margin-top: 0.5rem; }
 .sd-node { position: relative; border: 1px solid var(--line-strong);
   border-radius: var(--r-md); background: var(--panel); padding: 0.85rem 1rem;

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -344,6 +344,36 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 /* Keep a visible focus indicator on a focused panel for keyboard users. */
 .panel:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px;
                        border-radius: 6px; }
+/* Divider between the scoped telemetry tabs and the unscoped tail (Events/Config). */
+.tab-divider { align-self: stretch; width: 1px; margin: 0.4rem 0.5rem;
+  background: var(--line); }
+
+/* ----- Global UPS scope + fleet-status strip (v6.1.4) -------------------- */
+/* Header UPS scope selector; dimmed on tabs it doesn't affect (Events/Config). */
+.ups-scope { display: inline-flex; align-items: center; gap: 0.35rem;
+  color: var(--muted); font-size: 0.85rem; }
+.ups-scope select { font: inherit; }
+.ups-scope.inactive { opacity: 0.45; }
+/* Persistent fleet-status strip: chips, one per UPS, on every tab. */
+.fleet-strip { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;
+  padding: 0.5rem 1.25rem; max-width: 1100px; margin: 0 auto;
+  box-sizing: content-box; }
+.fleet-chip { display: inline-flex; align-items: center; gap: 0.45rem;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 999px;
+  padding: 0.25rem 0.7rem; cursor: pointer; font: inherit; color: var(--text); }
+.fleet-chip:hover { border-color: var(--accent); }
+.fleet-chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.fleet-chip.s-warn { border-color: var(--warn); }
+.fleet-chip.s-crit { border-color: var(--crit); }
+.fleet-name { font-weight: 600; }
+.fleet-metric { color: var(--muted); font-size: 0.85rem;
+  font-variant-numeric: tabular-nums; }
+.fleet-tag { color: var(--muted); font-size: 0.72rem; text-transform: uppercase;
+  letter-spacing: 0.04em; }
+/* Card header title row (title + optional badge, e.g. "monitoring only"). */
+.card-title { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.card-title h3 { margin: 0; }
+.mon-badge { font-size: 0.72rem; }
 .panel > h2:first-child { margin-top: 0; }
 
 /* Widget cards with a title + status badge (Battery / Energy tabs). The base

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -307,7 +307,8 @@ footer { padding: 0.6rem 1.25rem; color: var(--muted); font-size: 0.85rem;
 .term-value { display: inline-flex; align-items: center; gap: 0.5rem; }
 .term-meter { display: inline-block; width: 56px; height: 6px; border-radius: 3px;
   background: var(--line-strong); overflow: hidden; }
-.term-meter-fill { display: block; height: 100%; background: var(--muted); }
+.term-meter-fill { display: block; height: 100%; width: var(--w, 0%);
+  background: var(--muted); }
 .term-meter-fill.ok { background: var(--ok); }
 .term-meter-fill.warn { background: var(--warn); }
 .term-meter-fill.crit { background: var(--crit); }

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -374,6 +374,10 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 .card-title { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
 .card-title h3 { margin: 0; }
 .mon-badge { font-size: 0.72rem; }
+/* Stacked shutdown plans ("All UPS" compares every plan). */
+.sd-plan + .sd-plan { border-top: 1px solid var(--line); margin-top: 1.5rem;
+  padding-top: 1rem; }
+.sd-plan-title { margin: 0.25rem 0 0.75rem; }
 .panel > h2:first-child { margin-top: 0; }
 
 /* Widget cards with a title + status badge (Battery / Energy tabs). The base

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -328,6 +328,8 @@ footer { padding: 0.6rem 1.25rem; color: var(--muted); font-size: 0.85rem;
 .term-meter-fill.ok { background: var(--ok); }
 .term-meter-fill.warn { background: var(--warn); }
 .term-meter-fill.crit { background: var(--crit); }
+/* Actual battery age shown beside the age sub-score so "0" reads as "old". */
+.term-age { color: var(--muted); font-size: 0.85em; white-space: nowrap; }
 .graph .area.bh { fill: var(--accent-weak); }
 meter.bar.ok::-webkit-meter-optimum-value { background: var(--ok); }
 meter.bar.warn::-webkit-meter-optimum-value { background: var(--warn); }

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -369,11 +369,16 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
   background: var(--line); }
 
 /* ----- Global UPS scope + fleet-status strip (v6.1.4) -------------------- */
-/* Header UPS scope selector; dimmed on tabs it doesn't affect (Events/Config). */
-.ups-scope { display: inline-flex; align-items: center; gap: 0.35rem;
-  color: var(--muted); font-size: 0.85rem; }
-.ups-scope select { font: inherit; }
-.ups-scope.inactive { opacity: 0.45; }
+/* Header UPS scope selector — the primary scope control, so it reads as a
+   distinct pill (not another muted 'Theme'-style dropdown); dimmed a touch on
+   the tabs it doesn't affect (Events/Config), with a tooltip explaining why. */
+.ups-scope { display: inline-flex; align-items: center; gap: 0.4rem;
+  color: var(--text); font-size: 0.9rem; font-weight: 600;
+  background: var(--accent-weak); border: 1px solid rgba(var(--accent-rgb), 0.35);
+  border-radius: var(--r-pill); padding: 0.15rem 0.7rem; }
+.ups-scope select { font: inherit; font-weight: 600; color: var(--accent);
+  background: transparent; border: 0; cursor: pointer; }
+.ups-scope.inactive { opacity: 0.55; }
 /* Persistent fleet-status strip: chips, one per UPS, on every tab. */
 .fleet-strip { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;
   padding: 0.5rem 1.25rem; max-width: 1100px; margin: 0 auto;

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -199,6 +199,8 @@ select:focus-visible, input:not([type="checkbox"]):focus-visible {
 .graph .plot { fill: none; stroke: var(--accent); stroke-width: 2;
   stroke-linejoin: round; stroke-linecap: round; }
 .graph .area { stroke: none; }
+/* HA-style statistics band: translucent min–max envelope behind the mean line. */
+.graph .plot-band { fill: rgba(var(--accent-rgb), 0.16); stroke: none; }
 .graph .now-dot { fill: var(--accent); stroke: var(--panel); stroke-width: 2; }
 .graph .now-dot.s-warn { fill: var(--warn); }
 .graph .now-dot.s-crit { fill: var(--crit); }
@@ -410,6 +412,8 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
   font-variant-numeric: tabular-nums; }
 .fleet-tag { color: var(--muted); font-size: 0.72rem; text-transform: uppercase;
   letter-spacing: 0.04em; }
+.fleet-go { color: var(--muted); font-size: 1.1rem; line-height: 1; margin-left: 0.1rem; }
+.fleet-chip:hover .fleet-go { color: var(--accent); }
 /* Card header title row (title + optional badge, e.g. "monitoring only"). */
 .card-title { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
 .card-title h3 { margin: 0; }
@@ -501,8 +505,8 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
    used to swallow pointer events over the lower part of the guide, so the
    tooltip only appeared when hovering above the plotted data. */
 .graph .grid, .graph .axis, .graph .area, .graph .plot, .graph .plot-load,
-.graph .plot-watts, .graph .now-dot, .graph .band, .graph .band-edge,
-.graph .band-nominal, .graph .chart-title { pointer-events: none; }
+.graph .plot-watts, .graph .plot-band, .graph .now-dot, .graph .band,
+.graph .band-edge, .graph .band-nominal, .graph .chart-title { pointer-events: none; }
 .graph .ev-line { stroke-width: 1; opacity: 0.12; }
 .graph .ev-hit { stroke: transparent; stroke-width: 11; }
 /* Hover crosshair: a transparent capture rect over the plot area drives a

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -83,11 +83,13 @@ h2 { font-size: 0.8125rem; color: var(--muted); text-transform: uppercase;
 .card .row b { color: var(--text-2); font-weight: 600;
   font-variant-numeric: tabular-nums; }
 /* Status shown ONCE per card: a 2px accent strip on top (not green-on-everything). */
-.card.s-ok::before, .card.s-warn::before, .card.s-crit::before {
+.card.s-ok::before, .card.s-warn::before, .card.s-crit::before,
+.card.s-muted::before {
   content: ""; position: absolute; inset: 0 0 auto 0; height: 2px; }
 .card.s-ok::before   { background: var(--ok); }
 .card.s-warn::before { background: var(--warn); }
 .card.s-crit::before { background: var(--crit); }
+.card.s-muted::before { background: var(--muted); }
 
 /* ===== rc9 redesign components =================================== */
 
@@ -107,6 +109,7 @@ h2 { font-size: 0.8125rem; color: var(--muted); text-transform: uppercase;
 .card-ico.s-ok { background: var(--ok-weak); color: var(--ok); }
 .card-ico.s-warn { background: var(--warn-weak); color: var(--warn); }
 .card-ico.s-crit { background: var(--crit-weak); color: var(--crit); }
+.card-ico.s-muted { background: rgba(148,163,184,0.16); color: var(--muted); }
 
 /* Clickable cards (overview summary / UPS cards): lift on hover. */
 .card-click { cursor: pointer; }
@@ -193,6 +196,7 @@ select:focus-visible, input:not([type="checkbox"]):focus-visible {
 .badge.warn { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge.crit { background: rgba(255,92,92,0.15); color: var(--crit); }
 .badge.info { background: rgba(167,139,250,0.16); color: #a78bfa; }
+.badge.muted { background: rgba(148,163,184,0.16); color: var(--muted); }
 /* Events-table Type cell: icon-led severity badge (matches chart marker color) */
 .ev-badge { display: inline-flex; align-items: center; gap: 0.35rem;
   padding: 0.12rem 0.55rem; border-radius: 999px; font-size: 0.8rem;

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -7,13 +7,15 @@
   --panel-2: #1e222c;
   --text: #e7eaf0;
   --text-2: #c2c8d4;
-  --muted: #99a2b2;
+  --muted: #a8b2c2;
   --accent: #5b93f7;
   --accent-rgb: 91,147,247;
   --on-accent: #0b0e13;
-  --ok: #4ccb6e;   --ok-rgb: 76,203,110;
-  --warn: #e7a13a; --warn-rgb: 231,161,58;
-  --crit: #ef5b5b; --crit-rgb: 239,91,91;
+  /* Dark-mode status colors brightened to clear WCAG AA (4.5:1) on --bg; light
+     theme re-pins the original hues below (they read better on white). */
+  --ok: #5fdb7e;   --ok-rgb: 95,219,126;
+  --warn: #f0b940; --warn-rgb: 240,185,64;
+  --crit: #ff6b6b; --crit-rgb: 255,107,107;
   --line: #262b36;
   --line-strong: #313845;
   --grid: rgba(255,255,255,0.09);
@@ -36,6 +38,9 @@
     --bg: #f6f7f9; --panel: #ffffff; --panel-2: #f0f2f6; --text: #161a22;
     --text-2: #2f3744; --muted: #5b6473; --accent: #2563eb; --accent-rgb: 37,99,235;
     --on-accent: #ffffff; --line: #e6e9ef; --line-strong: #dde1e9;
+    --ok: #1f9d55;   --ok-rgb: 31,157,85;
+    --warn: #b0730a; --warn-rgb: 176,115,10;
+    --crit: #d64545; --crit-rgb: 214,69,69;
     --grid: rgba(15,20,30,0.10);
     --shadow-sm: 0 1px 2px rgba(15,20,30,0.05);
     --shadow-md: 0 4px 16px -6px rgba(15,20,30,0.14);
@@ -46,6 +51,9 @@
   --bg: #f6f7f9; --panel: #ffffff; --panel-2: #f0f2f6; --text: #161a22;
   --text-2: #2f3744; --muted: #5b6473; --accent: #2563eb; --accent-rgb: 37,99,235;
   --on-accent: #ffffff; --line: #e6e9ef; --line-strong: #dde1e9;
+  --ok: #1f9d55;   --ok-rgb: 31,157,85;
+  --warn: #b0730a; --warn-rgb: 176,115,10;
+  --crit: #d64545; --crit-rgb: 214,69,69;
   --grid: rgba(15,20,30,0.10);
   --shadow-sm: 0 1px 2px rgba(15,20,30,0.05);
   --shadow-md: 0 4px 16px -6px rgba(15,20,30,0.14);
@@ -316,11 +324,16 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 
 /* UPS detail modal */
 .detail-card { width: min(560px, 94vw); max-height: 85vh; overflow: auto; }
-.modal-head { display: flex; align-items: center; justify-content: space-between; }
+/* Keep the title + close button pinned so ✕ is always reachable on a long,
+   scrolled modal (a monitoring-only UPS's detail runs past the fold). */
+.modal-head { display: flex; align-items: center; justify-content: space-between;
+  position: sticky; top: 0; background: var(--panel); padding-bottom: 0.5rem;
+  z-index: 1; }
 .modal-head h3 { margin: 0; }
 .modal-head button { background: var(--panel-2); color: var(--text);
                      border: 1px solid var(--line); }
 .detail-section { margin-top: 0.5rem; }
+@media (max-width: 480px) { .detail-card { width: 96vw; } }
 .detail-section h4 { margin: 0 0 0.3rem; color: var(--muted); font-size: 0.8rem;
                      text-transform: uppercase; letter-spacing: 0.04em; }
 .detail-section .row { display: flex; justify-content: space-between;
@@ -341,7 +354,7 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 }
 .tab:hover { color: var(--text); }
 .tab[aria-selected="true"] { color: var(--accent); border-bottom-color: var(--accent); }
-.tab:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 /* Inline-SVG tab icons inherit currentColor → muted, brightening to accent when
    the tab is selected (no emoji font dependency). */
 .tab { display: inline-flex; align-items: center; gap: 0.4rem; }
@@ -417,7 +430,8 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
   background: var(--panel-2); color: var(--muted); font-size: 0.7rem;
   font-weight: 700; line-height: 1; cursor: help; user-select: none; }
 .help:hover, .help:focus-visible { background: var(--accent-weak);
-  color: var(--accent); outline: none; }
+  color: var(--accent); }
+.help:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 /* Config tab: colored, collapsible JSON tree (each section folds on its own) */
 .json-tree { background: var(--panel); border: 1px solid var(--line);
@@ -540,4 +554,22 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
   .authbox { flex-wrap: wrap; }
   .tabs { padding: 0 0.5rem; }
   .tab { padding: 0.5rem 0.6rem; }
+}
+/* Narrow phones: scroll the tab bar horizontally instead of wrapping the 7 tabs
+   into a ragged block; keep the divider from collapsing. (a11y #13) */
+@media (max-width: 500px) {
+  .tabs { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch;
+    gap: 0; }
+  .tab { flex: 0 0 auto; font-size: 0.85rem; }
+  .tab-divider { display: none; }
+  .fleet-strip { overflow-x: auto; flex-wrap: nowrap; }
+  .fleet-chip { flex: 0 0 auto; }
+}
+/* Respect reduced-motion: drop card lifts, ring sweeps, and other transitions
+   for users who ask for it. (a11y #6) */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important; animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important; scroll-behavior: auto !important;
+  }
 }

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -16,7 +16,7 @@
   --crit: #ef5b5b; --crit-rgb: 239,91,91;
   --line: #262b36;
   --line-strong: #313845;
-  --grid: rgba(255,255,255,0.05);
+  --grid: rgba(255,255,255,0.09);
   /* tinted status/accent surfaces */
   --accent-weak: rgba(var(--accent-rgb), 0.14);
   --ok-weak:   rgba(var(--ok-rgb), 0.13);
@@ -36,7 +36,7 @@
     --bg: #f6f7f9; --panel: #ffffff; --panel-2: #f0f2f6; --text: #161a22;
     --text-2: #2f3744; --muted: #5b6473; --accent: #2563eb; --accent-rgb: 37,99,235;
     --on-accent: #ffffff; --line: #e6e9ef; --line-strong: #dde1e9;
-    --grid: rgba(15,20,30,0.06);
+    --grid: rgba(15,20,30,0.10);
     --shadow-sm: 0 1px 2px rgba(15,20,30,0.05);
     --shadow-md: 0 4px 16px -6px rgba(15,20,30,0.14);
     --shadow-lg: 0 16px 40px -14px rgba(15,20,30,0.22);
@@ -46,7 +46,7 @@
   --bg: #f6f7f9; --panel: #ffffff; --panel-2: #f0f2f6; --text: #161a22;
   --text-2: #2f3744; --muted: #5b6473; --accent: #2563eb; --accent-rgb: 37,99,235;
   --on-accent: #ffffff; --line: #e6e9ef; --line-strong: #dde1e9;
-  --grid: rgba(15,20,30,0.06);
+  --grid: rgba(15,20,30,0.10);
   --shadow-sm: 0 1px 2px rgba(15,20,30,0.05);
   --shadow-md: 0 4px 16px -6px rgba(15,20,30,0.14);
   --shadow-lg: 0 16px 40px -14px rgba(15,20,30,0.22);
@@ -526,10 +526,13 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 .sd-step-detail { color: var(--muted); font-size: 0.78rem; margin-top: 0.15rem; }
 
 /* Energy dual-line chart: load% (kindred accent, translucent) + power (W). */
-.graph .plot-load { stroke: var(--accent); opacity: 0.45; fill: none; }
-.graph .plot-watts { stroke: var(--ok); fill: none; }
+/* Data series use a categorical palette (accent blue + violet), NOT the status
+   green — a power line drawn in "good green" misreads, and status hues are
+   reserved for status. Full opacity so identity isn't carried by transparency. */
+.graph .plot-load { stroke: var(--accent); fill: none; }
+.graph .plot-watts { stroke: #a78bfa; fill: none; }
 .graph rect.plot-load { stroke: none; fill: var(--accent); opacity: 0.55; }
-.graph rect.plot-watts { stroke: none; fill: var(--ok); }
+.graph rect.plot-watts { stroke: none; fill: #a78bfa; }
 
 @media (max-width: 640px) {
   .var-form { grid-template-columns: 1fr; }

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -16,6 +16,7 @@
   --ok: #5fdb7e;   --ok-rgb: 95,219,126;
   --warn: #f0b940; --warn-rgb: 240,185,64;
   --crit: #ff6b6b; --crit-rgb: 255,107,107;
+  --watts: #b794ff;   /* 2nd data series (power) — distinct from accent blue */
   --line: #262b36;
   --line-strong: #313845;
   --grid: rgba(255,255,255,0.09);
@@ -41,6 +42,7 @@
     --ok: #1f9d55;   --ok-rgb: 31,157,85;
     --warn: #b0730a; --warn-rgb: 176,115,10;
     --crit: #d64545; --crit-rgb: 214,69,69;
+    --watts: #6d28d9;
     --grid: rgba(15,20,30,0.10);
     --shadow-sm: 0 1px 2px rgba(15,20,30,0.05);
     --shadow-md: 0 4px 16px -6px rgba(15,20,30,0.14);
@@ -54,6 +56,7 @@
   --ok: #1f9d55;   --ok-rgb: 31,157,85;
   --warn: #b0730a; --warn-rgb: 176,115,10;
   --crit: #d64545; --crit-rgb: 214,69,69;
+    --watts: #6d28d9;
   --grid: rgba(15,20,30,0.10);
   --shadow-sm: 0 1px 2px rgba(15,20,30,0.05);
   --shadow-md: 0 4px 16px -6px rgba(15,20,30,0.14);
@@ -87,9 +90,12 @@ h2 { font-size: 0.8125rem; color: var(--muted); text-transform: uppercase;
   transition: transform .14s ease, box-shadow .14s ease, border-color .14s ease; }
 .card h3 { margin: 0 0 0.6rem; font-size: 1rem; font-weight: 600; }
 .card .row { display: flex; justify-content: space-between; padding: 0.18rem 0;
-  color: var(--muted); font-size: 0.9375rem; }
+  gap: 0.25rem 1rem; color: var(--muted); font-size: 0.9375rem; }
 .card .row b { color: var(--text-2); font-weight: 600;
   font-variant-numeric: tabular-nums; }
+/* Only the row's DIRECT value (e.g. a long config host) may wrap; the numeric
+   <b> nested inside a term meter must NOT (else "100" broke to "10"/"0"). */
+.card .row > b { min-width: 0; text-align: right; overflow-wrap: anywhere; }
 /* Status shown ONCE per card: a 2px accent strip on top (not green-on-everything). */
 .card.s-ok::before, .card.s-warn::before, .card.s-crit::before,
 .card.s-muted::before {
@@ -210,7 +216,7 @@ select:focus-visible, input:not([type="checkbox"]):focus-visible {
 .badge.warn { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge.crit { background: rgba(255,92,92,0.15); color: var(--crit); }
 .badge.info { background: rgba(167,139,250,0.16); color: #a78bfa; }
-.badge.muted { background: rgba(148,163,184,0.16); color: var(--muted); }
+.badge.muted { background: rgba(148,163,184,0.22); color: var(--text-2); }
 /* Events-table Type cell: icon-led severity badge (matches chart marker color) */
 .ev-badge { display: inline-flex; align-items: center; gap: 0.35rem;
   padding: 0.12rem 0.55rem; border-radius: 999px; font-size: 0.8rem;
@@ -249,8 +255,11 @@ select, input:not([type="checkbox"]) { background: var(--panel-2); color: var(--
 .graph .lbl { fill: var(--muted); font-size: 11px; }
 .graph .chart-title { fill: var(--muted); font-size: 11px; font-weight: 600;
                       letter-spacing: 0.03em; }
-.events { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-.events th, .events td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--line); }
+.events { width: 100%; border-collapse: collapse; font-size: 0.9rem;
+  table-layout: fixed; }
+.events th, .events td { text-align: left; padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--line);
+  overflow-wrap: anywhere; word-break: break-word; }
 .events th { color: var(--muted); font-weight: 600; }
 .th-sort { appearance: none; border: 0; background: transparent; color: inherit; font: inherit; font-weight: 600; padding: 0; cursor: pointer; }
 .th-sort:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -376,9 +385,15 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
   color: var(--text); font-size: 0.9rem; font-weight: 600;
   background: var(--accent-weak); border: 1px solid rgba(var(--accent-rgb), 0.35);
   border-radius: var(--r-pill); padding: 0.15rem 0.7rem; }
-.ups-scope select { font: inherit; font-weight: 600; color: var(--accent);
+.ups-scope select { font: inherit; font-weight: 600; color: var(--text);
   background: transparent; border: 0; cursor: pointer; }
-.ups-scope.inactive { opacity: 0.55; }
+.ups-scope.inactive { opacity: 0.6; }
+/* Windows High Contrast / forced-colors: don't rely on the accent-weak fill —
+   draw a real border and use system colors. */
+@media (forced-colors: active) {
+  .ups-scope { border: 1px solid CanvasText; background: Canvas; }
+  .fleet-chip { border: 1px solid CanvasText; }
+}
 /* Persistent fleet-status strip: chips, one per UPS, on every tab. */
 .fleet-strip { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;
   padding: 0.5rem 1.25rem; max-width: 1100px; margin: 0 auto;
@@ -427,7 +442,7 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 .tip.ev-ok   { border-left-color: var(--ok); }
 .tip.ev-warn { border-left-color: var(--warn); }
 .tip.ev-crit { border-left-color: var(--crit); }
-.tip.ev-info { border-left-color: #a78bfa; }
+.tip.ev-info { border-left-color: #14b8a6; }
 
 /* "?" help hint — reveals a tooltip on hover/focus (replaces verbose footnotes). */
 .label-tip { display: inline-flex; align-items: center; }
@@ -504,7 +519,7 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 .graph .ev-crit { stroke: var(--crit); fill: var(--crit); }   /* outage / danger */
 .graph .ev-warn { stroke: var(--warn); fill: var(--warn); }   /* over-voltage / overload */
 .graph .ev-ok   { stroke: var(--ok);   fill: var(--ok); }     /* power restored / recovered */
-.graph .ev-info { stroke: #a78bfa; fill: #a78bfa; }           /* other — violet, not the plot blue */
+.graph .ev-info { stroke: #14b8a6; fill: #14b8a6; }           /* info — teal, distinct from the violet power line */
 
 /* Shutdown plan: an ordered top-to-bottom flow with a connector between phases.
    Parallel phases lay their steps out side by side; skipped phases are muted. */
@@ -550,9 +565,9 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
    green — a power line drawn in "good green" misreads, and status hues are
    reserved for status. Full opacity so identity isn't carried by transparency. */
 .graph .plot-load { stroke: var(--accent); fill: none; }
-.graph .plot-watts { stroke: #a78bfa; fill: none; }
+.graph .plot-watts { stroke: var(--watts); fill: none; stroke-dasharray: 6 3; }
 .graph rect.plot-load { stroke: none; fill: var(--accent); opacity: 0.55; }
-.graph rect.plot-watts { stroke: none; fill: #a78bfa; }
+.graph rect.plot-watts { stroke: none; fill: var(--watts); }
 
 @media (max-width: 640px) {
   .var-form { grid-template-columns: 1fr; }

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -134,6 +134,12 @@ h2 { font-size: 0.8125rem; color: var(--muted); text-transform: uppercase;
 .hero-vitals .v-label { color: var(--muted); font-size: 0.8125rem; }
 .hero-vitals .v-value { font-size: 1.15rem; font-weight: 700; letter-spacing: -0.01em;
   font-variant-numeric: tabular-nums; }
+.hero-vitals .v-value.warn { color: var(--warn); }
+.hero-vitals .v-value.crit { color: var(--crit); }
+/* Outage urgency: an on-battery hero tints amber and carries a prominent
+   ON BATTERY · <time> chip so a live outage never reads as a calm green ring. */
+.hero.hero-alarm { background: var(--warn-weak); }
+.hero-ob { margin-left: 0.25rem; }
 @media (max-width: 560px) { .hero { grid-template-columns: 1fr; text-align: center; } }
 
 /* Battery ring gauge (SVG). */
@@ -482,11 +488,13 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
 
 /* Shutdown plan: an ordered top-to-bottom flow with a connector between phases.
    Parallel phases lay their steps out side by side; skipped phases are muted. */
+/* Descriptive ("this is what triggers a shutdown"), so neutral/info — not the
+   amber alarm styling it used to have, which cried wolf on every load. */
 .sd-trigger { display: flex; align-items: center; gap: 0.5rem;
   margin: 0.3rem 0 0.9rem; padding: 0.6rem 0.85rem; border-radius: var(--r-md);
-  background: var(--warn-weak); border: 1px solid rgba(var(--warn-rgb), 0.4);
+  background: var(--accent-weak); border: 1px solid var(--line);
   font-size: 0.9rem; }
-.sd-trigger .ic { width: 16px; height: 16px; color: var(--warn); flex: none; }
+.sd-trigger .ic { width: 16px; height: 16px; color: var(--muted); flex: none; }
 .sd-flow { display: flex; flex-direction: column; margin-top: 0.5rem; }
 .sd-node { position: relative; border: 1px solid var(--line-strong);
   border-radius: var(--r-md); background: var(--panel); padding: 0.85rem 1rem;

--- a/src/eneru/web/style.css
+++ b/src/eneru/web/style.css
@@ -201,6 +201,8 @@ select:focus-visible, input:not([type="checkbox"]):focus-visible {
 .graph .area { stroke: none; }
 /* HA-style statistics band: translucent min–max envelope behind the mean line. */
 .graph .plot-band { fill: rgba(var(--accent-rgb), 0.16); stroke: none; }
+.graph .plot-band-watts { fill: var(--watts); opacity: 0.16; stroke: none; }
+.graph .plot-band-load { fill: var(--accent); opacity: 0.14; stroke: none; }
 .graph .now-dot { fill: var(--accent); stroke: var(--panel); stroke-width: 2; }
 .graph .now-dot.s-warn { fill: var(--warn); }
 .graph .now-dot.s-crit { fill: var(--crit); }
@@ -505,7 +507,8 @@ meter.bar.crit::-moz-meter-bar { background: var(--crit); }
    used to swallow pointer events over the lower part of the guide, so the
    tooltip only appeared when hovering above the plotted data. */
 .graph .grid, .graph .axis, .graph .area, .graph .plot, .graph .plot-load,
-.graph .plot-watts, .graph .plot-band, .graph .now-dot, .graph .band,
+.graph .plot-watts, .graph .plot-band, .graph .plot-band-watts,
+.graph .plot-band-load, .graph .now-dot, .graph .band,
 .graph .band-edge, .graph .band-nominal, .graph .chart-title { pointer-events: none; }
 .graph .ev-line { stroke-width: 1; opacity: 0.12; }
 .graph .ev-hit { stroke: transparent; stroke-width: 11; }

--- a/tests/test_api_control.py
+++ b/tests/test_api_control.py
@@ -341,8 +341,8 @@ def test_store_for_ups_resolves_monitor(minimal_config):
 def test_run_self_test_issues(minimal_config, monkeypatch):
     _enable(minimal_config)
     minimal_config.nut_control.allowed_commands = ["test.battery.start"]
-    monkeypatch.setattr(apimod.selftest, "discover_self_test_command",
-                        lambda *a, **k: "test.battery.start")
+    monkeypatch.setattr(apimod.selftest, "list_supported_commands",
+                        lambda *a, **k: ["test.battery.start"])
     monkeypatch.setattr(apimod.selftest, "issue_self_test",
                         lambda *a, **k: {"ok": True, "test_id": 5, "error": ""})
     logs = []
@@ -363,8 +363,8 @@ def test_run_self_test_503_without_open_store(minimal_config, monkeypatch, store
     # missing store (None) and the present-but-closed store (_conn is None).
     _enable(minimal_config)
     minimal_config.nut_control.allowed_commands = ["test.battery.start"]
-    monkeypatch.setattr(apimod.selftest, "discover_self_test_command",
-                        lambda *a, **k: "test.battery.start")
+    monkeypatch.setattr(apimod.selftest, "list_supported_commands",
+                        lambda *a, **k: ["test.battery.start"])
     monkeypatch.setattr(apimod.selftest, "issue_self_test",
                         lambda *a, **k: pytest.fail("must not issue without a store"))
     if store == "closed":
@@ -384,8 +384,11 @@ def test_run_self_test_503_without_open_store(minimal_config, monkeypatch, store
 def test_run_self_test_unsupported_422(minimal_config, monkeypatch):
     _enable(minimal_config)
     minimal_config.nut_control.allowed_commands = ["test.battery.start"]
-    monkeypatch.setattr(apimod.selftest, "discover_self_test_command",
-                        lambda *a, **k: None)   # not exposed by the UPS
+    # The UPS exposes quick/deep but NOT the configured bare command (APC case):
+    # the 422 must name the startable tests so the operator can pick one.
+    monkeypatch.setattr(apimod.selftest, "list_supported_commands",
+                        lambda *a, **k: ["test.battery.start.quick",
+                                         "test.battery.stop", "beeper.toggle"])
     monkeypatch.setattr(apimod.selftest, "issue_self_test",
                         lambda *a, **k: pytest.fail("must not issue an unsupported cmd"))
     h = _control_handler(minimal_config, path="/api/v1/ups/UPS@h/self-test",
@@ -394,6 +397,9 @@ def test_run_self_test_unsupported_422(minimal_config, monkeypatch):
     h.headers["Authorization"] = f"Bearer {_token(h)}"
     status, _, payload = h._route_post()
     assert status == 422 and payload["error"]["code"] == "UNSUPPORTED"
+    msg = payload["error"]["message"]
+    assert "test.battery.start.quick" in msg      # candidate surfaced
+    assert "test.battery.stop" not in msg         # stop is not a startable test
 
 
 @pytest.mark.unit
@@ -425,8 +431,8 @@ def test_run_self_test_permitted_by_self_test_flag_without_nut_control(
     minimal_config.nut_control.enabled = False
     minimal_config.nut_control.allowed_commands = []
     captured = {}
-    monkeypatch.setattr(apimod.selftest, "discover_self_test_command",
-                        lambda ups, cmd, **k: cmd)
+    monkeypatch.setattr(apimod.selftest, "list_supported_commands",
+                        lambda *a, **k: ["test.battery.start"])
 
     def _issue(ups, cmd, nc, store, source="api"):
         captured["allowed"] = list(nc.allowed_commands)

--- a/tests/test_battery_health.py
+++ b/tests/test_battery_health.py
@@ -82,6 +82,21 @@ class TestCompute:
         assert "runtime" in health["availableTerms"]
         assert "self_test" in health["availableTerms"]
         assert "age" in health["availableTerms"]
+        # v6.1.4: the raw age is carried alongside the sub-score so the UI can
+        # explain a low age term ("~1.0 yr / 5 yr") instead of a bare "0".
+        assert health["installDate"] == "2025-06-01"
+        assert health["expectedLifeYears"] == 5
+        assert health["ageYears"] == pytest.approx(1.0, abs=0.05)
+
+    @pytest.mark.unit
+    def test_age_fields_unavailable_without_install_date(self, store):
+        cfg = _config("ups:\n  name: U@h\n"
+                      "battery_health:\n  battery_install_date: null\n")
+        mon = _Mon(cfg, store)
+        health = mon._compute_battery_health(cfg.battery_health, time.time())
+        assert health["installDate"] is None
+        assert health["ageYears"] is None
+        assert "age" not in health["availableTerms"]
 
     @pytest.mark.unit
     def test_nominal_runtime_learned_at_full_charge(self, store):

--- a/tests/test_battery_health.py
+++ b/tests/test_battery_health.py
@@ -89,6 +89,21 @@ class TestCompute:
         assert health["ageYears"] == pytest.approx(1.0, abs=0.05)
 
     @pytest.mark.unit
+    def test_unquoted_install_date_is_json_serializable(self, store):
+        # Regression: an UNQUOTED `battery_install_date: 2016-06-25` parses as a
+        # datetime.date; it must be normalized to a string so the status payload
+        # (json.dumps) doesn't raise "Object of type date is not JSON serializable".
+        import json
+        cfg = _config("ups:\n  name: U@h\n"
+                      "battery_health:\n  battery_install_date: 2016-06-25\n")
+        assert cfg.battery_health.battery_install_date == "2016-06-25"
+        assert isinstance(cfg.battery_health.battery_install_date, str)
+        mon = _Mon(cfg, store)
+        health = mon._compute_battery_health(cfg.battery_health, time.time())
+        assert health["installDate"] == "2016-06-25"
+        json.dumps(health)   # must not raise
+
+    @pytest.mark.unit
     def test_age_fields_unavailable_without_install_date(self, store):
         cfg = _config("ups:\n  name: U@h\n"
                       "battery_health:\n  battery_install_date: null\n")

--- a/tests/test_battery_prediction.py
+++ b/tests/test_battery_prediction.py
@@ -93,6 +93,22 @@ class TestTermScores:
         now = P.datetime(2026, 6, 1).timestamp()
         assert P.age_score("2030-01-01", 5.0, now) == 100.0  # negative age -> full
 
+    @pytest.mark.unit
+    def test_battery_age_years(self):
+        now = P.datetime(2026, 6, 1).timestamp()
+        assert P.battery_age_years("2025-06-01", now) == pytest.approx(1.0, abs=0.01)
+        # A very old battery (drives the age sub-score to 0 while still reporting
+        # a real age the UI can show) — the case behind "Battery age shows 0".
+        assert P.battery_age_years("2016-06-01", now) == pytest.approx(10.0, abs=0.05)
+        assert P.age_score("2016-06-01", 5.0, now) == 0.0  # ~10y > 5y expected
+
+    @pytest.mark.unit
+    def test_battery_age_years_unset_bad_and_future(self):
+        assert P.battery_age_years(None, 1000.0) is None
+        assert P.battery_age_years("not-a-date", 1000.0) is None
+        now = P.datetime(2026, 6, 1).timestamp()
+        assert P.battery_age_years("2030-01-01", now) == 0.0  # future -> 0, not negative
+
 
 # --------------------------------------------------------------------------
 # composite

--- a/tests/test_cli_self_test.py
+++ b/tests/test_cli_self_test.py
@@ -194,8 +194,8 @@ class TestRunDirect:
         monkeypatch.setattr(cli, "_load_config", lambda a: _config(SINGLE))
         monkeypatch.setattr(cli, "_open_stats_store", lambda c, g: _FakeStore())
         from eneru import self_test as st
-        monkeypatch.setattr(st, "discover_self_test_command",
-                            lambda *a, **k: "test.battery.start")
+        monkeypatch.setattr(st, "list_supported_commands",
+                            lambda *a, **k: ["test.battery.start"])
         monkeypatch.setattr(st, "issue_self_test",
                             lambda *a, **k: {"ok": True, "test_id": 1, "error": ""})
         cli._cmd_self_test_run(_args(direct=True))
@@ -209,8 +209,8 @@ class TestRunDirect:
         monkeypatch.setattr(cli, "_load_config", lambda a: _config(SINGLE))
         monkeypatch.setattr(cli, "_open_stats_store", lambda c, g: None)
         from eneru import self_test as st
-        monkeypatch.setattr(st, "discover_self_test_command",
-                            lambda *a, **k: "test.battery.start")
+        monkeypatch.setattr(st, "list_supported_commands",
+                            lambda *a, **k: ["test.battery.start"])
         called = {"issued": False}
         monkeypatch.setattr(
             st, "issue_self_test",
@@ -241,13 +241,17 @@ class TestRunDirect:
         assert e.value.code == 2
 
     @pytest.mark.unit
-    def test_command_not_exposed_exits(self, monkeypatch):
+    def test_command_not_exposed_exits(self, monkeypatch, capsys):
         monkeypatch.setattr(cli, "_load_config", lambda a: _config(SINGLE))
         from eneru import self_test as st
-        monkeypatch.setattr(st, "discover_self_test_command", lambda *a, **k: None)
+        # The UPS exposes quick, not the configured bare command: the CLI exits
+        # non-zero AND prints the available startable tests to guide the fix.
+        monkeypatch.setattr(st, "list_supported_commands",
+                            lambda *a, **k: ["test.battery.start.quick", "beeper.toggle"])
         with pytest.raises(SystemExit) as e:
             cli._cmd_self_test_run(_args(direct=True))
         assert e.value.code == 1
+        assert "test.battery.start.quick" in capsys.readouterr().out
 
     @pytest.mark.unit
     def test_direct_uses_per_ups_command(self, monkeypatch):
@@ -260,13 +264,13 @@ class TestRunDirect:
         monkeypatch.setattr(cli, "_open_stats_store", lambda c, g: _FakeStore())
         from eneru import self_test as st
         seen = {}
+        monkeypatch.setattr(st, "list_supported_commands",
+                            lambda *a, **k: ["test.battery.start.quick"])
 
-        def _disc(name, cmd, **k):
+        def _issue(name, cmd, nc, store, **k):
             seen["cmd"] = cmd
-            return cmd
-        monkeypatch.setattr(st, "discover_self_test_command", _disc)
-        monkeypatch.setattr(st, "issue_self_test",
-                            lambda *a, **k: {"ok": True, "test_id": 1, "error": ""})
+            return {"ok": True, "test_id": 1, "error": ""}
+        monkeypatch.setattr(st, "issue_self_test", _issue)
         cli._cmd_self_test_run(_args(ups="U1@h", direct=True))
         assert seen["cmd"] == "test.battery.start.quick"   # per-UPS override, not global
 
@@ -285,15 +289,15 @@ class TestRunDirect:
             "    nut_control:\n      enabled: true\n"
             "      allowed_commands: [test.battery.start]\n")
         monkeypatch.setattr(cli, "_load_config", lambda a: cfg)
-        called = {"discover": False}
+        called = {"listed": False}
         from eneru import self_test as st
         monkeypatch.setattr(
-            st, "discover_self_test_command",
-            lambda *a, **k: called.__setitem__("discover", True) or "x")
+            st, "list_supported_commands",
+            lambda *a, **k: called.__setitem__("listed", True) or ["x"])
         with pytest.raises(SystemExit) as e:
             cli._cmd_self_test_run(_args(ups="U1@h", direct=True))
         assert e.value.code == 2
-        assert called["discover"] is False   # never got past the enabled gate
+        assert called["listed"] is False   # never got past the enabled gate
 
     @pytest.mark.unit
     def test_direct_per_ups_override_inherits_global_enabled(self, monkeypatch):
@@ -312,8 +316,8 @@ class TestRunDirect:
         monkeypatch.setattr(cli, "_open_stats_store", lambda c, g: _FakeStore())
         from eneru import self_test as st
         seen = {}
-        monkeypatch.setattr(st, "discover_self_test_command",
-                            lambda *a, **k: "test.battery.start")
+        monkeypatch.setattr(st, "list_supported_commands",
+                            lambda *a, **k: ["test.battery.start"])
 
         def _issue(name, cmd, nc, store, **k):
             seen["enabled"] = nc.enabled
@@ -329,8 +333,8 @@ class TestRunDirect:
         monkeypatch.setattr(cli, "_load_config", lambda a: _config(SINGLE))
         monkeypatch.setattr(cli, "_open_stats_store", lambda c, g: _FakeStore())
         from eneru import self_test as st
-        monkeypatch.setattr(st, "discover_self_test_command",
-                            lambda *a, **k: "test.battery.start")
+        monkeypatch.setattr(st, "list_supported_commands",
+                            lambda *a, **k: ["test.battery.start"])
         monkeypatch.setattr(st, "issue_self_test",
                             lambda *a, **k: {"ok": False, "test_id": None, "error": "nope"})
         with pytest.raises(SystemExit) as e:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -177,7 +177,7 @@ def test_dashboard_formats_runtime_for_humans(minimal_config):
     assert "function formatRuntimeSeconds" in js
     assert 'return Math.floor(seconds / 3600) + "h "' in js
     assert 'return Math.floor(seconds / 60) + "m " + (seconds % 60) + "s"' in js
-    assert 'text: formatRuntimeSeconds(u.runtime)' in js
+    assert 'vital("Runtime", formatRuntimeSeconds(u.runtime))' in js
     assert 'detailRow("Runtime", formatRuntimeSeconds(u.runtime))' in js
     assert 'metric === "runtime"' in js
 

--- a/tests/test_multi_ups.py
+++ b/tests/test_multi_ups.py
@@ -282,6 +282,50 @@ class TestMultiUPSCoordinator:
         assert len(coord._monitors) == 0
 
     @pytest.mark.unit
+    def test_migrate_legacy_default_db_preserves_history(self, tmp_path):
+        """single→multi migration folds the WAL in, moves a single self-contained
+        file, and leaves no stranded default.db* sidecars (v6.1.4 review)."""
+        from eneru.stats import StatsStore
+        legacy = tmp_path / "default.db"
+        s = StatsStore(legacy)
+        s.open()
+        s.record_self_test("test.battery.start", "scheduler")   # real WAL write
+        s.close()
+        config = self._make_config([
+            UPSGroupConfig(ups=UPSConfig(name="ups@10.0.0.1"), is_local=True),
+        ])
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+        coord._migrate_legacy_default_db(tmp_path)
+        # The legacy file and every sidecar are gone (migration complete)...
+        assert not legacy.exists()
+        assert not (tmp_path / "default.db-wal").exists()
+        assert not (tmp_path / "default.db-shm").exists()
+        # ...and the row survived into the first group's per-UPS DB.
+        target = tmp_path / "ups-10.0.0.1.db"
+        assert target.exists()
+        s2 = StatsStore(target)
+        s2.open()
+        assert s2.latest_self_test() is not None
+        s2.close()
+
+    @pytest.mark.unit
+    def test_migrate_legacy_default_db_idempotent_when_target_exists(self, tmp_path):
+        """If a per-UPS DB already exists, leave default.db untouched (no clobber)."""
+        from eneru.stats import StatsStore
+        legacy = tmp_path / "default.db"
+        s = StatsStore(legacy); s.open(); s.close()
+        target = tmp_path / "ups-10.0.0.1.db"
+        t = StatsStore(target); t.open(); t.close()
+        config = self._make_config([
+            UPSGroupConfig(ups=UPSConfig(name="ups@10.0.0.1"), is_local=True),
+        ])
+        coord = MultiUPSCoordinator(config)
+        coord._log = lambda msg: None
+        coord._migrate_legacy_default_db(tmp_path)
+        assert legacy.exists() and target.exists()   # both preserved
+
+    @pytest.mark.unit
     def test_is_local_triggers_local_shutdown(self):
         """is_local group triggers _handle_local_shutdown."""
         config = self._make_config([

--- a/tests/test_self_test.py
+++ b/tests/test_self_test.py
@@ -105,6 +105,43 @@ class TestDiscover:
 
 
 # --------------------------------------------------------------------------
+# list_supported_commands / test_command_candidates (v6.1.4 "did you mean")
+# --------------------------------------------------------------------------
+
+class TestCandidates:
+    @pytest.mark.unit
+    def test_list_supported_returns_full_list(self, monkeypatch):
+        monkeypatch.setattr(
+            self_test.nutctl, "list_commands",
+            lambda ups, username="", password="", timeout=10:
+                (True, ["beeper.toggle", "test.battery.start.quick"], ""))
+        assert self_test.list_supported_commands("U@h") == [
+            "beeper.toggle", "test.battery.start.quick"]
+
+    @pytest.mark.unit
+    def test_list_supported_raises_on_transient_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            self_test.nutctl, "list_commands",
+            lambda ups, username="", password="", timeout=10: (False, [], "boom"))
+        with pytest.raises(self_test.SelfTestUnavailable):
+            self_test.list_supported_commands("U@h")
+
+    @pytest.mark.unit
+    def test_candidates_are_startable_tests_only(self):
+        # APC-style list: quick/deep are candidates; stop (ends a test) and
+        # non-test commands are not.
+        cmds = ["beeper.enable", "load.off", "test.battery.start.deep",
+                "test.battery.start.quick", "test.battery.stop"]
+        assert self_test.test_command_candidates(cmds) == [
+            "test.battery.start.deep", "test.battery.start.quick"]
+
+    @pytest.mark.unit
+    def test_candidates_empty_when_no_tests(self):
+        assert self_test.test_command_candidates(["beeper.toggle"]) == []
+        assert self_test.test_command_candidates(None) == []
+
+
+# --------------------------------------------------------------------------
 # self_test_control (v6.1.2 narrow permission)
 # --------------------------------------------------------------------------
 

--- a/tests/test_shutdown_plan.py
+++ b/tests/test_shutdown_plan.py
@@ -84,7 +84,21 @@ def test_coordinator_mode_is_handoff(cfg):
     plan = build_shutdown_plan(cfg, is_local=True, coordinator_mode=True)
     term = plan["phases"][-1]
     assert term["id"] == "local-poweroff" and term["title"] == "Group handoff"
+    assert term["enabled"] and term["steps"]     # a local group owns the poweroff
     assert plan["note"] and "coordinator" in plan["note"].lower()
+
+
+@pytest.mark.unit
+def test_coordinator_mode_non_local_skips_handoff(cfg):
+    # A non-local (monitoring-only) UPS in coordinator mode must NOT show an
+    # enabled host-poweroff handoff — losing a UPS that doesn't power this host
+    # triggers nothing here (mirrors _on_group_shutdown, which won't poweroff).
+    plan = build_shutdown_plan(cfg, is_local=False, coordinator_mode=True)
+    term = plan["phases"][-1]
+    assert term["id"] == "local-poweroff"
+    assert not term["enabled"]
+    assert term["skipped"] == "non-local group"
+    assert term["steps"] == []
 
 
 @pytest.mark.unit

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1522,6 +1522,45 @@ class TestInputVoltageContextualFilter:
         from eneru.stats import _to_input_voltage
         assert _to_input_voltage("-1.0", ups_status="OL") is None
 
+
+class TestBatteryChargeContextualFilter:
+    """``_to_battery_charge`` drops a phantom 0% (or negative) battery.charge
+    only while on line power; on battery / FSD a low reading is real depletion
+    history and must survive (mirrors the input-voltage filter, v6.1.4)."""
+
+    @pytest.mark.unit
+    def test_zero_charge_on_line_dropped(self):
+        # The monitoring-only-UPS partial-poll case behind the "spurious 0%
+        # spikes" bug: a transient 0 while OL is not a real deep discharge.
+        from eneru.stats import _to_battery_charge
+        assert _to_battery_charge("0", ups_status="OL") is None
+        assert _to_battery_charge("0.0", ups_status="OL CHRG") is None
+        assert _to_battery_charge(0, ups_status="ALARM OL") is None
+        assert _to_battery_charge("-1", ups_status="OL") is None
+
+    @pytest.mark.unit
+    def test_zero_charge_on_battery_or_fsd_kept(self):
+        # Deep outage: a genuine low/zero charge must persist so real depletion
+        # shows on the graph + aggregates.
+        from eneru.stats import _to_battery_charge
+        assert _to_battery_charge("0", ups_status="OB DISCHRG") == 0.0
+        assert _to_battery_charge("0", ups_status="OL OB") == 0.0   # transient flap
+        assert _to_battery_charge("0", ups_status="OB FSD") == 0.0
+        assert _to_battery_charge("0", ups_status="FSD") == 0.0
+
+    @pytest.mark.unit
+    def test_normal_charge_passes_through(self):
+        from eneru.stats import _to_battery_charge
+        assert _to_battery_charge("100", ups_status="OL") == 100.0
+        assert _to_battery_charge("42.5", ups_status="OB DISCHRG") == 42.5
+
+    @pytest.mark.unit
+    def test_empty_and_non_numeric_return_none(self):
+        from eneru.stats import _to_battery_charge
+        assert _to_battery_charge("", ups_status="OL") is None
+        assert _to_battery_charge(None, ups_status="OB") is None
+        assert _to_battery_charge("abc", ups_status="OL") is None
+
     @pytest.mark.unit
     def test_sample_roundtrip_filters_on_line_zero(self, store):
         """End-to-end: buffer_sample with status=OL + input.voltage=0


### PR DESCRIPTION
## v6.1.4 — multi-UPS correctness + full dashboard UX overhaul

Shipped as a **bug-fix release** (cut with `--latest=false` so a pinned minor stays GitHub "Latest"). Triggered by adding a second, **monitoring-only** UPS to a running prod system, which flipped Eneru into multi-UPS mode and surfaced a wide set of correctness bugs and dashboard gaps. Every finding — High → nit — is folded in; for the UI, polish *is* the feature.

No config or shutdown-behavior changes: existing single-UPS configs keep working unchanged.

### Correctness fixes
- **History loss on single→multi transition:** going from one UPS to many switched the stats store from `default.db` to per-UPS DBs, orphaning the pre-existing UPS's history/events/aggregates. First multi-UPS boot now migrates `default.db` into the first group's per-UPS DB (idempotent, restart-safe).
- **Spurious 0% battery-charge spikes** from a monitoring-only UPS returning a transient `0` on a partial poll while on line power (mirrors the input-voltage guard).
- **Sparse telemetry rendered as bare units** ("V"/"Hz"/"°C" with no number) → now "—".
- **Battery-health factor meters rendered full-width** regardless of value (strict CSP stripped their inline width) → CSSOM `--w` var; the `data:` favicon → packaged same-origin asset.
- **Line-quality verdict** reads "Unknown" (not a confident green "Good") when a UPS reports too little AC telemetry.
- **Self-test "command not exposed" is now actionable:** the API 422 + CLI list the startable test commands the UPS actually offers (APC via `usbhid-ups` exposes `test.battery.start.quick`/`.deep`, not the bare default).
- **Battery age no longer reads as a bare "0":** the age sub-score (0–100, where 0 = past expected life) now shows the actual age ("~10.0 yr / 5 yr") beside it; a UPS without its own install date reads "n/a" instead of borrowing another battery's date.
- **Unquoted `battery_install_date` YAML crash:** PyYAML parses `2016-06-25` as a `date`, which broke JSON serialization of the new battery-health payload; normalized to a `"YYYY-MM-DD"` string at parse time (quoted + unquoted both supported).

### Multi-UPS UX
- **Global header UPS selector** (default "All UPS") scopes Power/Battery/Energy/Shutdown + per-UPS card grids; per-tab dropdowns retired. Overview stays fleet-wide.
- **Fleet-aware Overview:** persistent fleet-status strip, "monitoring only" badge on non-local UPSes, KPIs report worst battery-health / total energy / worst self-test across the fleet.
- **Per-UPS, discoverable shutdown plans;** a monitoring-only UPS shows why it runs no local actions.
- Empty "no redundancy groups configured" hint removed for independent-UPS setups; Events gains a Source column + is seeded from the global selection; tab order moves Events/Config to the end.

### Data-viz + a11y
- Charts: time axis, gap breaks (no bridging), categorical non-status palette, HA-style min/max band + mean line, a persistent value/min-max/time readout on hover.
- Status colors calibrated (on-battery amber ring + "ON BATTERY", confidence-tempered health badges, neutral idle regulation states, neutral trigger banner).
- WCAG 2.2 AA: status-color contrast, modal focus trap + Esc, visible focus rings, `prefers-reduced-motion`, ARIA on charts/modals/controls, narrow-viewport handling.
- API listen backlog raised so bursts of concurrent dashboard requests aren't refused.

### Docs
- Documented that credentials, self-test command, and battery install date are **per-UPS overridable**, with a copy-pasteable multi-UPS example in the config reference + cross-links in the nut-control / self-test guides.

### Testing
- `pytest -m unit` → **2856 pass**. Frontend verified via `dashboard-preview` against the live prod daemon (light/dark, All-UPS + single-UPS). E2E/full CI run here.
- New `favicon.svg` asset has its matching `nfpm.yaml` contents entry (deb/rpm parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-UPS correctness issues and overhauls the dashboard for multi-UPS deployments with fleet scoping, clearer charts, and better accessibility. No config changes; single-UPS setups keep working.

- **Bug Fixes**
  - Preserve history on single→multi by auto-migrating `default.db` into the first per-UPS DB (idempotent, WAL-safe; cleans up `default.db*` sidecars).
  - Drop transient 0% `battery.charge` readings while on line power to remove false chart plunges.
  - Normalize unquoted `battery_install_date` to "YYYY-MM-DD" to prevent JSON errors; battery age now shows real age (e.g. "~10.0 yr / 5 yr").
  - Self-test errors now list the battery-test commands the UPS actually supports (e.g. `test.battery.start.quick`/`.deep`) in API 422 and CLI.
  - Monitoring-only UPS shutdown plan no longer shows an enabled handoff; displays a clear "monitoring only" note.
  - Fix CSP-related UI: battery-health meters size via a CSS var; packaged `/favicon.svg`; API serves `.svg` with the correct MIME type.
  - Improve telemetry rendering and line-quality verdict with partial data; sparse fields show "—" instead of bare units.
  - Raise API listen backlog to handle bursts of concurrent dashboard/API requests and close the socket on bind failure.

- **New Features**
  - Global UPS selector (default “All UPS”) scopes Power/Battery/Energy/Shutdown; per-tab dropdowns removed. Overview supports fleet and per-UPS views.
  - Fleet strip with per-UPS chips and a “monitoring only” badge; KPIs summarize lowest battery health, total energy, and worst self-test.
  - Charts upgraded: time axis, gap-aware paths, Home Assistant–style min–max band + mean line, a live value/min–max/time readout, and a health-trend that keeps far-future replacement markers visible.
  - Clearer status semantics and colors: on-battery ring and caption, neutral idle regulation states, and confidence-tempered health badges.
  - Accessibility: WCAG 2.2 AA contrast, focus trap + Esc on modals, focus rings, ARIA labels, prefers-reduced-motion, and mobile tweaks.
  - Docs: show per-UPS overrides for credentials, self-test command, and battery install date, with a copy-pasteable multi-UPS example.

<sup>Written for commit cc1d9399ee55e033defaa2d5ca680ebfae9ec50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global UPS selector and fleet-wide dashboard views for charts, events, shutdown planning, and overview summaries.
  * Added battery age details and clearer health information, including install date and expected lifespan.
  * Added support for per-UPS configuration overrides and a packaged dashboard favicon.

* **Bug Fixes**
  * Improved self-test handling by showing available commands when a requested test isn’t supported.
  * Normalized battery install dates and filtered invalid zero charge readings on-line.
  * Fixed multi-UPS history migration from legacy storage.

* **Documentation**
  * Expanded setup and multi-UPS guidance with copy-paste examples and clearer self-test command instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->