### PR TITLE
fix(followup): v6.1.6 post-merge review batch (ISS-010/042/046 + nits)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Brief description of changes.
 
 ## Testing
 Describe how you tested your changes:
-- [ ] Tested with `--validate-config`
+- [ ] Tested with `eneru validate`
 - [ ] Tested with `--dry-run` mode
 - [ ] Tested actual shutdown sequence (if applicable)
 - [ ] Tested on: [OS/Python version]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,7 +91,10 @@ jobs:
           # E2E_NOTIFICATION_URL is a hard FAIL rather than a silent SKIP, so
           # a rotated/unset secret can't leave Test 7 permanently un-run. Fork
           # PRs have no secret access and legitimately keep the SKIP.
-          E2E_EXPECT_NOTIFICATION_SECRET: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.fork == false) && '1' || '' }}
+          # Dependabot-triggered runs receive Dependabot secrets, not Actions
+          # secrets, so the URL is legitimately empty there too — treat them
+          # like forks (SKIP, not FAIL).
+          E2E_EXPECT_NOTIFICATION_SECRET: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.fork == false) && github.actor != 'dependabot[bot]' && '1' || '' }}
           # Bypass the v5.4 "is_local requires root" startup check so
           # eneru runs as the runner user. Sudo-elevating eneru would
           # leave its SQLite DB and state files root-owned, which then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,6 +86,7 @@ jobs:
   # Test pip installation across Python versions
   test-pip-install:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -118,6 +119,7 @@ jobs:
   test-deb:
     needs: build-packages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -186,6 +188,7 @@ jobs:
   test-rpm:
     needs: build-packages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -292,6 +295,7 @@ jobs:
   # Test pip installation inside containers (ensures pyproject.toml works on real distros)
   test-pip-in-container:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -355,6 +359,7 @@ jobs:
   # not depend on a GHCR tag that may not exist before the first 5.4 release.
   test-oci-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          # ISS-010 (minimal hardening): this job pip-installs the full
+          # dependency tree and runs pytest before any publish step, so don't
+          # leave the contents:write+packages:write GITHUB_TOKEN sitting in
+          # .git/config while untrusted dep code runs. Every credentialed
+          # operation below (docker login, gh release, gh-pages push) passes
+          # the token explicitly via env/URL and is unaffected.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,9 +409,9 @@ When writing documentation, use the correct invocation style for the context:
 
 | Context | Command Style | Example |
 |---------|---------------|---------|
-| Package users (README, troubleshooting) | `/opt/ups-monitor/eneru.py` | `sudo python3 /opt/ups-monitor/eneru.py --validate-config` |
+| Package users (README, troubleshooting) | `/opt/ups-monitor/eneru.py` | `sudo python3 /opt/ups-monitor/eneru.py validate --config /etc/ups-monitor/config.yaml` |
 | Developers (CONTRIBUTING, testing) | `python -m eneru` or `eneru` | `python -m eneru run --dry-run --config examples/config-reference.yaml` |
-| PyPI users | `eneru` | `eneru --validate-config` |
+| PyPI users | `eneru` | `eneru validate` |
 
 ## Key Dependencies
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,24 @@ included in a future release.
   monitor and the multi-UPS coordinator still constructed the worker without
   it, so after a `systemctl reload` / API reload its warnings fell back to
   `print`. Both reload paths now pass the shared logger.
+- **Failed logins audit as `LOGIN_FAILURE` with intact IPv6 addresses.** Audit
+  rows for failed/throttled logins previously fell back to the generic
+  `CONTROL` event type, and IPv6 client addresses were truncated at the last
+  colon (ISS-032 follow-up).
+- **Container/VM shutdown summaries no longer claim ✅ after failures.** The
+  rootless-Podman and libvirt phase summaries now report a ⚠️ with the failure
+  count when any stop/destroy command failed (ISS-040 follow-up).
+- **Neutral-status log throttle holds under alternating statuses.** A UPS
+  flipping between two neutral statuses (e.g. `OFF` ↔ `BYPASS`) every poll no
+  longer re-logs the "neither on-line nor on-battery" info line each time; the
+  transition itself is still logged (ISS-019 follow-up).
+- **Docs/templates referenced a nonexistent `--validate-config` flag.**
+  Remaining guidance in `AGENTS.md`, the PR template, and the E2E README now
+  shows the real `validate` subcommand (ISS-046 follow-up).
+- **E2E notification check no longer hard-fails Dependabot PRs.** Dependabot
+  runs receive Dependabot secrets, not Actions secrets, so
+  `E2E_NOTIFICATION_URL` is legitimately empty there; those runs now SKIP
+  Test 7 like fork PRs instead of failing (ISS-051 follow-up).
 
 ### Security
 
