### PR TITLE
fix(ci): dnf smoke gate can never pass — answer the GPG key-import prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -866,12 +866,14 @@ jobs:
               > /etc/apt/sources.list.d/eneru.list
             # Freshness gate: wait until the repo advertises the version THIS
             # run built, not whatever Pages still caches from the last release.
-            for i in $(seq 1 30); do
+            # 10-min window (matches the dnf leg): Pages CDN propagation can
+            # straggle past 5 minutes.
+            for i in $(seq 1 60); do
               apt-get update >/dev/null 2>&1 || true
               if apt-cache policy eneru | grep -qF "$PKG_VERSION"; then
                 echo "Repo advertises ${PKG_VERSION} after attempt ${i}."; break
               fi
-              if [ "$i" = "30" ]; then
+              if [ "$i" = "60" ]; then
                 echo "::error::Repo never advertised ${PKG_VERSION}."; exit 1
               fi
               echo "Attempt ${i}: repo metadata still stale; sleeping 10s..."; sleep 10
@@ -889,12 +891,19 @@ jobs:
             else
               curl -fsSL "${BASE}/${{ matrix.repo_stable }}" -o /etc/yum.repos.d/eneru.repo
             fi
-            # Freshness gate (same reasoning as the apt leg).
-            for i in $(seq 1 30); do
-              if dnf --refresh -q info eneru 2>/dev/null | grep -qF "$PKG_VERSION"; then
+            # Freshness gate (same reasoning as the apt leg). -y is LOAD-BEARING:
+            # eneru.repo sets repo_gpgcheck=1, so the first metadata fetch must
+            # import the signing key, and dnf PROMPTS for that import. Without
+            # -y the non-interactive prompt is refused, dnf fails with "Bad GPG
+            # signature", and 2>/dev/null makes every attempt look like stale
+            # metadata — the gate can never pass (v6.1.7 release run failed
+            # twice this way while the repo was demonstrably fine). The window
+            # is also 10 min, not 5: Pages CDN propagation can straggle.
+            for i in $(seq 1 60); do
+              if dnf -y --refresh -q info eneru 2>/dev/null | grep -qF "$PKG_VERSION"; then
                 echo "Repo advertises ${PKG_VERSION} after attempt ${i}."; break
               fi
-              if [ "$i" = "30" ]; then
+              if [ "$i" = "60" ]; then
                 echo "::error::Repo never advertised ${PKG_VERSION}."; exit 1
               fi
               echo "Attempt ${i}: repo metadata still stale; sleeping 10s..."; sleep 10


### PR DESCRIPTION
The v6.1.7 release run failed both dnf smoke legs (twice — rerun included) with "Repo never advertised 6.1.7", while the published repo was demonstrably fine. Root cause reproduced in a ubi9 container: `eneru.repo` sets `repo_gpgcheck=1`, dnf's first metadata fetch prompts to import the signing key, the gate's `dnf --refresh -q info` has no `-y`, the non-interactive prompt is refused → "Bad GPG signature" → `2>/dev/null` disguises every attempt as stale metadata. The gate is deterministically un-passable; the `dnf install -y` behind it was always fine.

- Add `-y` to the gate poll (load-bearing, commented as such).
- Widen both legs' poll window 5 → 10 min for Pages CDN propagation.

Release validation for v6.1.7 was completed manually in ubi9 + ubi8 containers: freshness gate (with `-y`), EPEL, install, and `eneru version` → `Eneru v6.1.7-08f78cf` on both; the el8 leg pulled `python39` through the RPM's own deps (F-013 behavior confirmed in the wild).

CI-only trivial PR per AGENTS.md — no AI-review round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `dnf` freshness gate by adding `-y` to accept the GPG key import, allowing the gate to pass and preventing false "Repo never advertised" failures. Also widen the repo poll window in both `apt-get` and `dnf` legs from 5 to 10 minutes (30→60 attempts) to handle Pages CDN propagation.

<sup>Written for commit 5755025276ebaa068343ab56552b86af21791394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

