### PR TITLE
Update release.yml to support multi-arch OCI image manifests

### DIFF
--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -6,14 +6,9 @@ description: >-
   All four E2E matrix jobs invoke this action so they share an
   identical, isolated test environment.
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh
-# periodically by re-running
-# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
-# tracked actions, `gh api repos/<owner>/<repo>/branches/<branch>`)
-# and updating both the SHA and the comment in lockstep across every
-# workflow.
+# Third-party actions use readable upstream release refs. Dependabot watches
+# this composite action weekly; review its release notes and let CI test each
+# proposed update. The accepted mutability tradeoff is in docs/maintenance.md.
 
 inputs:
   e2e-dir:
@@ -25,8 +20,8 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      # ISS-041: kept in lockstep with the workflows' setup-python pin.
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      # ISS-041: kept in lockstep with the workflows' setup-python version.
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -48,7 +43,7 @@ runs:
         cp /tmp/e2e-ssh-key.pub ${{ inputs.e2e-dir }}/ssh-target/authorized_keys
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      uses: docker/setup-buildx-action@v4.2.0
 
     # Pre-build the two E2E image contexts once, with the GitHub Actions
     # cache backend, then bring the stack up with --no-build. Before
@@ -63,7 +58,7 @@ runs:
     # token the gha cache backend needs — a raw `docker buildx build`
     # would additionally require crazy-max/ghaction-github-runtime.
     - name: Build nut-dummy image (cached)
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      uses: docker/build-push-action@v7.3.0
       with:
         context: ${{ inputs.e2e-dir }}/nut-dummy
         load: true
@@ -72,7 +67,7 @@ runs:
         cache-to: type=gha,mode=max,scope=e2e-nut-dummy
 
     - name: Build ssh-target image (cached)
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      uses: docker/build-push-action@v7.3.0
       with:
         context: ${{ inputs.e2e-dir }}/ssh-target
         load: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,9 @@ version: 2
 updates:
   # Keep GitHub Actions up to date.
   # ISS-041: the default "/" directory only scans .github/workflows; composite
-  # actions under .github/actions/ were invisible to Dependabot, so their pins
-  # rotted structurally (e2e-setup drifted from the workflows' setup-python pin).
-  # List both so composite-action pins get update PRs too.
+  # actions under .github/actions/ were invisible to Dependabot, so their
+  # versions drifted (e2e-setup diverged from the workflows' setup-python ref).
+  # List both so composite-action release refs get update PRs too.
   - package-ecosystem: "github-actions"
     directories:
       - "/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,11 +9,8 @@ on:
     # Run weekly on Monday at 06:00 UTC
     - cron: '0 6 * * 1'
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh by
-# re-running `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` and
-# updating both the SHA and the comment.
+# Third-party actions use readable upstream release refs. Dependabot proposes
+# updates weekly; review their release notes and let CI test each change.
 jobs:
   analyze:
     name: Analyze (Python)
@@ -27,14 +24,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,14 +9,8 @@ on:
 env:
   E2E_DIR: tests/e2e
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh
-# periodically by re-running
-# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
-# tracked actions like pypa/gh-action-pypi-publish@release/v1,
-# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
-# the SHA and the comment in lockstep across every workflow.
+# Third-party actions use readable upstream release refs. Dependabot proposes
+# updates weekly; review their release notes and let CI test each change.
 #
 # Each E2E group runs as a separate matrix job so they execute in
 # parallel. Total wall-clock is bounded by the slowest group instead
@@ -70,7 +64,7 @@ jobs:
           - { group: loopback,              label: "Loopback" }
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Set up E2E environment
         uses: ./.github/actions/e2e-setup

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -398,7 +398,7 @@ jobs:
   # not depend on a GHCR tag that may not exist before the first 5.4 release.
   test-oci-image:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -421,6 +421,36 @@ jobs:
           # blocks on the initial NUT connection, and there's no NUT server in
           # this job) — that runs in E2E Test 46 against the real NUT dummy.
           docker run --rm --entrypoint python eneru:ci -c "import importlib.resources as r; assert (r.files('eneru.web')/'index.html').read_text().find('<title>Eneru</title>') >= 0; print('dashboard asset present in image')"
