### PR TITLE
fix: always augment remote command PATH (v6.1.8)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -163,11 +163,9 @@ jobs:
         if: matrix.group == 'single-ups-core' || matrix.group == 'loopback'
         run: |
           if [ "${{ matrix.group }}" = "single-ups-core" ]; then
-            grep -q "Test 59: Remote PATH augmentation opt-in and safe default both work" tests/e2e/groups/single-ups-core.sh
+            grep -q "Test 59: Remote PATH augmentation always resolves bare commands" tests/e2e/groups/single-ups-core.sh
             grep -q "Test 60: Local Compose shutdown honors the configured timeout form" tests/e2e/groups/single-ups-core.sh
             grep -q 'shutdown_command: "eneru-path-probe"' tests/e2e/groups/single-ups-core.sh
-            grep -q "augment_remote_path: true" tests/e2e/groups/single-ups-core.sh
-            grep -q 'shutdown_command: "/usr/local/bin/verify-unaugmented-path"' tests/e2e/groups/single-ups-core.sh
           else
             grep -q "Test 61: E2E delegated poweroff delivery writes completion marker" tests/e2e/groups/loopback.sh
             grep -Eq "^[[:space:]]*delegated_completion_marker_case[[:space:]]*$" tests/e2e/groups/loopback.sh

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.8] - 2026-07-12
+
+### Fixed
+
+- **Remote shutdown always receives the expanded system `PATH`.** Eneru 6.1.7
+  added the expanded path after a Synology NAS failed to shut down during a
+  real outage, but the final release made it opt-in. Existing configurations
+  therefore kept sending bare commands through SSH without `/usr/syno/sbin`,
+  and `synoshutdown` could still fail with `command not found`. Eneru now adds
+  the standard system directories and Synology directories to every remote
+  command. The short-lived `augment_remote_path` option has been removed;
+  6.1.7 configurations that contain it still load, but its value is ignored.
+
 ## [6.1.7] - 2026-07-10
 
 A stabilizing bug-fix release built on a full-repository pre-release code

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,7 +488,6 @@ mounts:
 | `command_timeout` | `30` | Default timeout for remote commands |
 | `shutdown_command` | `sudo shutdown -h now` | Final shutdown command |
 | `use_sudo` | `false` | Prefix generated privileged actions and non-sudo final shutdown commands with `sudo -n`. Useful for non-root loopback or remote users with NOPASSWD sudo |