@@ -28,6 +46,21 @@ included in a future release.
   the persisted credential was unused; `persist-credentials: false` narrows
   token exposure across the package-repository build steps (zizmor
   `artipacked`).
+- **CI: don't persist the GitHub token on the release workflow's main checkout
+  either (ISS-010, minimal form).** The build job installs the full dependency
+  tree and runs the test suite before publishing; every credentialed publish
+  step already passes the token explicitly, so the persisted copy in
+  `.git/config` was pure ambient exposure.
+- **`eneru validate` redacts notification URLs with the shared helper.** The
+  config summary previously fell back to printing the first 20 characters of a
+  scheme-less Apprise URL, which could leak webhook path fragments; it now
+  always prints `scheme://***`.
+
+### Changed
+
+- **CI hygiene (ISS-042/022 follow-ups).** All `integration.yml` jobs now carry
+  `timeout-minutes`; the `upsc -l` diagnostic cooldown and the neutral-status
+  log interval are named module constants in `monitor.py`.
 
 ---
 

--- a/src/eneru/api.py
+++ b/src/eneru/api.py
@@ -1442,6 +1442,7 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         "config": "CONFIG_RELOAD",
         "events": "EVENTS_DELETED",
         "self-test": "CONTROL_SELF_TEST",
+        "login": "LOGIN_FAILURE",
     }
 
     @staticmethod
@@ -1465,7 +1466,13 @@ class EneruAPIHandler(BaseHTTPRequestHandler):
         if hasattr(source, "record_control_event"):
             # target is "{ups}:{command_or_var}"; the UPS NUT name itself can
             # contain a colon (e.g. UPS@host:3493), so split on the LAST one.
-            ups = target.rsplit(":", 1)[0] if ":" in target else ""
+            # Login audits carry a client IP as the target, not ups:command --
+            # never split those (an IPv6 address would be truncated); the full
+            # address stays in the detail string and the ups column is empty.
+            if kind == "login":
+                ups = ""
+            else:
+                ups = target.rsplit(":", 1)[0] if ":" in target else ""
             event_type = self._AUDIT_EVENT_TYPES.get(kind, "CONTROL")
             try:
                 source.record_control_event(ups, event_type,

--- a/src/eneru/cli.py
+++ b/src/eneru/cli.py
@@ -1014,11 +1014,7 @@ def _cmd_validate(args):
         if APPRISE_AVAILABLE:
             print(f"    Enabled: {len(config.notifications.urls)} service(s)")
             for url in config.notifications.urls:
-                if '://' in url:
-                    scheme = url.split('://')[0]
-                    print(f"      - {scheme}://***")
-                else:
-                    print(f"      - {url[:20]}...")
+                print(f"      - {redact_apprise_url(url)}")
             if config.notifications.title:
                 print(f"    Title: {config.notifications.title}")
             else:

--- a/src/eneru/monitor.py
+++ b/src/eneru/monitor.py
@@ -68,6 +68,13 @@ SLOW_NUT_NOTIFY_CONSECUTIVE_POLLS = 3
 # persistently-broken config doesn't re-attempt (and spawn an upscmd subprocess)
 # on every poll tick.
 SELF_TEST_ISSUE_RETRY_SECONDS = 300.0
+# ISS-022: minimum interval between `upsc -l` ups.name diagnostics -- the
+# probe blocks the poll thread for up to ~10s, so a flapping NUT server is
+# probed at most once per window.
+NAME_DIAGNOSTIC_COOLDOWN_SECONDS = 600.0
+# ISS-019: rate limit for the "status is neither on-line nor on-battery"
+# info line while the UPS sits in a neutral state (OFF, BYPASS, ...).
+NEUTRAL_STATUS_LOG_INTERVAL_SECONDS = 300.0
 
 # Re-export for backwards compatibility (tests may mock these)
 try:
@@ -187,7 +194,6 @@ class UPSGroupMonitor(
         self._last_ob_status_log_mono = None
         self._last_name_diagnostic_mono = None
         self._last_unknown_status_log_mono = None
-        self._last_unknown_status_logged = ""
         # ISS-055: last distinct state-file persist error, so a recurring disk
         # failure is logged once per cause instead of silently swallowed.
         self._last_state_save_error: Optional[str] = None
@@ -2623,7 +2629,8 @@ class UPSGroupMonitor(
                             and "OB" not in self.state.previous_status
                             and (self._last_name_diagnostic_mono is None
                                  or time.monotonic()
-                                 - self._last_name_diagnostic_mono > 600)):
+                                 - self._last_name_diagnostic_mono
+                                 > NAME_DIAGNOSTIC_COOLDOWN_SECONDS)):
                         self._last_name_diagnostic_mono = time.monotonic()
                         self._run_ups_name_diagnostic(error_msg)
                     self.state.stale_data_count = 0