+
+      # This is the ARM equivalent of starting the engine before shipping the
+      # car: QEMU boots the actual ARM64 image and checks its native wheels.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Build ARM64 OCI image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: eneru:ci-arm64
+          build-args: |
+            VERSION=${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha,scope=oci-arm64
+          cache-to: type=gha,mode=max,scope=oci-arm64
+
+      - name: Verify ARM64 OCI image
+        run: |
+          docker run --rm --platform linux/arm64 eneru:ci-arm64 version
+          docker run --rm --platform linux/arm64 eneru:ci-arm64 validate --config /etc/ups-monitor/config.yaml
+          docker run --rm --platform linux/arm64 --entrypoint python eneru:ci-arm64 -c "import bcrypt, yaml; print('ARM64 dependencies import correctly')"
+          ACTUAL=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' eneru:ci-arm64)
+          test "$ACTUAL" = "${{ steps.version.outputs.VERSION }}"
 
       - name: Verify OCI image with Podman
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,14 +6,8 @@ on:
   pull_request:
     branches: [main]
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh
-# periodically by re-running
-# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
-# tracked actions like pypa/gh-action-pypi-publish@release/v1,
-# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
-# the SHA and the comment in lockstep across every workflow.
+# Third-party actions use readable upstream release refs. Dependabot proposes
+# updates weekly; review their release notes and let CI test each change.
 #
 # nFPM is pinned to a specific release AND its archive is verified
 # against the goreleaser-published checksums.txt before extraction.
@@ -39,10 +33,10 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -94,7 +88,7 @@ jobs:
           VERSION=${{ steps.version.outputs.VERSION }} nfpm package --packager rpm --target . -f nfpm-el8.yaml
 
       - name: Upload packages
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: packages
           path: |
@@ -113,10 +107,10 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -165,10 +159,10 @@ jobs:
       image: ${{ matrix.distro }}:${{ matrix.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Download packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: packages
 
@@ -230,10 +224,10 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Download packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: packages
 
@@ -364,7 +358,7 @@ jobs:
       image: ${{ matrix.image || format('{0}:{1}', matrix.distro, matrix.version) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Install pip and dependencies (Debian/Ubuntu)
         if: matrix.distro != ''
@@ -401,7 +395,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
 
       - name: Extract version
         id: version

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -388,11 +388,13 @@ jobs:
             eneru validate --config "$config"
           done
 
-  # Build the official OCI image from the checked-out commit. PR CI must
-  # not depend on a GHCR tag that may not exist before the first 5.4 release.
-  test-oci-image:
+  # Build the official OCI image from the checked-out commit. PR CI must not
+  # depend on a GHCR tag that may not exist before the release publishes it.
+  # Native runners build both architectures in parallel; test-oci-image below
+  # keeps the stable branch-protection context and gates both results.
+  test-oci-image-amd64:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0
@@ -416,36 +418,6 @@ jobs:
           # this job) — that runs in E2E Test 46 against the real NUT dummy.
           docker run --rm --entrypoint python eneru:ci -c "import importlib.resources as r; assert (r.files('eneru.web')/'index.html').read_text().find('<title>Eneru</title>') >= 0; print('dashboard asset present in image')"
 
-      # This is the ARM equivalent of starting the engine before shipping the
-      # car: QEMU boots the actual ARM64 image and checks its native wheels.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.2.0
-        with:
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
-
-      - name: Build ARM64 OCI image
-        uses: docker/build-push-action@v7.3.0
-        with:
-          context: .
-          platforms: linux/arm64
-          load: true
-          tags: eneru:ci-arm64
-          build-args: |
-            VERSION=${{ steps.version.outputs.VERSION }}
-          cache-from: type=gha,scope=oci-arm64
-          cache-to: type=gha,mode=max,scope=oci-arm64
-
-      - name: Verify ARM64 OCI image
-        run: |
-          docker run --rm --platform linux/arm64 eneru:ci-arm64 version
-          docker run --rm --platform linux/arm64 eneru:ci-arm64 validate --config /etc/ups-monitor/config.yaml
-          docker run --rm --platform linux/arm64 --entrypoint python eneru:ci-arm64 -c "import bcrypt, yaml; print('ARM64 dependencies import correctly')"
-          ACTUAL=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' eneru:ci-arm64)
-          test "$ACTUAL" = "${{ steps.version.outputs.VERSION }}"
-
       - name: Verify OCI image with Podman
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -456,3 +428,47 @@ jobs:
           docker save localhost/eneru:ci -o /tmp/eneru-ci.tar
           sudo podman load -i /tmp/eneru-ci.tar
           sudo podman run --rm localhost/eneru:ci version
+
+  # A native ARM runner is the actual road, not a QEMU driving simulator. It
+  # validates the architecture-specific wheels while avoiding emulation cost.
+  test-oci-image-arm64:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.0
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/eneru/version.py)
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build ARM64 OCI image natively
+        run: docker build --build-arg VERSION=${{ steps.version.outputs.VERSION }} -t eneru:ci-arm64 .
+
+      - name: Verify ARM64 OCI image
+        run: |
+          docker run --rm eneru:ci-arm64 version
+          docker run --rm eneru:ci-arm64 validate --config /etc/ups-monitor/config.yaml
+          docker run --rm --entrypoint python eneru:ci-arm64 -c "import bcrypt, yaml; print('ARM64 dependencies import correctly')"
+          ARCH=$(docker image inspect --format '{{ .Architecture }}' eneru:ci-arm64)
+          test "$ARCH" = "arm64"
+          ACTUAL=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' eneru:ci-arm64)
+          test "$ACTUAL" = "${{ steps.version.outputs.VERSION }}"
+
+  # Branch protection requires this exact job ID. The small aggregator makes
+  # that one check represent both parallel architecture jobs.
+  test-oci-image:
+    needs: [test-oci-image-amd64, test-oci-image-arm64]
+    if: always()
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Require both OCI architecture jobs
+        env:
+          AMD64_RESULT: ${{ needs.test-oci-image-amd64.result }}
+          ARM64_RESULT: ${{ needs.test-oci-image-arm64.result }}
+        run: |
+          test "$AMD64_RESULT" = "success"
+          test "$ARM64_RESULT" = "success"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,14 +15,8 @@ on:
         type: string
         default: 'main'
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh
-# periodically by re-running
-# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
-# tracked actions like pypa/gh-action-pypi-publish@release/v1,
-# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
-# the SHA and the comment in lockstep across every workflow.
+# Third-party actions use readable upstream release refs. Dependabot proposes
+# updates weekly; review their release notes and let CI test each change.
 #
 # Split build and publish into separate jobs so the OIDC `id-token:
 # write` permission only applies to the publish step, not to
@@ -36,12 +30,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -87,7 +81,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: dist
           path: dist/
@@ -100,10 +94,10 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,65 +189,90 @@ jobs:
           PY
           nfpm package --packager rpm --target . -f nfpm-el8.yaml
           ls -la -- ./*.el8.*.rpm
+          
+      # Set up Qemu for multi-architecture support (e.g., ARM64)
+      - name: Set up Qemu
+        uses: docker/setup-qemu-action@v3
 
-      - name: Build OCI image
+      # Set up the Buildx builder instance
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Authenticate to your container registry
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Prepare IMAGE_NAME
+      - name: Prepare IMAGE_NAME
+        id: image_name
         env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
           IMAGE_NAME: ghcr.io/${{ github.repository }}
         run: |
+          IMAGE_NAME=ghcr.io/${{ github.repository }}
           IMAGE_NAME="${IMAGE_NAME,,}"
-          # Docker installs the copied source with pip, and
-          # pyproject.toml derives the package version from this file.
-          # Keep the OCI image on the clean release version so the
-          # wheel metadata and exact image tag are both valid/simple.
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+
+      # Docker installs the copied source with pip, and
+      # pyproject.toml derives the package version from this file.
+      # Keep the OCI image on the clean release version so the
+      # wheel metadata and exact image tag are both valid/simple.
+      - name: Prepare version.py
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
           sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" src/eneru/version.py
           grep "__version__" src/eneru/version.py
-          docker build --build-arg VERSION="$VERSION" -t "${IMAGE_NAME}:${VERSION}" .
-
+      
+      # Build and push using Buildx
       # F-014: push ONLY the immutable version tag first, verify it below, and
       # only then move the `:latest`/`:testing` channel alias onto it. This
       # keeps a broken build from ever landing on `:latest`/`:testing` while
-      # verification fails. F-037: GITHUB_TOKEN and the actor username are passed
-      # via env (referenced as "$GITHUB_TOKEN"/"$ACTOR") rather than interpolated
-      # into the shell text, so a value containing quotes/backslashes can't break
-      # the step or inject shell.
-      - name: Push versioned OCI image to GHCR
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-          IMAGE_NAME: ghcr.io/${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          IMAGE_NAME="${IMAGE_NAME,,}"
-          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-          docker push "${IMAGE_NAME}:${VERSION}"
+      # verification fails.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image_name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+          # Optional: Enables GitHub Actions cache backend for faster builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Verify pushed OCI image
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-          IMAGE_NAME: ghcr.io/${{ github.repository }}
+      - name: Verify Multi-Arch Manifest
         run: |
-          IMAGE_NAME="${IMAGE_NAME,,}"
-          docker pull "${IMAGE_NAME}:${VERSION}"
-          docker run --rm "${IMAGE_NAME}:${VERSION}" version
+          docker buildx imagetools inspect ${{ steps.image_name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} | grep -E "Platform:.*linux/amd64"
+          docker buildx imagetools inspect ${{ steps.image_name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} | grep -E "Platform:.*linux/arm64"
+      
+      # Test/Run the specific architectures locally on the runner
+      - name: Test AMD64 Container
+        run: |
+          docker run --rm --platform linux/amd64 "${{ steps.image_name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}" version
+
+      # QEMU automatically handles this execution transparently
+      - name: Test ARM64 Container
+        run: |
+          docker run --rm --platform linux/arm64 "${{ steps.image_name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}" version
 
       # F-014: only now — after the versioned image is verified — promote the
-      # channel alias. `docker login` from the push step above persists in the
-      # runner's docker config for this job, so no re-login (and no extra
-      # wall-clock) is needed. Stable -> `:latest`, pre-release -> `:testing`.
+      # channel alias.
+      # buildx imagetools create is used to create the latest/testing manifest from the source VERSION manifest
+      # Stable -> `:latest`, pre-release -> `:testing`.
       - name: Promote OCI channel alias
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           CHANNEL: ${{ steps.channel.outputs.CHANNEL }}
-          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          IMAGE_NAME: ${{ steps.image_name.outputs.IMAGE_NAME }}
         run: |
-          IMAGE_NAME="${IMAGE_NAME,,}"
           if [ "$CHANNEL" = "stable" ]; then
-            docker tag "${IMAGE_NAME}:${VERSION}" "${IMAGE_NAME}:latest"
-            docker push "${IMAGE_NAME}:latest"
+            docker buildx imagetools create -t "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${VERSION}"
           else
-            docker tag "${IMAGE_NAME}:${VERSION}" "${IMAGE_NAME}:testing"
-            docker push "${IMAGE_NAME}:testing"
+            docker buildx imagetools create -t "${IMAGE_NAME}:testing" "${IMAGE_NAME}:${VERSION}"
           fi
 
       - name: Upload packages to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,8 @@ on:
         type: string
         default: 'main'
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh
-# periodically by re-running
-# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
-# tracked actions like pypa/gh-action-pypi-publish@release/v1,
-# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
-# the SHA and the comment in lockstep across every workflow.
+# Third-party actions use readable upstream release refs. Dependabot proposes
+# updates weekly; review their release notes and let CI test each change.
 #
 # nFPM is pinned + checksum-verified; bump NFPM_VERSION here to refresh.
 env:
@@ -52,7 +46,7 @@ jobs:
       version_full: ${{ steps.version.outputs.VERSION_FULL }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           # ISS-010 (minimal hardening): this job pip-installs the full
@@ -64,7 +58,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -273,7 +267,7 @@ jobs:
 
       - name: Upload packages to GitHub Release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
@@ -321,7 +315,7 @@ jobs:
 
       - name: Checkout gh-pages branch
         if: steps.ghpages.outputs.exists == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@v7.0.0
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,31 +190,25 @@ jobs:
           nfpm package --packager rpm --target . -f nfpm-el8.yaml
           ls -la -- ./*.el8.*.rpm
           
-      # Set up Qemu for multi-architecture support (e.g., ARM64)
-      - name: Set up Qemu
-        uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.2.0
 
-      # Set up the Buildx builder instance
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.2.0
 
-      # Authenticate to your container registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Prepare IMAGE_NAME
       - name: Prepare IMAGE_NAME
         id: image_name
-        env:
-          IMAGE_NAME: ghcr.io/${{ github.repository }}
         run: |
-          IMAGE_NAME=ghcr.io/${{ github.repository }}
+          IMAGE_NAME="ghcr.io/${{ github.repository }}"
           IMAGE_NAME="${IMAGE_NAME,,}"
-          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
 
       # Docker installs the copied source with pip, and
       # pyproject.toml derives the package version from this file.
@@ -233,13 +227,15 @@ jobs:
       # keeps a broken build from ever landing on `:latest`/`:testing` while
       # verification fails.
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.image_name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.VERSION }}
           # Optional: Enables GitHub Actions cache backend for faster builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,14 +11,8 @@ on:
 permissions:
   contents: read
 
-# All third-party action invocations are SHA-pinned (with the
-# corresponding tag in a comment) so a moved tag in the upstream
-# action repo cannot silently change what runs in CI. Refresh
-# periodically by re-running
-# `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (or, for branch-
-# tracked actions like pypa/gh-action-pypi-publish@release/v1,
-# `gh api repos/<owner>/<repo>/branches/<branch>`) and updating both
-# the SHA and the comment in lockstep across every workflow.
+# Third-party actions use readable upstream release refs. Dependabot proposes
+# updates weekly; review their release notes and let CI test each change.
 jobs:
   # F-042: cheap regression guard against XSS sinks in the dashboard. The
   # dashboard deliberately builds DOM via el()/txt() helpers behind a strict
@@ -30,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - uses: actions/checkout@v7.0.0
     - name: Forbid innerHTML / insertAdjacentHTML / eval( under src/eneru/web
       run: |
         if grep -rnE 'innerHTML|insertAdjacentHTML|eval\(' src/eneru/web/; then
@@ -62,10 +56,10 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - uses: actions/checkout@v7.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -119,7 +113,7 @@ jobs:
       # 3.12 is in both the reduced PR matrix and the full push matrix, so
       # coverage uploads on PRs as well as on main.
       if: matrix.python-version == '3.12'
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage.xml
         fail_ci_if_error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ This repo deliberately keeps individual source files on the smaller side (the v5
 
 `main` is protected. All changes go through feature branches and pull requests.
 
-**Branch protection on `main`:** required checks = `validate` (reduced PR matrix `3.9`, `3.12`, `3.15-dev`; only `3.9` + `3.12` required) + `test-oci-image` (AMD64, ARM64/QEMU, config, native dependency, metadata, and Podman smoke checks) + **8** parallel E2E matrix jobs (`E2E CLI`, `E2E UPS Single Core`, `E2E UPS Single Auth`, `E2E UPS Multi`, `E2E Redundancy Quorum`, `E2E Redundancy Regression`, `E2E Stats`, `E2E Loopback`). Strict mode (branch up-to-date with main), enforce admins, no force pushes, 0 required reviewers (CI-gated), branches auto-delete after merge.
+**Branch protection on `main`:** required checks = `validate` (reduced PR matrix `3.9`, `3.12`, `3.15-dev`; only `3.9` + `3.12` required) + `test-oci-image` (aggregates parallel native AMD64 and ARM64 builds, config/native-dependency/metadata checks, and the Podman smoke) + **8** parallel E2E matrix jobs (`E2E CLI`, `E2E UPS Single Core`, `E2E UPS Single Auth`, `E2E UPS Multi`, `E2E Redundancy Quorum`, `E2E Redundancy Regression`, `E2E Stats`, `E2E Loopback`). Strict mode (branch up-to-date with main), enforce admins, no force pushes, 0 required reviewers (CI-gated), branches auto-delete after merge.
 
 **Workflow:**
 ```text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ This repo deliberately keeps individual source files on the smaller side (the v5
 
 `main` is protected. All changes go through feature branches and pull requests.
 
-**Branch protection on `main`:** required checks = `validate` (reduced PR matrix `3.9`, `3.12`, `3.15-dev`; only `3.9` + `3.12` required) + **8** parallel E2E matrix jobs (`E2E CLI`, `E2E UPS Single Core`, `E2E UPS Single Auth`, `E2E UPS Multi`, `E2E Redundancy Quorum`, `E2E Redundancy Regression`, `E2E Stats`, `E2E Loopback`). Strict mode (branch up-to-date with main), enforce admins, no force pushes, 0 required reviewers (CI-gated), branches auto-delete after merge.
+**Branch protection on `main`:** required checks = `validate` (reduced PR matrix `3.9`, `3.12`, `3.15-dev`; only `3.9` + `3.12` required) + `test-oci-image` (AMD64, ARM64/QEMU, config, native dependency, metadata, and Podman smoke checks) + **8** parallel E2E matrix jobs (`E2E CLI`, `E2E UPS Single Core`, `E2E UPS Single Auth`, `E2E UPS Multi`, `E2E Redundancy Quorum`, `E2E Redundancy Regression`, `E2E Stats`, `E2E Loopback`). Strict mode (branch up-to-date with main), enforce admins, no force pushes, 0 required reviewers (CI-gated), branches auto-delete after merge.
 
 **Workflow:**
 ```text
@@ -141,7 +141,7 @@ Tags are the immutable release snapshots; no release branches. Point releases (`
 
 Three layers of AI review, all **manually invoked** (free-tier quotas: CodeRabbit one review/45 min, cubic.dev 40/month; per-commit auto-review burns quota on noisy intermediate diffs while the E2E suite already gates every push):
 
-1. **Pre-push:** spawn the `agent-skills:code-reviewer` skill as a SUBAGENT via the `Agent` tool (fresh context = independent opinion — a same-session review defends its own choices; findings come back P0-P3, triage before pushing).
+1. **Pre-push:** spawn the `agent-skills:code-reviewer` skill as a SUBAGENT via the `Agent` tool (fresh context = independent opinion — a same-session review defends its own choices; findings come back P0-P3, triage before pushing). Record the reviewer's exact model identifier and reasoning level in the review audit trail when the runtime exposes them; never guess missing metadata.
    - if you're Claude Code, you must leverage the `model: opus`.
    - if you're Codex, you must leverage the `model: gpt-5.5` with `reasoning_effort: high`.
 2. **After CI is green** (never before), post in PR comments:
@@ -164,7 +164,7 @@ Two install methods with different invocation styles — package (deb/rpm → `s
 
 ## Maintenance reference
 
-GitHub Actions SHA-pin refresh (quarterly), the nFPM pin, the deliberate Docker-base-image freshness exception (ISS-045), and GitHub-release mechanics live in `docs/maintenance.md`. Read it before touching workflow pins or cutting a release.
+GitHub Actions tag maintenance, the nFPM pin, the deliberate Docker-base-image freshness policy (ISS-045), and GitHub-release mechanics live in `docs/maintenance.md`. Read it before touching workflow refs or cutting a release.
 
 ## Key Dependencies
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Official ARM64 OCI images.** Release tags now publish one multi-platform
+  manifest for `linux/amd64` and `linux/arm64`. Pulling the same tag selects the
+  correct image automatically. PR CI also builds and runs the ARM64 image under
+  QEMU, validates the bundled configuration, and imports the architecture-
+  sensitive `bcrypt` dependency.
+
 ## [6.1.8] - 2026-07-12
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ARM64 missing from the official OCI artifact.** Release tags now publish
   one multi-platform manifest for `linux/amd64` and `linux/arm64`. Pulling the
-  same tag selects the correct image automatically. PR CI also builds and runs
-  the ARM64 image under QEMU, validates the bundled configuration, and imports
-  the architecture-sensitive `bcrypt` dependency.
+  same tag selects the correct image automatically. PR CI builds AMD64 and
+  ARM64 images in parallel on native GitHub-hosted runners, validates the
+  bundled configuration, and imports the architecture-sensitive `bcrypt`
+  dependency.
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,13 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- **Official ARM64 OCI images.** Release tags now publish one multi-platform
-  manifest for `linux/amd64` and `linux/arm64`. Pulling the same tag selects the
-  correct image automatically. PR CI also builds and runs the ARM64 image under
-  QEMU, validates the bundled configuration, and imports the architecture-
-  sensitive `bcrypt` dependency.
+- **ARM64 missing from the official OCI artifact.** Release tags now publish
+  one multi-platform manifest for `linux/amd64` and `linux/arm64`. Pulling the
+  same tag selects the correct image automatically. PR CI also builds and runs
+  the ARM64 image under QEMU, validates the bundled configuration, and imports
+  the architecture-sensitive `bcrypt` dependency.
+
+### Changed
+
+- **Readable GitHub Actions release refs.** Workflows now use upstream version
+  tags instead of opaque commit SHAs. Dependabot continues to propose weekly
+  updates, with release-note review and the full CI matrix as the maintenance
+  gate.
 
 ## [6.1.8] - 2026-07-12
 

--- a/docs/containers-kubernetes.md
+++ b/docs/containers-kubernetes.md
@@ -7,6 +7,10 @@ docker pull ghcr.io/m4r1k/eneru:latest
 podman pull ghcr.io/m4r1k/eneru:latest
 ```
 
+The same tag supports `linux/amd64` and `linux/arm64`; Docker and Podman
+automatically pull the image matching the host. The published image supports
+64-bit ARM systems, not 32-bit ARM devices.
+
 The v5.5 image is **first-class for both remote-only and full
 local-host deployments**. For local-host ownership from a container,
 Eneru SSHes to the host it runs on (the "loopback delegate") so the

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,62 +4,54 @@ Maintainer-facing reference: dependency pinning, installation layouts, and
 release mechanics. Day-to-day contributor rules live in `AGENTS.md` at the
 repo root; this page holds the detail that is only needed a few times a year.
 
-## GitHub Actions SHA pin maintenance
+## GitHub Actions tag maintenance
 
-Every third-party GitHub Actions invocation across the workflows
-(`validate.yml`, `integration.yml`, `e2e.yml`, `codeql.yml`, `pypi.yml`,
-`release.yml`, plus `.github/actions/e2e-setup/action.yml`) is pinned to a
-full commit SHA with the corresponding tag in a trailing comment. A moved
-upstream tag therefore cannot silently change what runs in CI — the pinned
-SHA is the single source of truth.
+Third-party GitHub Actions use readable upstream release refs across the
+workflows and `.github/actions/e2e-setup/action.yml`. Think of the ref as the
+label on a toolbox: `@v7.0.0` tells a maintainer what is inside at a glance,
+while a 40-character commit ID must be looked up before it means anything.
 
-These pins drift over time as upstream actions ship security fixes,
-dependency bumps, and bug fixes under the same major-version tag. The repo
-doesn't auto-renew them; refresh **about every 3 months**, or when a security
-advisory lands for one of the pinned actions, or when an upstream
-major-version bump is needed.
+The tradeoff is deliberate: unlike a commit SHA, an upstream tag or release
+branch can be moved. Eneru accepts that supply-chain risk for maintainability
+and limits it by using actions from trusted publishers, having Dependabot scan
+both workflow and composite-action directories weekly, reviewing upstream
+release notes, and requiring CI to pass before an update merges.
 
-**How to refresh:**
+Prefer an exact release tag when the publisher provides one. Use a maintained
+major tag when that is the action's normal release channel, and retain an
+official release branch only where the publisher documents one (currently
+`pypa/gh-action-pypi-publish@release/v1`). Dependabot opens update PRs; review
+the proposed ref and release notes, then let the full CI matrix test it.
 
-```bash
-# For tag-tracked actions (most cases — actions/checkout@v6, etc.):
-gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.sha'
+The current set (as of 2026-07-13):
 
-# For branch-tracked actions (pypa/gh-action-pypi-publish@release/v1):
-gh api repos/<owner>/<repo>/branches/<branch> --jq '.commit.sha'
-```
-
-Update both the SHA and the `# vX.Y` trailing comment in lockstep. After
-bumping, run the full CI matrix on a throwaway branch before merging — silent
-breakage is the failure mode the pins exist to prevent in the first place.
-
-The current pinned set (as of 2026-06-29):
-
-| Action | Tag | SHA prefix |
-|---|---|---|
-| `actions/checkout` | `v7.0.0` | `9c091bb2…` |
-| `actions/setup-python` | `v6` | `ece7cb06…` |
-| `actions/upload-artifact` | `v7` | `043fb46d…` |
-| `actions/download-artifact` | `v8` | `3e5f45b2…` |
-| `codecov/codecov-action` | `v6` | `fb8b3582…` |
-| `github/codeql-action` | `v4` | `54f647b7…` |
-| `pypa/gh-action-pypi-publish` | `release/v1` | `cef22109…` |
-| `softprops/action-gh-release` | `v3` | `718ea10b…` |
-| `docker/setup-buildx-action` | `v4.2.0` | `bb05f3f5…` |
-| `docker/build-push-action` | `v7.3.0` | `53b7df96…` |
+| Action | Release ref |
+|---|---|
+| `actions/checkout` | `v7.0.0` |
+| `actions/setup-python` | `v6` |
+| `actions/upload-artifact` | `v7.0.1` |
+| `actions/download-artifact` | `v8.0.1` |
+| `codecov/codecov-action` | `v6` |
+| `github/codeql-action` | `v4` |
+| `pypa/gh-action-pypi-publish` | `release/v1` |
+| `softprops/action-gh-release` | `v3` |
+| `docker/setup-qemu-action` | `v4.2.0` |
+| `docker/setup-buildx-action` | `v4.2.0` |
+| `docker/login-action` | `v4.4.0` |
+| `docker/build-push-action` | `v7.3.0` |
 
 `nFPM` is similarly pinned (`NFPM_VERSION` env var in `release.yml` and
 `integration.yml`) and verified against the goreleaser-published
 `checksums.txt` before extraction. Bump the version constant and the checksum
 check still verifies the new download.
 
-The **Docker base image** (`Dockerfile`, `python:3.12-slim-trixie`) is
-deliberately NOT digest-pinned (ISS-045). A base OS image is the one
-dependency where freshness beats reproducibility: the mutable tag plus
+The **Docker base image** (`Dockerfile`, `python:3.12-slim-trixie`) is also
+deliberately tag-based rather than digest-pinned (ISS-045). For the base OS,
+freshness beats reproducibility: the mutable tag plus
 `apt-get upgrade -y` pulls current security patches on every build, whereas a
 frozen digest drifts stale (and potentially vulnerable) between manual
-refreshes. This is the intentional exception to the SHA-pinning convention,
-which still governs GitHub Actions and nFPM.
+refreshes. nFPM remains version-pinned and checksum-verified because it is a
+downloaded executable rather than an action or base image.
 
 ## Installation paths
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -255,7 +255,7 @@ workflow.
 | Config hot-reload | Strict load+validate (bad YAML / non-mapping / validation error rejected, running config kept), safe-vs-restart classification, in-place live apply across shared + per-monitor configs, subsystem reload hooks for stats/notifications/MQTT/remote-health, SIGHUP handler and API `/config/reload` endpoint |
 | Periodic reports | Daily/weekly/monthly scheduling and deduplication, retry after gather/render/enqueue failures, previous-full-day event and uptime windows, current-day/month energy windows, aggregate multi-UPS delivery |
 | Web dashboard | Static asset serving via `importlib.resources`, MIME mapping, path-traversal rejection, strict CSP + `nosniff` on HTML, bytes-body responses, dashboard open before the read gate, event filters, sortable Time header, uppercase remote-health status rendering, control variable forms, `nutControl` exposure in the config summary, Power-tab line-quality handling for AVR `BOOST`/`TRIM` versus binary bypass/overload states, and marker guards for the asset-level surfaces with no browser in CI (`[hidden]` reset, resize-safe graph, wide-history range/paging, delete-selected, drill-down, Light/Dark/System theme) |
-| Packaging | nFPM file list, package install paths, dynamic EL8 interpreter re-exec, EL8 repository routing, exact-version release smoke contracts, safe artifact selection, OCI image smoke tests |
+| Packaging | nFPM file list, package install paths, dynamic EL8 interpreter re-exec, EL8 repository routing, exact-version release smoke contracts, safe artifact selection, AMD64 and QEMU-backed ARM64 OCI smoke tests |
 
 ## End-to-end tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -255,7 +255,7 @@ workflow.
 | Config hot-reload | Strict load+validate (bad YAML / non-mapping / validation error rejected, running config kept), safe-vs-restart classification, in-place live apply across shared + per-monitor configs, subsystem reload hooks for stats/notifications/MQTT/remote-health, SIGHUP handler and API `/config/reload` endpoint |
 | Periodic reports | Daily/weekly/monthly scheduling and deduplication, retry after gather/render/enqueue failures, previous-full-day event and uptime windows, current-day/month energy windows, aggregate multi-UPS delivery |
 | Web dashboard | Static asset serving via `importlib.resources`, MIME mapping, path-traversal rejection, strict CSP + `nosniff` on HTML, bytes-body responses, dashboard open before the read gate, event filters, sortable Time header, uppercase remote-health status rendering, control variable forms, `nutControl` exposure in the config summary, Power-tab line-quality handling for AVR `BOOST`/`TRIM` versus binary bypass/overload states, and marker guards for the asset-level surfaces with no browser in CI (`[hidden]` reset, resize-safe graph, wide-history range/paging, delete-selected, drill-down, Light/Dark/System theme) |
-| Packaging | nFPM file list, package install paths, dynamic EL8 interpreter re-exec, EL8 repository routing, exact-version release smoke contracts, safe artifact selection, AMD64 and QEMU-backed ARM64 OCI smoke tests |
+| Packaging | nFPM file list, package install paths, dynamic EL8 interpreter re-exec, EL8 repository routing, exact-version release smoke contracts, safe artifact selection, readable Actions-ref policy, AMD64 and QEMU-backed ARM64 OCI smoke tests |
 
 ## End-to-end tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -255,7 +255,7 @@ workflow.
 | Config hot-reload | Strict load+validate (bad YAML / non-mapping / validation error rejected, running config kept), safe-vs-restart classification, in-place live apply across shared + per-monitor configs, subsystem reload hooks for stats/notifications/MQTT/remote-health, SIGHUP handler and API `/config/reload` endpoint |
 | Periodic reports | Daily/weekly/monthly scheduling and deduplication, retry after gather/render/enqueue failures, previous-full-day event and uptime windows, current-day/month energy windows, aggregate multi-UPS delivery |
 | Web dashboard | Static asset serving via `importlib.resources`, MIME mapping, path-traversal rejection, strict CSP + `nosniff` on HTML, bytes-body responses, dashboard open before the read gate, event filters, sortable Time header, uppercase remote-health status rendering, control variable forms, `nutControl` exposure in the config summary, Power-tab line-quality handling for AVR `BOOST`/`TRIM` versus binary bypass/overload states, and marker guards for the asset-level surfaces with no browser in CI (`[hidden]` reset, resize-safe graph, wide-history range/paging, delete-selected, drill-down, Light/Dark/System theme) |
-| Packaging | nFPM file list, package install paths, dynamic EL8 interpreter re-exec, EL8 repository routing, exact-version release smoke contracts, safe artifact selection, readable Actions-ref policy, AMD64 and QEMU-backed ARM64 OCI smoke tests |
+| Packaging | nFPM file list, package install paths, dynamic EL8 interpreter re-exec, EL8 repository routing, exact-version release smoke contracts, safe artifact selection, readable Actions-ref policy, parallel native AMD64/ARM64 OCI smoke tests with a required aggregate gate |
 
 ## End-to-end tests
 

--- a/src/eneru/version.py
+++ b/src/eneru/version.py
@@ -2,4 +2,4 @@
 
 # Version is set at build time via git describe --tags
 # Format: "5.2.1" for tagged releases, "5.2.1-5-gabcdef1" for dev builds
-__version__ = "6.1.8"
+__version__ = "6.1.9"

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -91,9 +91,8 @@ services:
   mqtt-broker:
     # Pinned to a specific version so PR CI is reproducible — a moved
     # `:2` floating tag would let upstream Mosquitto changes break our
-    # E2E without any local code change. Refresh on the same cadence
-    # as the GitHub Actions SHA pins (~quarterly), or sooner on a
-    # security advisory. The `-alpine` variant is ~5x smaller so the
+    # E2E without any local code change. Refresh periodically, or
+    # sooner on a security advisory. The `-alpine` variant is ~5x smaller so the
     # CI pull is faster.
     image: eclipse-mosquitto:2.1.2-alpine
     container_name: eneru-e2e-mqtt

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -268,20 +268,36 @@ class TestReleaseWorkflowContracts:
         assert "VERSION=${{ steps.version.outputs.VERSION }}" in build_step
 
     @pytest.mark.unit
-    def test_integration_smokes_arm64_oci_runtime_and_dependencies(self) -> None:
-        """PR CI must boot and validate the shipped ARM64 runtime under QEMU."""
+    def test_integration_uses_native_arm64_and_required_aggregator(self) -> None:
+        """PR CI must gate both native architectures without QEMU emulation."""
         workflow = (REPO_ROOT / ".github/workflows/integration.yml").read_text()
-        oci_job = workflow.split("test-oci-image:", 1)[1]
+        amd64_job = workflow.split("  test-oci-image-amd64:\n", 1)[1].split(
+            "\n  test-oci-image-arm64:\n", 1
+        )[0]
+        arm64_job = workflow.split("  test-oci-image-arm64:\n", 1)[1].split(
+            "\n  test-oci-image:\n", 1
+        )[0]
+        required_gate = workflow.split("\n  test-oci-image:\n", 1)[1]
 
-        assert "docker/setup-qemu-action@" in oci_job
-        assert "docker/setup-buildx-action@" in oci_job
-        assert "docker/build-push-action@" in oci_job
-        assert "platforms: linux/arm64" in oci_job
-        assert "load: true" in oci_job
-        assert "docker run --rm --platform linux/arm64" in oci_job
-        assert "validate --config /etc/ups-monitor/config.yaml" in oci_job
-        assert "import bcrypt" in oci_job
-        assert "org.opencontainers.image.version" in oci_job
+        assert "runs-on: ubuntu-latest" in amd64_job
+        assert "Verify OCI image with Podman" in amd64_job
+        assert "dashboard asset present in image" in amd64_job
+
+        assert "runs-on: ubuntu-24.04-arm" in arm64_job
+        assert "docker/setup-qemu-action@" not in arm64_job
+        assert "docker/setup-buildx-action@" not in arm64_job
+        assert "docker/build-push-action@" not in arm64_job
+        assert "docker build --build-arg VERSION=" in arm64_job
+        assert "validate --config /etc/ups-monitor/config.yaml" in arm64_job
+        assert "import bcrypt" in arm64_job
+        assert "org.opencontainers.image.version" in arm64_job
+        assert 'test "$ARCH" = "arm64"' in arm64_job
+
+        assert "test-oci-image-amd64" in required_gate
+        assert "test-oci-image-arm64" in required_gate
+        assert "if: always()" in required_gate
+        assert 'test "$AMD64_RESULT" = "success"' in required_gate
+        assert 'test "$ARM64_RESULT" = "success"' in required_gate
 
 
 class TestGithubActionReferences:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -250,3 +250,35 @@ class TestReleaseWorkflowContracts:
         assert 'debs=(../*.deb)' in workflow
         assert 'rpms=(../*.rpm)' in workflow
         assert 'for r in "${rpms[@]}"' in workflow
+
+    @pytest.mark.unit
+    def test_release_oci_build_exports_name_and_version_metadata(self) -> None:
+        """The release image tag and OCI version label must not be empty/stale."""
+        workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()
+        image_name_step = workflow.split("- name: Prepare IMAGE_NAME", 1)[1].split(
+            "- name: Prepare version.py", 1
+        )[0]
+        build_step = workflow.split("- name: Build and push", 1)[1].split(
+            "- name: Verify Multi-Arch Manifest", 1
+        )[0]
+
+        assert 'echo "IMAGE_NAME=$IMAGE_NAME" >> "$GITHUB_OUTPUT"' in image_name_step
+        assert "$GITHUB_ENV" not in image_name_step
+        assert "build-args:" in build_step
+        assert "VERSION=${{ steps.version.outputs.VERSION }}" in build_step
+
+    @pytest.mark.unit
+    def test_integration_smokes_arm64_oci_runtime_and_dependencies(self) -> None:
+        """PR CI must boot and validate the shipped ARM64 runtime under QEMU."""
+        workflow = (REPO_ROOT / ".github/workflows/integration.yml").read_text()
+        oci_job = workflow.split("test-oci-image:", 1)[1]
+
+        assert "docker/setup-qemu-action@" in oci_job
+        assert "docker/setup-buildx-action@" in oci_job
+        assert "docker/build-push-action@" in oci_job
+        assert "platforms: linux/arm64" in oci_job
+        assert "load: true" in oci_job
+        assert "docker run --rm --platform linux/arm64" in oci_job
+        assert "validate --config /etc/ups-monitor/config.yaml" in oci_job
+        assert "import bcrypt" in oci_job
+        assert "org.opencontainers.image.version" in oci_job

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -282,3 +282,26 @@ class TestReleaseWorkflowContracts:
         assert "validate --config /etc/ups-monitor/config.yaml" in oci_job
         assert "import bcrypt" in oci_job
         assert "org.opencontainers.image.version" in oci_job
+
+
+class TestGithubActionReferences:
+    """Keep action dependencies readable under the repository's tag policy."""
+
+    @pytest.mark.unit
+    def test_third_party_actions_do_not_use_commit_shas(self) -> None:
+        """Every third-party ``uses:`` reference must avoid opaque SHA refs."""
+        action_files = sorted((REPO_ROOT / ".github").rglob("*.yml"))
+        action_files += sorted((REPO_ROOT / ".github").rglob("*.yaml"))
+        sha_ref = re.compile(r"^\s*(?:-\s*)?uses:\s*[^\s#]+@[0-9a-f]{40}(?:\s|$)")
+        pinned = []
+
+        for path in action_files:
+            for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+                if sha_ref.match(line):
+                    pinned.append(
+                        f"{path.relative_to(REPO_ROOT)}:{line_number}: {line.strip()}"
+                    )
+
+        assert not pinned, "Opaque GitHub Action SHA references remain:\n" + "\n".join(
+            pinned
+        )


### PR DESCRIPTION
## Description
- rewrite steps for producing OCI image to use buildx and related github actions
- target linux/amd64 and linux/arm64
- perform extra check on manifest to confirm both architectures are present
- perform separate "docker run" confirmations to confirm both amd64 and arm64 images run successfully
- modify post-verification latest/testing tagging to use "buildx imagetool create" in order to generate appropriate tagged manifest

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Configuration change

## Testing
Describe how you tested your changes:
- [ ] Tested with `eneru validate`
- [ ] Tested with `--dry-run` mode
- [ ] Tested actual shutdown sequence (if applicable)
- [ ] Tested on: [OS/Python version]

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated configuration examples if needed
- [ ] My changes generate no new warnings
- [ ] I have tested my changes thoroughly

## Related issues
Fixes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build and publish a multi-arch OCI image to `ghcr.io` using Docker Buildx for `linux/amd64` and `linux/arm64`, and only promote `:latest`/`:testing` after both architectures pass verification. PR CI now builds AMD64 and ARM64 natively in parallel and uses an aggregate gate to block merges if either fails.

- **New Features**
  - Build and push a multi-arch image with `buildx`; verify the manifest includes both arches and run `docker run --platform` for each.
  - CI: native ARM64 runner replaces QEMU; AMD64 includes a Podman smoke. The required `test-oci-image` job aggregates both results and validates config, `bcrypt` import, and the `org.opencontainers.image.version` label.

- **Dependencies**
  - Add `docker/login-action@v4.4.0`; use `docker/setup-qemu-action@v4.2.0`, `docker/setup-buildx-action@v4.2.0`, `docker/build-push-action@v7.3.0`.
  - Switch workflows and `.github/actions` to readable action release refs; Dependabot now covers both, and tests forbid commit-SHA action refs.

<sup>Written for commit c25d1ef4bee8199a9dbc2a7209ad52c559b51ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/m4r1k/Eneru/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release container images are now published as multi-platform images (AMD64 and ARM64).
  * Stable and testing aliases are promoted only after the multi-platform image is verified for both architectures.

* **Bug Fixes**
  * ARM64 is no longer missing from released image tags; pulling the same tag now selects the correct architecture automatically.
  * CI now validates architecture-specific release and integration expectations more strictly.

* **Documentation**
  * Updated changelog, Kubernetes, and testing guidance to reflect multi-architecture releases and tag-based CI references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->