-| `augment_remote_path` | `false` | Opt in to a POSIX-sh `export PATH=...` prefix so bare commands (for example Synology's `synoshutdown`) resolve in a minimal non-interactive `PATH`. Enable only for sh/bash/dash/zsh remotes; csh/tcsh and Windows targets keep receiving commands verbatim. See [Bare command names and PATH](remote-servers.md#bare-command-names-and-path) |
 | `ssh_key_path` | `null` | Optional SSH private-key path, useful for container/Kubernetes volume mounts |
 | `ssh_options` | `[]` | Extra SSH options. Eneru defaults each remote to `StrictHostKeyChecking=accept-new` (learns and pins the host key on first use; bare metal uses the running user's `~/.ssh/known_hosts`, Docker/Podman uses `/var/lib/eneru/ssh/known_hosts`, Kubernetes samples set a PVC-backed path), so no entry is needed for normal use. Set your own `StrictHostKeyChecking` or `UserKnownHostsFile` to override; avoid `StrictHostKeyChecking=no` in production |
 | `pre_shutdown_commands` | `[]` | Pre-shutdown actions or commands. For loopback entries Eneru generates these from the local config — don't duplicate |

--- a/docs/remote-servers.md
+++ b/docs/remote-servers.md
@@ -318,8 +318,7 @@ with a minimal `PATH`. On Synology in particular that means `/usr/syno/sbin`
 with `sudo: synoshutdown: command not found` even though `which synoshutdown`
 works fine when you SSH in by hand.
 
-When `augment_remote_path: true` is enabled, Eneru appends the standard
-privileged directories (`/usr/local/sbin`,
+Eneru appends the standard privileged directories (`/usr/local/sbin`,
 `/usr/local/bin`, `/usr/sbin`, `/usr/bin`, `/sbin`, `/bin`) plus Synology's
 `/usr/syno/sbin` and `/usr/syno/bin`, so bare binary names resolve in the
 daemon's SSH session exactly like they would in an interactive login. The
@@ -339,22 +338,6 @@ Two consequences worth knowing:
   give an absolute path in `shutdown_command` (e.g.
   `sudo /usr/syno/sbin/synoshutdown -s`). Absolute paths bypass `PATH`
   resolution entirely and always work.
-
-!!! warning "The prefix assumes a POSIX login shell — enable it only there"
-    The `PATH` augmentation is a POSIX-sh `export PATH=...` statement. It works
-    on any remote whose SSH login shell is `sh`/`bash`/`dash`/`zsh` (the vast
-    majority, including Synology). It does **not** work on non-POSIX shells:
-
-    - **csh/tcsh** (FreeBSD / TrueNAS CORE root default): `export` isn't a csh
-      builtin, so every command prints a harmless-but-noisy
-      `export: Command not found.` before running your real command.
-    - **cmd.exe / Windows**: `;` is not a command separator, so the whole
-      line — prefix and your `shutdown_command` together — is handed to a
-      nonexistent `export`. Your shutdown command **silently never runs**.
-
-    Eneru therefore defaults `augment_remote_path` to `false` and sends commands
-    verbatim. On a POSIX remote that needs extra bare-command directories, set
-    it to `true`; otherwise supply absolute paths where needed.
 
 ## Safe test checklist
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -277,7 +277,7 @@ matrix wall-clock is bounded by a smaller slowest group):
 | Group | Focus |
 |-------|-------|
 | CLI | Validation, bare command safety, one-shot output |
-| UPS Single Core | Single UPS events, shutdown paths, embedded API, MQTT, remote PATH opt-out, real Compose timeout shutdown |
+| UPS Single Core | Single UPS events, shutdown paths, embedded API, MQTT, unconditional remote PATH augmentation, real Compose timeout shutdown |
 | UPS Single Auth | v6.0 auth, UPS control, hot-reload, dashboard, event management (tests 52–56) |
 | UPS Multi | Independent UPS groups and local-drain policies |
 | Redundancy Quorum | Quorum behavior and advisory triggers (tests 21–27, 37, 38) |
@@ -358,7 +358,7 @@ The numbered E2E tests are defined in `tests/e2e/groups/*.sh`. There are 61 numb
 | 56 | UPS Single | Event management: a wide-range `/api/v1/events` query returns source-qualified rows, an authenticated `DELETE` removes a real event (anonymous is 401), and a history `from > to` is 400 |
 | 57 | Loopback | Containerized remote SSH with **no** `ssh_options` relies on the built-in `StrictHostKeyChecking=accept-new` default: it learns the host key on the first probe into `/var/lib/eneru/ssh/known_hosts`, reaches `HEALTHY`, and preserves the first learned trust entries after the container is recreated |
 | 58 | CLI | NUT name autodiscovery (issue #71) lists a single exposed UPS with `upsc -l`, auto-corrects the runtime poll target, and logs the `ups.name` fix hint |
-| 59 | UPS Single | Opted-in remote PATH augmentation resolves a Synology-only bare command, while the safe default preserves a custom command verbatim |
+| 59 | UPS Single | Unconditional remote PATH augmentation resolves a Synology-only bare command without per-server configuration |
 | 60 | UPS Single | A real local Compose stack is removed through Eneru's `down -t <seconds>` shutdown path |
 | 61 | Loopback | A real coordinator/list-form delegated poweroff reaches the SSH target, skips in-container poweroff, and persists a `sequence_complete` recovery marker |
 | E1 | CLI | Bash, zsh, and fish shell completion output is syntactically usable |

--- a/examples/config-reference.yaml
+++ b/examples/config-reference.yaml
@@ -551,12 +551,6 @@ remote_servers:
     # Prefix generated privileged actions and final shutdown_command with
     # sudo -n when using a non-root SSH user with NOPASSWD sudo.
     use_sudo: false
-    # Prepend a POSIX-sh `export PATH=...` to every SSH command so bare command
-    # names (e.g. Synology's synoshutdown) resolve in the minimal non-interactive
-    # PATH. Default false so non-POSIX targets (csh/tcsh or Windows) keep
-    # receiving commands verbatim. Enable only for sh/bash/dash/zsh targets
-    # that need bare commands from the expanded path.
-    augment_remote_path: true
     # Optional private key path. Useful when the key is mounted into a
     # Docker/Podman container or Kubernetes pod. If omitted, OpenSSH
     # defaults and ssh_options are used as before.

--- a/src/eneru/config.py
+++ b/src/eneru/config.py
@@ -426,11 +426,6 @@ class RemoteServerConfig:
     command_timeout: int = 30
     shutdown_command: str = "sudo shutdown -h now"
     use_sudo: bool = False
-    # Prepend a POSIX-sh `export PATH=...` to every command sent over SSH so a
-    # bare command name (e.g. Synology's `synoshutdown`) resolves in the minimal
-    # non-interactive PATH (see RemoteShutdownMixin.REMOTE_PATH_PREFIX). Opt in:
-    # prepending POSIX syntax by default would break csh and Windows remotes.
-    augment_remote_path: bool = False
     ssh_key_path: Optional[str] = None
     ssh_options: List[str] = field(default_factory=list)
     pre_shutdown_commands: List[RemoteCommandConfig] = field(default_factory=list)
@@ -1338,7 +1333,6 @@ class ConfigLoader:
                 command_timeout=server_data.get('command_timeout', 30),
                 shutdown_command=server_data.get('shutdown_command', 'sudo shutdown -h now'),
                 use_sudo=server_data.get('use_sudo', False),
-                augment_remote_path=server_data.get('augment_remote_path', False),
                 ssh_key_path=server_data.get('ssh_key_path'),
                 ssh_options=server_data.get('ssh_options', []),
                 pre_shutdown_commands=pre_cmds,
@@ -2044,6 +2038,9 @@ class ConfigLoader:
             remote_server_keys = {
                 "name", "enabled", "host", "user", "connect_timeout",
                 "command_timeout", "shutdown_command", "ssh_key_path",
+                # v6.1.7 exposed this switch briefly. It is accepted but
+                # ignored so upgraded configs still pass strict validation;
+                # remote PATH augmentation is unconditional from v6.1.8.
                 "use_sudo", "augment_remote_path", "ssh_options",
                 "pre_shutdown_commands", "parallel",
                 "shutdown_order", "shutdown_safety_margin",
@@ -3143,12 +3140,6 @@ class ConfigLoader:
                     messages.append(
                         f"ERROR: Remote server '{display}': use_sudo must be "
                         f"a boolean, got {server.use_sudo!r}"
-                    )
-
-                if not isinstance(server.augment_remote_path, bool):
-                    messages.append(
-                        f"ERROR: Remote server '{display}': augment_remote_path "
-                        f"must be a boolean, got {server.augment_remote_path!r}"
                     )
 
                 if not isinstance(server.is_host_loopback, bool):

--- a/src/eneru/shutdown/remote.py
+++ b/src/eneru/shutdown/remote.py
@@ -650,24 +650,11 @@ class RemoteShutdownMixin:
         # execution paths never reach _run_remote_command, so they are
         # correctly left untouched.
         #
-        # F-080: the prefix is a POSIX-sh `export PATH=...` statement. On a
-        # csh/tcsh remote (FreeBSD/TrueNAS CORE root) it emits noisy
-        # "export: Command not found." lines; on a cmd.exe/Windows remote `;`
-        # isn't a separator, so the ENTIRE line becomes args to a nonexistent
-        # `export` and the real shutdown silently never runs. Per-server
-        # `augment_remote_path` is opt-in because Eneru cannot reliably infer a
-        # remote login shell before it sends the command. POSIX targets that
-        # need bare commands can enable it; every other shell stays verbatim.
-        remote_command = (
-            REMOTE_PATH_PREFIX + command
-            if server.augment_remote_path
-            else command
-        )
         ssh_cmd.extend([
             "-o", f"ConnectTimeout={server.connect_timeout}",
             "-o", "BatchMode=yes",  # Prevent password prompts from hanging
             f"{server.user}@{server.host}",
-            remote_command,
+            REMOTE_PATH_PREFIX + command,
         ])
 
         # Add buffer to account for SSH connection overhead, unless a

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.1.7"
+__version__ = "6.1.8"

--- a/tests/e2e/groups/single-ups-core.sh
+++ b/tests/e2e/groups/single-ups-core.sh
@@ -1060,15 +1060,15 @@ echo "PASS: MQTT status payload arrived with power-quality metrics"
 )
 
 # ======================================================================
-# Test 59: Remote PATH augmentation opt-in and safe default both work
+# Test 59: Remote PATH augmentation always resolves bare commands
 # ======================================================================
 (
 echo ""
-echo ">>> Running: Test 59: Remote PATH augmentation opt-in and safe default both work"
+echo ">>> Running: Test 59: Remote PATH augmentation always resolves bare commands"
 
-config=/tmp/config-e2e-path-opt-out.yaml
+config=/tmp/config-e2e-path.yaml
 docker compose -f "$E2E_DIR/docker-compose.yml" exec -T ssh-target \
-  rm -f /tmp/eneru-path-verbatim /tmp/eneru-path-augmented
+  rm -f /tmp/eneru-path-augmented
 cat >"$config" <<'YAML'
 ups:
   name: "TestUPS@localhost:3493"
@@ -1087,22 +1087,11 @@ logging:
 statistics:
   db_directory: "/tmp/eneru-e2e-path-stats"
 remote_servers:
-  - name: "default-path-target"
+  - name: "always-augmented-path-target"
     enabled: true
     host: "localhost"
     user: "testuser"
-    augment_remote_path: true
     shutdown_command: "eneru-path-probe"
-    ssh_options:
-      - "-o Port=2222"
-      - "-o StrictHostKeyChecking=no"
-      - "-o UserKnownHostsFile=/dev/null"
-      - "-o IdentityFile=/tmp/e2e-ssh-key"
-  - name: "verbatim-path-target"
-    enabled: true
-    host: "localhost"
-    user: "testuser"
-    shutdown_command: "/usr/local/bin/verify-unaugmented-path"
     ssh_options:
       - "-o Port=2222"
       - "-o StrictHostKeyChecking=no"
@@ -1117,18 +1106,12 @@ eneru run --config "$config" --exit-after-shutdown \
   2>&1 | tee /tmp/test59.log
 
 if ! docker compose -f "$E2E_DIR/docker-compose.yml" exec -T ssh-target \
-    test -f /tmp/eneru-path-verbatim; then
-  echo "FAIL: safe PATH default did not deliver the custom command verbatim"
-  cat /tmp/test59.log
-  exit 1
-fi
-if ! docker compose -f "$E2E_DIR/docker-compose.yml" exec -T ssh-target \
     test -f /tmp/eneru-path-augmented; then
-  echo "FAIL: opted-in PATH augmentation did not resolve the Synology probe"
+  echo "FAIL: unconditional PATH augmentation did not resolve the Synology probe"
   cat /tmp/test59.log
   exit 1
 fi
-echo "PASS: opted-in PATH augmentation and the safe default both worked"
+echo "PASS: unconditional PATH augmentation resolved the Synology probe"
 )
 
 # ======================================================================

--- a/tests/e2e/ssh-target/Dockerfile
+++ b/tests/e2e/ssh-target/Dockerfile
@@ -40,15 +40,7 @@ RUN echo '#!/bin/bash' > /usr/local/bin/fake-shutdown && \
     echo 'echo "Shutdown initiated"' >> /usr/local/bin/fake-shutdown && \
     chmod +x /usr/local/bin/fake-shutdown
 
-# F-090/F-080: verifies `augment_remote_path: false` sends a custom command
-# without Eneru's POSIX PATH prefix. The command deliberately fails if the
-# Synology-only directory appears in its inherited PATH.
-RUN echo '#!/bin/sh' > /usr/local/bin/verify-unaugmented-path && \
-    echo 'case ":${PATH}:" in *:/usr/syno/sbin:*) exit 42 ;; esac' >> /usr/local/bin/verify-unaugmented-path && \
-    echo 'touch /tmp/eneru-path-verbatim' >> /usr/local/bin/verify-unaugmented-path && \
-    chmod +x /usr/local/bin/verify-unaugmented-path
-
-# Default-path probe: its bare command name resolves only if Eneru prepends the
+# PATH probe: its bare command name resolves only if Eneru prepends the
 # shipped Synology/POSIX directories to the non-interactive SSH command.
 RUN mkdir -p /usr/syno/sbin && \
     echo '#!/bin/sh' > /usr/syno/sbin/eneru-path-probe && \

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1088,6 +1088,23 @@ remote_servers:
         assert server.shutdown_safety_margin == 60  # default
 
     @pytest.mark.unit
+    def test_legacy_augment_remote_path_key_is_accepted_but_ignored(
+        self, temp_config_file
+    ):
+        """A 6.1.7 config upgrades cleanly after PATH becomes unconditional."""
+        temp_config_file.write_text("""
+remote_servers:
+  - host: "nas.lan"
+    user: "ups"
+    augment_remote_path: false
+""")
+
+        config = ConfigLoader.load(str(temp_config_file))
+
+        assert len(config.remote_servers) == 1
+        assert not hasattr(config.remote_servers[0], "augment_remote_path")
+
+    @pytest.mark.unit
     def test_filesystems_sync_disabled(self, temp_config_file):
         """Test disabling filesystem sync."""
         config_data = """

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -1442,7 +1442,6 @@ class TestRunRemoteCommand:
             host="192.168.1.50",
             user="admin",
             connect_timeout=10,
-            augment_remote_path=True,
             ssh_options=["-o StrictHostKeyChecking=no"],
         )
 
@@ -1483,7 +1482,6 @@ class TestRunRemoteCommand:
             host="192.168.1.60",
             user="admin",
             use_sudo=True,
-            augment_remote_path=True,
             shutdown_command="synoshutdown -s",
         )
 
@@ -1503,32 +1501,10 @@ class TestRunRemoteCommand:
             assert sent_command.endswith("sudo -n synoshutdown -s")
 
     @pytest.mark.unit
-    def test_augment_remote_path_false_sends_command_verbatim(self, ssh_monitor):
-        """F-080: a non-POSIX remote (csh/tcsh, cmd.exe) opts out via
-        augment_remote_path=false and receives its command with NO
-        `export PATH=...` prefix, so the POSIX-only statement can't break it."""
-        server = RemoteServerConfig(
-            name="TrueNAS CORE", host="192.168.1.70", user="root",
-            augment_remote_path=False,
-        )
-        with patch("eneru.shutdown.remote.run_command") as mock_run:
-            mock_run.return_value = (0, "", "")
-            ssh_monitor._run_remote_command(server, "shutdown -p now", 30, "test")
-            sent = mock_run.call_args[0][0][-1]
-            assert sent == "shutdown -p now"
-            assert "export PATH" not in sent
-
-    @pytest.mark.unit
-    def test_augment_remote_path_is_opt_in(self, ssh_monitor):
-        """Non-POSIX remotes stay compatible unless PATH expansion is opted in."""
+    def test_remote_path_is_always_augmented(self, ssh_monitor):
+        """Privileged bare commands resolve without a per-server switch."""
         server = RemoteServerConfig(host="192.168.1.50", user="root")
-        assert server.augment_remote_path is False
-        with patch("eneru.shutdown.remote.run_command") as mock_run:
-            mock_run.return_value = (0, "", "")
-            ssh_monitor._run_remote_command(server, "echo hi", 30, "test")
-            assert mock_run.call_args[0][0][-1] == "echo hi"
-
-        server.augment_remote_path = True
+        assert not hasattr(server, "augment_remote_path")
         with patch("eneru.shutdown.remote.run_command") as mock_run:
             mock_run.return_value = (0, "", "")
             ssh_monitor._run_remote_command(server, "echo hi", 30, "test")


### PR DESCRIPTION
## What changed

- remove the `augment_remote_path` runtime option
- prepend the standard privileged and Synology PATH entries to every remote SSH command
- accept the short-lived 6.1.7 YAML key as ignored upgrade baggage
- update synthetic and real SSH E2E coverage
- bump Eneru to 6.1.8 and add release notes

This branch is based on `main` after PRs #95 and #96, so the release includes the matched CodeQL 4.37.0 `init` and `analyze` updates.

## Why

6.1.7 contained the Synology PATH fix but shipped it disabled by default. Existing production configurations could still send `sudo -n synoshutdown -s` through a minimal non-interactive PATH and fail with `command not found` during an outage.

## Validation

- 337 focused remote/config tests passed
- full parallel unit run: 3,261 passed; 3 environment-sensitive package-wrapper tests fail only because the local host exposes extra Python interpreters, and clean CI is authoritative
- every source file remains at or above 95% coverage; overall 97%
- strict MkDocs build passed
- every example config validated as Eneru 6.1.8
- wheel and sdist built successfully
- production config remote shutdown drill passed in dry-run mode with no commands executed
- E2E Test 59 proves the Synology-only bare command resolves with no opt-in key

External AI reviews intentionally not triggered per maintainer instruction for this narrow release fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always prepend an expanded PATH to every remote SSH command so bare commands (e.g., Synology `synoshutdown`) resolve reliably; removed the `augment_remote_path` toggle and released as 6.1.8 to prevent “command not found” failures during outages.

- **Bug Fixes**
  - Always add standard privileged dirs plus Synology dirs to remote commands.
  - Removed `augment_remote_path`; 6.1.7 configs that include it still validate, but it’s ignored.
  - Updated docs, examples, and E2E/unit tests to reflect unconditional behavior.
  - Version bumped to 6.1.8 with changelog entry.

- **Migration**
  - No action required. You may delete `augment_remote_path` from configs; it has no effect.

<sup>Written for commit 8c9a5295f5a4f52c0ed037ecfd4ea8e8d800bb7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