@@ -2836,12 +2843,14 @@ class UPSGroupMonitor(
                 # per-outage failsafe latch is handled separately above at its
                 # own re-arm check, which clears on any non-OB/non-FSD status.)
                 # Note it, throttled, for visibility; environment checks below
-                # still run on the raw status.
-                if (ups_status != self._last_unknown_status_logged
-                        or self._last_unknown_status_log_mono is None
+                # still run on the raw status. Purely time-based: a changed
+                # neutral status is already surfaced immediately by the
+                # "🔄  Status changed" line above, and keying on the last
+                # logged status here would defeat the throttle when two
+                # neutral statuses alternate (OFF <-> BYPASS every poll).
+                if (self._last_unknown_status_log_mono is None
                         or time.monotonic() - self._last_unknown_status_log_mono
-                        >= 300):
-                    self._last_unknown_status_logged = ups_status
+                        >= NEUTRAL_STATUS_LOG_INTERVAL_SECONDS):
                     self._last_unknown_status_log_mono = time.monotonic()
                     self._log_message(
                         f"ℹ️  UPS status '{ups_status}' is neither on-line nor "

--- a/src/eneru/shutdown/containers.py
+++ b/src/eneru/shutdown/containers.py
@@ -283,6 +283,7 @@ class ContainerShutdownMixin:
             self._log_message("  ⚠️  Failed to list users for rootless container check")
             return
 
+        stop_failures = 0
         for line in stdout.strip().split('\n'):
             if not line.strip():
                 continue
@@ -320,13 +321,22 @@ class ContainerShutdownMixin:
                             stop_cmd,
                             timeout=self.config.containers.stop_timeout + 30)
                         if rc != 0:
+                            stop_failures += 1
                             detail = f": {err.strip()[:200]}" if err and err.strip() else ""
                             self._log_message(
                                 f"  ⚠️  rootless podman stop for '{username}' "
                                 f"returned rc={rc}{detail}"
                             )
 
-        self._log_message("  ✅  Rootless Podman containers stopped")
+        # ISS-040 follow-up: the phase summary must not claim ✅ when a
+        # per-user stop failed above (best-effort semantics unchanged).
+        if stop_failures:
+            self._log_message(
+                f"  ⚠️  Rootless Podman container stop finished with "
+                f"{stop_failures} failure(s)"
+            )
+        else:
+            self._log_message("  ✅  Rootless Podman containers stopped")
 
 
 def _looks_like_container_id(value: str) -> bool:

--- a/src/eneru/shutdown/vms.py
+++ b/src/eneru/shutdown/vms.py
@@ -94,15 +94,26 @@ class VMShutdownMixin:
             # Sleep only up to the remaining budget so we don't overshoot.
             time.sleep(max(0, min(wait_interval, deadline - time.monotonic())))
 
+        destroy_failures = 0
         if remaining_vms:
             self._log_message("  ⚠️  Timeout reached. Force destroying remaining VMs.")
             for vm in remaining_vms:
                 self._log_message(f"  ⚡  Force destroying VM: {vm}")
                 rc, _, err = run_command(["virsh", "destroy", vm])
                 if rc != 0:
+                    destroy_failures += 1
                     detail = f": {err.strip()[:200]}" if err and err.strip() else ""
                     self._log_message(
                         f"  ⚠️  virsh destroy {vm} returned rc={rc}{detail}"
                     )
 
-        self._log_message("  ✅  All VMs shutdown complete")
+        # ISS-040 follow-up: don't claim ✅ when a force-destroy failed --
+        # those VMs may still be running (graceful-path rc failures are
+        # covered by the destroy pass, so only destroy failures count here).
+        if destroy_failures:
+            self._log_message(
+                f"  ⚠️  VM shutdown finished with {destroy_failures} VM(s) "
+                f"possibly still running"
+            )
+        else:
+            self._log_message("  ✅  All VMs shutdown complete")

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ sleep 10
 upsc TestUPS@localhost:3493
 
 # Run Eneru against the test environment
-eneru --validate-config --config config-e2e-dry-run.yaml
+eneru validate --config config-e2e-dry-run.yaml
 ```
 
 ### Simulating scenarios

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -413,6 +413,67 @@ def test_login_throttled_after_burst(minimal_config, tmp_path):
 
 
 @pytest.mark.unit
+def test_login_failure_audits_event_row(minimal_config, tmp_path):
+    """ISS-032 follow-up: a failed login must reach the events table via
+    record_control_event with the dedicated LOGIN_FAILURE type (not the
+    generic CONTROL fallback), an empty ups column (the target is a client
+    IP, not ups:command), and the FULL client address in the detail --
+    including IPv6 addresses, which the ups:command colon-split used to
+    truncate."""
+    _enable_auth(minimal_config)
+    store = AuthStore(tmp_path / "auth.db")
+    store.create_user("alice", "s3cret")
+    source = MagicMock()
+    body = json.dumps({"username": "alice", "password": "wrong"}).encode()
+    h = _handler(minimal_config, source=source, auth_store=store,
+                 sessions=SessionManager(3600),
+                 path="/api/v1/auth/login", body=body)
+    h.client_address = ("2001:db8::1", 54321)
+
+    with pytest.raises(APIUnauthorized):
+        h._route_post()
+
+    source.record_control_event.assert_called_once()
+    ups, event_type, detail = source.record_control_event.call_args[0]
+    assert ups == ""
+    assert event_type == "LOGIN_FAILURE"
+    assert "2001:db8::1" in detail
+    assert detail.endswith("-> failed")
+
+
+@pytest.mark.unit
+def test_login_throttled_audits_event_row(minimal_config, tmp_path):
+    """The 429 short-circuit path audits too, with result 'throttled'."""
+    import eneru.api as api_mod
+    _enable_auth(minimal_config)
+    store = AuthStore(tmp_path / "auth.db")
+    store.create_user("alice", "s3cret")
+    source = MagicMock()
+
+    def _bad():
+        body = json.dumps({"username": "alice", "password": "wrong"}).encode()
+        h = _handler(minimal_config, source=source, auth_store=store,
+                     sessions=SessionManager(3600),
+                     path="/api/v1/auth/login", body=body)
+        h.client_address = ("203.0.113.9", 54321)
+        return h
+
+    for _ in range(api_mod.LOGIN_FAIL_MAX):
+        with pytest.raises(APIUnauthorized):
+            _bad()._route_post()
+    status, _, _ = _bad()._route_post()
+    assert status == 429
+
+    calls = source.record_control_event.call_args_list
+    assert len(calls) == api_mod.LOGIN_FAIL_MAX + 1
+    ups, event_type, detail = calls[-1][0]
+    assert ups == ""
+    assert event_type == "LOGIN_FAILURE"
+    assert "203.0.113.9" in detail
+    assert detail.endswith("-> throttled")
+
+
+@pytest.mark.unit
 def test_ready_minimal_for_anonymous_under_require_for_reads(
     minimal_config, monkeypatch,
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1196,6 +1196,38 @@ notifications:
         assert "Title: UPS Alert" in captured.out
 
     @pytest.mark.unit
+    def test_validate_config_redacts_schemeless_notification_url(
+            self, tmp_path, capsys):
+        """A scheme-less URL must not leak any of its characters.
+
+        The old display fell back to ``url[:20]...`` for URLs without
+        ``://``, printing up to 20 raw characters of what may be a
+        malformed-but-secret webhook reference. It now goes through
+        redact_apprise_url like every other notification URL surface.
+        """
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+ups:
+  name: "TestUPS@localhost"
+
+notifications:
+  urls:
+    - "hooks.example.com/services/SECRETTOKENPART"
+""")
+
+        with patch.object(sys, "argv", [
+            "eneru", "validate", "-c", str(config_file)
+        ]):
+            with patch("eneru.cli.APPRISE_AVAILABLE", True):
+                with pytest.raises(SystemExit):
+                    main()
+
+        captured = capsys.readouterr()
+        assert "unknown://***" in captured.out
+        assert "SECRETTOKENPART" not in captured.out
+        assert "hooks.example.com" not in captured.out
+
+    @pytest.mark.unit
     def test_validate_config_nonexistent_file(self, tmp_path, capsys):
         """Validate against a non-existent path: ConfigLoader.load
         prints a warning and falls back to defaults; the resulting
@@ -3596,31 +3628,10 @@ class TestShutdownRemoteAppliesRuntimePrep:
 
 
 class TestValidateNotificationFormatting:
-    """Cover lines 913, 917, 919 — URL-without-scheme truncation,
-    Title:(none), and avatar_url branch."""
-
-    @pytest.mark.unit
-    def test_validate_truncates_url_without_scheme(self, tmp_path, capsys):
-        # ConfigLoader normalizes notification URLs; we patch APPRISE_AVAILABLE
-        # and inject a no-scheme URL via the loaded Config object directly
-        # by writing a YAML with a no-scheme entry.
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text(
-            "ups:\n"
-            "  name: 'TestUPS@localhost'\n"
-            "notifications:\n"
-            "  urls:\n"
-            "    - 'no-scheme-here-just-bare-text-1234567890abcdef'\n"
-        )
-        with patch.object(sys, "argv", [
-            "eneru", "validate", "-c", str(config_file)
-        ]), patch("eneru.cli.APPRISE_AVAILABLE", True):
-            with pytest.raises(SystemExit):
-                main()
-        out = capsys.readouterr().out
-        # Line 913: no `://` → first 20 chars + ellipsis.
-        assert "no-scheme-here-just-" in out
-        assert "..." in out
+    """Cover the notification display branches — Title:(none) and
+    avatar_url. The URL-without-scheme case now redacts via
+    redact_apprise_url; see
+    test_validate_config_redacts_schemeless_notification_url."""
 
     @pytest.mark.unit
     def test_validate_no_title_prints_none(self, tmp_path, capsys):

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -4113,6 +4113,39 @@ class TestMainLoopBranchCoverage:
         monitor._handle_on_line.assert_not_called()
 
     @pytest.mark.unit
+    def test_neutral_status_log_throttled_across_alternating_statuses(
+        self, tmp_path,
+    ):
+        """ISS-019 follow-up: the neutral-status info line is purely
+        time-throttled. Alternating neutral statuses (OFF <-> BYPASS every
+        poll) must NOT re-log it each time the status changes -- the
+        transition itself is already surfaced by the "Status changed" line."""
+        monitor = make_monitor(tmp_path)
+        monitor._handle_on_battery = MagicMock()
+        monitor._handle_on_line = MagicMock()
+        monitor.state.previous_status = "OL"
+        monitor.state.connection_state = "OK"
+        logs = []
+        # BYPASS also fires _log_power_event, which passes level= kwargs.
+        monitor._log_message = lambda msg, **kw: logs.append(msg)
+
+        for status in ("OFF", "BYPASS", "OFF"):
+            # _run_one_iteration sets the stop event to bound the loop to a
+            # single pass; clear it so the next pass runs too.
+            monitor._stop_event.clear()
+            _run_one_iteration(monitor, (True, {
+                "ups.status": status, "battery.charge": "80",
+                "battery.runtime": "1200", "ups.load": "30",
+            }, ""))
+
+        neutral_lines = [
+            m for m in logs if "neither on-line nor on-battery" in m
+        ]
+        assert len(neutral_lines) == 1, logs
+        # The alternation is still visible via the status-change line.
+        assert any("Status changed: OFF -> BYPASS" in m for m in logs), logs
+
+    @pytest.mark.unit
     def test_ol_chrg_routes_to_on_line(self, tmp_path):
         """ISS-019: `OL CHRG` still routes to the on-line handler under tokens."""
         monitor = make_monitor(tmp_path)

--- a/tests/test_shutdown_containers.py
+++ b/tests/test_shutdown_containers.py
@@ -722,6 +722,37 @@ def test_rootless_podman_stops_user_containers(tmp_path):
     assert "def456" in stop_calls[0]
     assert "15" in stop_calls[0]  # stop_timeout
     assert any("user 'alice'" in m for m in log), log
+    assert any("✅  Rootless Podman containers stopped" in m for m in log), log
+
+
+@pytest.mark.unit
+def test_rootless_podman_stop_failure_summary_not_success(tmp_path):
+    """ISS-040 follow-up: a failed per-user stop must flip the phase summary
+    to ⚠️ instead of the unconditional ✅."""
+    monitor = _make_container_monitor(
+        tmp_path, runtime="podman", container_runtime="podman",
+        include_user_containers=True, stop_timeout=15,
+    )
+    log = []
+    monitor._log_message = log.append
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "loginctl":
+            return (0, "1000 alice\n", "")
+        if "ps" in cmd:
+            return (0, "abc123\n", "")
+        if "stop" in cmd:
+            return (125, "", "cannot connect to user socket")
+        return (1, "", "")
+
+    with patch("eneru.shutdown.containers.run_command", side_effect=fake_run):
+        monitor._shutdown_podman_user_containers()
+
+    assert any("rootless podman stop for 'alice' returned rc=125" in m
+               for m in log), log
+    assert not any("✅  Rootless Podman containers stopped" in m
+                   for m in log), log
+    assert any("finished with 1 failure(s)" in m for m in log), log
 
 
 @pytest.mark.unit

--- a/tests/test_shutdown_vms.py
+++ b/tests/test_shutdown_vms.py
@@ -228,3 +228,34 @@ def test_shutdown_vms_reports_failed_rc(tmp_path):
 
     assert any("virsh shutdown vm1 returned rc=1" in m for m in logs), logs
     assert any("virsh destroy vm1 returned rc=1" in m for m in logs), logs
+    # ISS-040 follow-up: the phase summary must not claim ✅ when a
+    # force-destroy failed -- that VM may still be running.
+    assert not any("All VMs shutdown complete" in m for m in logs), logs
+    assert any("1 VM(s) possibly still running" in m for m in logs), logs
+
+
+@pytest.mark.unit
+def test_shutdown_vms_summary_success_when_destroy_succeeds(tmp_path):
+    """A destroy that succeeds after a failed graceful shutdown still ends
+    with the ✅ summary (graceful-path rc failures are covered by the
+    destroy pass)."""
+    monitor = _make_vm_monitor(tmp_path, max_wait=5)
+    logs = []
+    monitor._log_message = logs.append
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["virsh", "list", "--name"]:
+            return (0, "vm1\n", "")
+        if cmd[:2] == ["virsh", "shutdown"]:
+            return (1, "", "shutdown refused")
+        if cmd[:2] == ["virsh", "destroy"]:
+            return (0, "", "")
+        return (0, "", "")
+
+    with patch("eneru.shutdown.vms.command_exists", return_value=True), \
+         patch("eneru.shutdown.vms.run_command", side_effect=fake_run), \
+         patch("eneru.shutdown.vms.time.sleep"):
+        monitor._shutdown_vms()
+
+    assert any("All VMs shutdown complete" in m for m in logs), logs
+    assert not any("possibly still running" in m for m in logs), logs


### PR DESCRIPTION
## Summary

Follow-up batch from the post-implementation review of PR #88 (v6.1.6 audit remediation). One commit, no version bump; brief notes added to the changelog `[Unreleased]` section (rides a future release together with #91).

### Outstanding blueprint items
- **ISS-010 (minimal form):** `persist-credentials: false` on release.yml's main checkout. The build job pip-installs the full dependency tree and runs pytest before any publish step, so the persisted `contents:write`+`packages:write` token in `.git/config` was pure ambient exposure. Every credentialed operation already passes the token explicitly: docker login (env → `--password-stdin`), `gh release upload` (env), gh-pages push (`x-access-token` URL); the gh-pages *checkout* got the same treatment in #91. Failures, if any, would be loud (auth error), not silent.
- **ISS-042:** `timeout-minutes: 15` on the five remaining integration.yml jobs (`test-pip-install`, `test-deb`, `test-rpm`, `test-pip-in-container`, `test-oci-image`). All historically finish in ~1 minute; `build-packages` already had 30.
- **ISS-046:** the nonexistent `--validate-config` flag purged from live guidance — AGENTS.md docs-guidelines table, the PR template checklist, and `tests/e2e/README.md` now show the real `validate` subcommand.

### Residual nits from the review
- **cli.py redaction:** the `eneru validate` notification summary now uses `redact_apprise_url`; the old `url[:20]...` fallback could print raw characters of a scheme-less (possibly secret) webhook reference. The old truncation test is superseded by a redaction test.
- **ISS-032 trio:** failed/throttled logins audit as `LOGIN_FAILURE` (new `_AUDIT_EVENT_TYPES` entry) instead of falling back to generic `CONTROL`; login audit rows no longer `rsplit(":", 1)` the client address (which truncated IPv6 — `2001:db8::1` became `2001:db8:`); ups column is empty for login events, full address stays in the detail string. Two regression tests assert the exact `record_control_event` rows for the 401 and 429 paths.
- **ISS-040:** rootless-Podman and libvirt phase summaries only claim ✅ when zero stop/destroy commands failed; otherwise ⚠️ with the failure count. vms.py counts destroy failures only — graceful-path rc failures are covered by the force-destroy pass (tested both ways).
- **ISS-022/019:** the `upsc -l` diagnostic cooldown (600 s) and neutral-status log interval (300 s) are named module constants; the neutral-status info line is now purely time-throttled, so alternating neutral statuses (`OFF` ↔ `BYPASS` each poll) can't defeat the throttle via the old changed-status OR-clause. The transition itself is still surfaced by the generic "🔄 Status changed" line (regression test drives three real main-loop iterations).

### CI fix (root cause of #89/#90 failures)
Dependabot-triggered `pull_request` runs receive **Dependabot** secrets, not Actions secrets, so `E2E_NOTIFICATION_URL` is legitimately empty there — but the ISS-051 gate saw a same-repo branch and hard-failed Test 7. `E2E_EXPECT_NOTIFICATION_SECRET` now also requires `github.actor != 'dependabot[bot]'`, so those runs SKIP like fork PRs. After this merges, `@dependabot rebase` on #89/#90 will re-run them green.

## Test plan
- [x] `pytest -m unit` in the uv venv: **2978 passed**
- [x] Per-file line+branch coverage ≥95% on all touched sources (api 95.6%, cli 97.1%, monitor 95.8%, containers 98.8%, vms 100%)
- [x] Pre-push code-reviewer pass: APPROVE, no blocking findings (verified the GH-expression precedence, traced every credentialed release.yml step against `persist-credentials: false`)
- [ ] Full CI (validate 3.9/3.12 + 8 E2E groups) upstream
- [x] Tested with `eneru validate` (no config-surface changes beyond display redaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI/release for v6.1.6 follow‑up and fixes auditing, logging, and shutdown summaries. Also updates docs to use the real `validate` subcommand and improves URL redaction in `eneru validate`.

- **Bug Fixes**
  - ISS-010: `release.yml` main checkout sets `persist-credentials: false`; all publish steps pass tokens explicitly.
  - ISS-042: Added `timeout-minutes: 15` to remaining `integration.yml` jobs.
  - ISS-051: Dependabot PRs now SKIP the E2E notification check instead of failing.
  - ISS-032: Failed/throttled logins audit as `LOGIN_FAILURE`; IPv6 addresses no longer truncated; `ups` column empty for login events.
  - ISS-040: Rootless Podman and libvirt summaries show ⚠️ with failure counts when stop/destroy commands fail.
  - ISS-019/022: Neutral-status info line is purely time-throttled; named constants added for the `upsc -l` diagnostic cooldown and neutral-status interval.
  - CLI: `eneru validate` redacts notification URLs via the shared helper; no schemeless fragments are printed.
  - ISS-046: Replaced nonexistent `--validate-config` in docs/template/E2E README with the `validate` subcommand.

<sup>Written for commit 955a646643ea7ba6a7d549173d054f078dab439e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login audit logging so failed sign-ins are recorded correctly, including full IP addresses.
  * Fixed shutdown summaries to avoid reporting success when container or VM stop/destroy steps fail.
  * Made notification URL redaction consistent during validation output.
  * Reduced repeated logging for neutral UPS status changes and added safer handling for notification tests on Dependabot runs.

* **Chores**
  * Updated developer guidance and CI workflows, including shorter test timeouts and safer checkout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->