### PR TITLE
fix: keep notification worker logger across reload + drop persisted gh-pages token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,11 @@ jobs:
           ref: gh-pages
           path: gh-pages
           fetch-depth: 0
+          # Don't persist GITHUB_TOKEN into gh-pages/.git/config: the "Deploy to
+          # gh-pages" step pushes with an explicit x-access-token URL, so the
+          # persisted credential is unused and only widens token exposure across
+          # the many steps that run inside gh-pages/ (zizmor artipacked).
+          persist-credentials: false
 
       - name: Initialize gh-pages if missing
         if: steps.ghpages.outputs.exists == 'false'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [6.1.6] - Unreleased
+## [Unreleased]
+
+Small fast-follow fixes from post-merge review of the v6.1.6 audit; to be
+included in a future release.
+
+### Fixed
+
+- **Notification worker keeps the structured logger across a config reload.**
+  The v6.1.6 change routed worker warnings through the daemon's logger
+  (ISS-060) on startup, but the reload/rebuild paths in both the single-UPS
+  monitor and the multi-UPS coordinator still constructed the worker without
+  it, so after a `systemctl reload` / API reload its warnings fell back to
+  `print`. Both reload paths now pass the shared logger.
+
+### Security
+
+- **CI: don't persist the GitHub token on the release workflow's gh-pages
+  checkout.** The deploy step pushes with an explicit `x-access-token` URL, so
+  the persisted credential was unused; `persist-credentials: false` narrows
+  token exposure across the package-repository build steps (zizmor
+  `artipacked`).
+
+---
+
+## [6.1.6] - 2026-07-06
 
 An unusually large "bug-fix" release: a full-repository adversarial audit
 (source, tests, CI, packaging, deployment manifests, config parsing) surfaced

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -1764,7 +1764,9 @@ class UPSGroupMonitor(
                 "Install with: uv pip install apprise"
             )
             return
-        worker = NotificationWorker(self.config)
+        # Reload path: pass the shared logger like the startup path (ISS-060)
+        # so warnings keep going through the structured logger after a reload.
+        worker = NotificationWorker(self.config, logger=self.logger)
         if worker.start():
             if self._stats_store is not None and self._stats_store._conn is not None:
                 worker.register_store(self._stats_store)

--- a/src/eneru/multi_ups.py
+++ b/src/eneru/multi_ups.py
@@ -1017,7 +1017,10 @@ class MultiUPSCoordinator:
                 "Install with: uv pip install apprise"
             )
             return
-        worker = NotificationWorker(self.config)
+        # Pass the coordinator's shared logger on the reload path too, so the
+        # rebuilt worker routes its warnings through the structured logger just
+        # like the startup path (ISS-060) rather than falling back to print.
+        worker = NotificationWorker(self.config, logger=self._logger)
         if not worker.start():
             self._log("⚠️  WARNING: Failed to reload notifications")
             return

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -486,12 +486,13 @@ def test_monitor_reload_notification_worker_restarts_and_registers(monkeypatch):
     mon._stats_store = MagicMock()
     mon._stats_store._conn = object()
     mon._log_message = MagicMock()
+    mon.logger = object()  # shared structured logger
     worker = MagicMock()
     worker.start.return_value = True
     worker.get_service_count.return_value = 2
     monkeypatch.setattr(monitormod, "APPRISE_AVAILABLE", True)
-    monkeypatch.setattr(monitormod, "NotificationWorker",
-                        MagicMock(return_value=worker))
+    worker_cls = MagicMock(return_value=worker)
+    monkeypatch.setattr(monitormod, "NotificationWorker", worker_cls)
 
     old = mon._notification_worker
     mon._reload_notification_worker()
@@ -500,6 +501,8 @@ def test_monitor_reload_notification_worker_restarts_and_registers(monkeypatch):
     worker.start.assert_called_once()
     worker.register_store.assert_called_once_with(mon._stats_store)
     assert mon._notification_worker is worker
+    # Reload must forward the shared logger (else warnings fall back to print).
+    assert worker_cls.call_args.kwargs.get("logger") is mon.logger
 
 
 @pytest.mark.unit
@@ -556,6 +559,7 @@ def test_coordinator_reload_notification_worker_rewires_children(monkeypatch):
     coord.config.notifications.enabled = True
     coord._notification_worker = MagicMock()
     coord._log = MagicMock()
+    coord._logger = object()  # shared structured logger
     monitor = MagicMock()
     monitor._stats_store = MagicMock()
     monitor._stats_store._conn = object()
@@ -566,8 +570,8 @@ def test_coordinator_reload_notification_worker_rewires_children(monkeypatch):
     worker.start.return_value = True
     worker.get_service_count.return_value = 1
     monkeypatch.setattr(multi_mod, "APPRISE_AVAILABLE", True)
-    monkeypatch.setattr(multi_mod, "NotificationWorker",
-                        MagicMock(return_value=worker))
+    worker_cls = MagicMock(return_value=worker)
+    monkeypatch.setattr(multi_mod, "NotificationWorker", worker_cls)
 
     old = coord._notification_worker
     coord._reload_notification_worker()
@@ -577,6 +581,8 @@ def test_coordinator_reload_notification_worker_rewires_children(monkeypatch):
     assert coord._notification_worker is worker
     assert monitor._notification_worker is worker
     assert executor._notification_worker is worker
+    # Reload must forward the shared logger (else warnings fall back to print).
+    assert worker_cls.call_args.kwargs.get("logger") is coord._logger
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fast-follow from the post-merge review of #88 (v6.1.6). Two small fixes, to be included in a **future release** (changelog is under `[Unreleased]`).

## Fixed
- **Notification worker keeps the structured logger across a config reload.** The v6.1.6 ISS-060 change routed worker warnings through the daemon's logger on startup, but the reload/rebuild paths in both `UPSGroupMonitor._reload_notification_worker` and `MultiUPSCoordinator._reload_notification_worker` still built the worker without it — so after a `systemctl reload` / API reload, warnings (URL-add failure, buffer overflow, pending-on-stop) fell back to `print`. Both reload paths now pass the shared logger. Regression tests assert the logger is forwarded on reload.

## Security
- **CI: `persist-credentials: false` on the release workflow's gh-pages checkout.** The deploy step pushes with an explicit `x-access-token` URL, so the persisted `GITHUB_TOKEN` was unused and only widened exposure across the many steps that run inside `gh-pages/` (zizmor `artipacked`).

## Declined
- A review note claimed `auth`/`mqtt` extras are undefined in `requirements-dev.txt`. They **are** defined in `pyproject.toml` (lines 41/44), and the validate lane's `python -c "import paho.mqtt"` step passes — proving the `mqtt` extra installs. No change.

## Verification
- Full unit suite: 2973 passed; per-file coverage gate green (0 files < 95%, total 96.84%).
- `release.yml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the notification worker using the shared structured logger after config reloads so its warnings don’t fall back to print. Also harden the release workflow by setting `persist-credentials: false` on the `gh-pages` checkout, since deploy already uses an explicit `x-access-token` push.

<sup>Written for commit 6a0b33e7bbfa55bb94bbf8fddeeb9554fbb7648a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

